### PR TITLE
Fix npc move command

### DIFF
--- a/src/game/Commands/CreatureCommands.cpp
+++ b/src/game/Commands/CreatureCommands.cpp
@@ -822,15 +822,6 @@ bool ChatHandler::HandleNpcMoveCommand(char* args)
 
     if (pCreature)
     {
-        if (CreatureData const* data = sObjectMgr.GetCreatureData(pCreature->GetGUIDLow()))
-        {
-            const_cast<CreatureData*>(data)->posX = x;
-            const_cast<CreatureData*>(data)->posY = y;
-            const_cast<CreatureData*>(data)->posZ = z;
-            const_cast<CreatureData*>(data)->orientation = o;
-        }
-        pCreature->GetMap()->CreatureRelocation(pCreature, x, y, z, o);
-        pCreature->GetMotionMaster()->Initialize();
         pCreature->SetHomePosition(x, y, z, o);
         if (pCreature->isAlive())                           // dead creature will reset movement generator at respawn
         {

--- a/src/game/Commands/CreatureCommands.cpp
+++ b/src/game/Commands/CreatureCommands.cpp
@@ -831,6 +831,7 @@ bool ChatHandler::HandleNpcMoveCommand(char* args)
         }
         pCreature->GetMap()->CreatureRelocation(pCreature, x, y, z, o);
         pCreature->GetMotionMaster()->Initialize();
+        pCreature->SetHomePosition(x, y, z, o);
         if (pCreature->isAlive())                           // dead creature will reset movement generator at respawn
         {
             pCreature->SetDeathState(JUST_DIED);


### PR DESCRIPTION
This fixes a glitch with the NPC Move Command.

Prior to these commits, the move command actually relocates the creature twice.

The first time relocates the creature to the correct new location. However, visibility is never updated on the client.

The second time the creature is relocated by killing and respawning the creature.  The re-spawn function calls RemoveCorpse().  The RemoveCorpse function removes the corpse but then also performs creature relocation a second time, however this time to the wrong location.  Since it uses the function GetRespawnCoord(), which be default gets the coordinates of the Creature's home position... which has not been updated.    This causes the creature to be moved back to starting location immediately after the relocation to the target new location.  Then the rest of the Respawn() function updates the visibility of the creature (at the wrong original position).  This small issue is fixed in my first commit ad43b5b.

However, I then pushed a second commit (651e548) because I am realizing entire first relocation is not necessary, since it gets taken care of with just setting the HomePosition and then respawning the creature.

Best