### PR TITLE
fix linux build for maria DB

### DIFF
--- a/src/shared/Database/DatabaseMysql.cpp
+++ b/src/shared/Database/DatabaseMysql.cpp
@@ -161,7 +161,9 @@ bool MySQLConnection::HandleMySQLError(uint32 errNo)
     {
         case CR_SERVER_GONE_ERROR:
         case CR_SERVER_LOST:
+            #if !(MARIADB_VERSION_ID >= 100200)
         case CR_INVALID_CONN_HANDLE:
+            #endif
         case CR_SERVER_LOST_EXTENDED:
         {
             mysql_close(mMysql);


### PR DESCRIPTION
fix's this build error using Maria DB on Linux

`/var/michael/core/src/shared/Database/DatabaseMysql.cpp:164:14: error: use of undeclared identifier
      'CR_INVALID_CONN_HANDLE'
        case CR_INVALID_CONN_HANDLE:
             ^
1 error generated.
make[2]: *** [src/shared/CMakeFiles/shared.dir/build.make:271: src/shared/CMakeFiles/shared.dir/Database/DatabaseMysql.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:425: src/shared/CMakeFiles/shared.dir/all] Error 2
make: *** [Makefile:130: all] Error 2`