### PR TITLE
Corrections for fishing loot patch

### DIFF
--- a/sql/migrations/20200216130600_world.sql
+++ b/sql/migrations/20200216130600_world.sql
@@ -1,0 +1,27 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200216130600');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200216130600');
+-- Add your query below.
+
+delete from `fishing_loot_template` where (entry=284 AND item=21153);
+delete from `fishing_loot_template` where (entry=1681 AND item=21153);
+delete from `fishing_loot_template` where (entry=1682 AND item=21153);
+delete from `fishing_loot_template` where (entry=1681 AND item=21150);
+delete from `fishing_loot_template` where (entry=1682 AND item=21150);
+delete from `fishing_loot_template` where (entry=327 AND item=6326);
+delete from `fishing_loot_template` where (entry=45 AND item=6326);
+delete from `fishing_loot_template` where (entry=172 AND item=6358);
+delete from `fishing_loot_template` where (entry=237 AND item=6358);
+delete from `fishing_loot_template` where (entry=1338 AND item=6358);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20200216130600_world.sql
+++ b/sql/migrations/20200216130600_world.sql
@@ -8,16 +8,16 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20200216130600');
 -- Add your query below.
 
-delete from `fishing_loot_template` where (entry=284 AND item=21153);
-delete from `fishing_loot_template` where (entry=1681 AND item=21153);
-delete from `fishing_loot_template` where (entry=1682 AND item=21153);
-delete from `fishing_loot_template` where (entry=1681 AND item=21150);
-delete from `fishing_loot_template` where (entry=1682 AND item=21150);
-delete from `fishing_loot_template` where (entry=327 AND item=6326);
-delete from `fishing_loot_template` where (entry=45 AND item=6326);
-delete from `fishing_loot_template` where (entry=172 AND item=6358);
-delete from `fishing_loot_template` where (entry=237 AND item=6358);
-delete from `fishing_loot_template` where (entry=1338 AND item=6358);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=284 AND `item`=21153);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=1681 AND `item`=21153);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=1682 AND `item`=21153);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=1681 AND `item`=21150);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=1682 AND `item`=21150);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=327 AND `item`=6326);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=45 AND `item`=6326);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=172 AND `item`=6358);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=237 AND `item`=6358);
+DELETE FROM `fishing_loot_template` WHERE (`entry`=1338 AND `item`=6358);
 
 -- End of migration.
 END IF;


### PR DESCRIPTION
A few corrections after: https://github.com/vmangos/core/commit/c5fa66e33da2cc8c126c23b3c61a8aa3d62a2f87 

-removed items from gerneral fishing loot, which belong to schools.
-fix startup error:
ERROR:Table 'fishing_loot_template' entry 1681 group 1 has total chance > 100% (107.340004)
ERROR:Table 'fishing_loot_template' entry 1681 group 1 has items with chance=0% but group total chance >= 100% (107.340004)