### PR TITLE
Support player names in `.god` command

### DIFF
--- a/src/game/Commands/CharacterCommands.cpp
+++ b/src/game/Commands/CharacterCommands.cpp
@@ -73,10 +73,6 @@ bool ChatHandler::HandleXpCommand(char* args)
 
 bool ChatHandler::HandleGodCommand(char* args)
 {
-    Player *pPlayer = GetSelectedPlayer();
-    if (!pPlayer)
-        pPlayer = m_session->GetPlayer();
-
     if (*args)
     {
         bool value;
@@ -86,7 +82,12 @@ bool ChatHandler::HandleGodCommand(char* args)
             SetSentErrorMessage(true);
             return false;
         }
-        pPlayer->SetGodMode(value, true);
+        
+        Player* target;
+        if (!ExtractPlayerTarget(&args, &target))
+            return false;
+
+        target->SetGodMode(value, true);
     }
 
     return true;


### PR DESCRIPTION
Allows for GMs to use `.god <on/off> <name>` to toggle god mode on players without targeting them. Useful in macros to flag an entire raid group at once.

Current behavior remains unchanged.