### PR TITLE
Added drop chance for item 1728

### DIFF
--- a/sql/migrations/20200205154800_world.sql
+++ b/sql/migrations/20200205154800_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200205154800');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200205154800');
+-- Add your query below.
+
+insert into `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `patch_min`, `patch_max`) values('12101','1728','0.01','0','1','1','0','0','10');
+insert into `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `patch_min`, `patch_max`) values('11658','1728','0.01','0','1','1','0','0','10');
+insert into `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `patch_min`, `patch_max`) values('12100','1728','0.01','0','1','1','0','0','10');
+insert into `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `patch_min`, `patch_max`) values('15818','1728','6','0','1','1','0','0','10');
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;
+


### PR DESCRIPTION
I could not find any dropchance for item 1728 (Teebu's Blazing Longsword)  in creature_loot_template.
Implemented dropchance for the following npcs:
Lava reever: 0.01%
Molten Giant: 0.01%
Lava Surger: 0.01%
Lieutenant General Nokhor: 6%
sniff:
https://classic.wowhead.com/item=1728/teebus-blazing-longsword