### PR TITLE
Fixed pet and mini pet angle / distance to match Classic.

### DIFF
--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -569,7 +569,8 @@ void PetAI::HandleReturnMovement()
             ClearCharmInfoFlags();
             m_creature->GetCharmInfo()->SetIsReturning(true);
             m_creature->GetMotionMaster()->Clear(false);
-            m_creature->GetMotionMaster()->MoveFollow(m_creature->GetCharmerOrOwner(), PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+            m_creature->GetMotionMaster()->MoveFollow(m_creature->GetCharmerOrOwner(), PET_FOLLOW_DIST,
+                                                      m_creature->ToPet()->getPetType() == MINI_PET ? MINI_PET_FOLLOW_ANGLE : PET_FOLLOW_ANGLE);
         }
     }
 }

--- a/src/game/AI/PetEventAI.cpp
+++ b/src/game/AI/PetEventAI.cpp
@@ -210,7 +210,8 @@ void PetEventAI::UpdateAI(uint32 const uiDiff)
 
         if (hasAliveOwner && m_creature->GetCharmInfo()->HasCommandState(COMMAND_FOLLOW) && !m_creature->HasUnitState(UNIT_STAT_FOLLOW))
         {
-            m_creature->GetMotionMaster()->MoveFollow(m_creature->GetCharmerOrOwner(), PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+            m_creature->GetMotionMaster()->MoveFollow(m_creature->GetCharmerOrOwner(), PET_FOLLOW_DIST,
+                                                      m_creature->ToPet()->getPetType() == MINI_PET ? MINI_PET_FOLLOW_ANGLE : PET_FOLLOW_ANGLE);
             if (m_creature->GetCharmInfo())
                 m_creature->GetCharmInfo()->SetIsReturning(true);
         }     

--- a/src/game/Objects/Pet.h
+++ b/src/game/Objects/Pet.h
@@ -136,7 +136,10 @@ extern uint32 const LevelStartLoyalty[6];
 #define ACTIVE_SPELLS_MAX           4
 
 #define PET_FOLLOW_DIST  1.0f
+#define PET_FOLLOW_DIST 2.0f
 #define PET_FOLLOW_ANGLE (M_PI_F/2.0f)
+#define MINI_PET_FOLLOW_ANGLE (M_PI_F)
+#define MINI_PET_SUMMON_ANGLE (M_PI_F/4.0f)
 
 class Player;
 struct CharacterPetCache;

--- a/src/game/Objects/Pet.h
+++ b/src/game/Objects/Pet.h
@@ -135,7 +135,6 @@ extern uint32 const LevelStartLoyalty[6];
 
 #define ACTIVE_SPELLS_MAX           4
 
-#define PET_FOLLOW_DIST  1.0f
 #define PET_FOLLOW_DIST 2.0f
 #define PET_FOLLOW_ANGLE (M_PI_F/2.0f)
 #define MINI_PET_FOLLOW_ANGLE (M_PI_F)

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -6135,7 +6135,7 @@ void Spell::EffectSummonCritter(SpellEffectIndex eff_idx)
     if (old_critter)
         player->RemoveMiniPet();
 
-    CreatureCreatePos pos(m_caster, m_caster->GetOrientation(), PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+    CreatureCreatePos pos(m_caster, m_caster->GetOrientation(), PET_FOLLOW_DIST, MINI_PET_SUMMON_ANGLE);
     if (!(m_targets.m_targetMask & TARGET_FLAG_DEST_LOCATION))
         pos = CreatureCreatePos(m_caster, m_caster->GetOrientation());
 
@@ -6161,7 +6161,7 @@ void Spell::EffectSummonCritter(SpellEffectIndex eff_idx)
 
     critter->AIM_Initialize();
     critter->InitPetCreateSpells();                         // e.g. disgusting oozeling has a create spell as critter...
-    critter->SelectLevel(critter->GetCreatureInfo());       // some summoned creaters have different from 1 DB data for level/hp
+    critter->SelectLevel(critter->GetCreatureInfo());       // some summoned creatures have different from 1 DB data for level/hp
     critter->SetUInt32Value(UNIT_NPC_FLAGS, critter->GetCreatureInfo()->npc_flags);
     // some mini-pets have quests
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8654362/74354804-2d742c00-4dbc-11ea-9dc8-8a64087a6904.png)

Basically in Classic pets spawn at π/2 and mini pets (companions) at π/4. Then, pets follow at π/2 and mini pets at π. Also they spawn a bit further from the player.

Currently in vmangos both pets and mini pets spawn and follow at π/2 and have a lower following distance.
