### PR TITLE
Delete Gadgetzan Bruisers from Un'goro

### DIFF
--- a/sql/migrations/20200504023011_world.sql
+++ b/sql/migrations/20200504023011_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200504023011');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200504023011');
+-- Add your query below.
+
+-- Delete Gadgetzan Bruiser from Un'goro
+DELETE FROM `vmangos`.`creature` WHERE  `guid`=24665;
+DELETE FROM `vmangos`.`creature` WHERE  `guid`=24664;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20200504023011_world.sql
+++ b/sql/migrations/20200504023011_world.sql
@@ -9,8 +9,8 @@ INSERT INTO `migrations` VALUES ('20200504023011');
 -- Add your query below.
 
 -- Delete Gadgetzan Bruiser from Un'goro
-DELETE FROM `vmangos`.`creature` WHERE  `guid`=24665;
-DELETE FROM `vmangos`.`creature` WHERE  `guid`=24664;
+DELETE FROM `creature` WHERE  `guid`=24665;
+DELETE FROM `creature` WHERE  `guid`=24664;
 
 -- End of migration.
 END IF;


### PR DESCRIPTION
Gadgetzan Bruisers should not be spawned at the Un'goro flight master in vanilla.

Image from classic:
![nomacs_OSV7aqMooH](https://user-images.githubusercontent.com/6137576/80933616-cc5d6280-8dc4-11ea-949a-7545145ad060.png)
