### PR TITLE
Implemented Lordaeron's Blessing, fixes #338.

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -6619,6 +6619,23 @@ void Player::UpdateArea(uint32 newArea)
     }
 
     UpdateAreaDependentAuras();
+
+    if (HasAura(30238)) // Lordaeron's Blessing
+    {
+        bool isEffectActive = HasAura(31906);
+        switch (newArea)
+        {
+            case 139: // Eastern Plaguelands
+            case 2017: // Stratholme
+            case 2057: // Scholomance
+                if (!isEffectActive)
+                    CastSpell(this, 31906, true, nullptr);
+                break;
+            default:
+                if (isEffectActive)
+                    RemoveAurasDueToSpell(31906);
+        }
+    }
 }
 
 void Player::UpdateZone(uint32 newZone, uint32 newArea)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1739,6 +1739,17 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
             }
             case SPELLFAMILY_SHAMAN:
                 break;
+            case SPELLFAMILY_PRIEST:
+                switch (GetId())
+                {
+                    case 30238: // Lordaeron's Blessing
+                    {
+                        // Lordaeron's Blessing Effect (DND)
+                        target->CastSpell(target, 31906, true, nullptr);
+                        break;
+                    }
+                }
+                break;
         }
     }
     // AT REMOVE
@@ -1937,6 +1948,11 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
             {
                 if (target->HasAura(29660))
                     target->RemoveAurasDueToSpell(29660);
+                break;
+            }
+            case 30238: // Lordaeron's Blessing
+            {
+                target->RemoveAurasDueToSpell(31906);
                 break;
             }
         }


### PR DESCRIPTION
I haven't figured out a better way to only give the effect while inside Eastern Plaguelands, Scholomance or Stratholme, I wanted to handle it inside `Player::UpdateAreaDependentAuras` but I couldn't.

If any of you comes with a better way of handling it, just let me know. Or, @ratkosrb, if you know a better way, you can also merge this and commit the improvement after merging.

Apart from that, it works perfectly fine at this moment.