### PR TITLE
Fix level 40 paladin mount quest ExclusiveGroup.

### DIFF
--- a/sql/migrations/20200526235421_world.sql
+++ b/sql/migrations/20200526235421_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200526235421');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200526235421');
+-- Add your query below.
+
+UPDATE `quest_template` set `ExclusiveGroup` = 0 WHERE `entry` = 1661;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20200526235421_world.sql
+++ b/sql/migrations/20200526235421_world.sql
@@ -8,7 +8,7 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20200526235421');
 -- Add your query below.
 
-UPDATE `quest_template` set `ExclusiveGroup` = 0 WHERE `entry` = 1661;
+UPDATE `quest_template` SET `ExclusiveGroup` = 0 WHERE `entry` = 1661;
 
 -- End of migration.
 END IF;


### PR DESCRIPTION
There are 3 quests involved here. 4485 (humans), 4486 (dwarfs) and 1661 (both, the actual quests that teaches the mount). 4485 and 4486 are just **OPTIONAL** pre-quests that lead you to Duthorian Rall in order to take and complete 1661. I say they are optional because you can complete 1661 without completing any of the 2 pre-quests. At this momenet all 3 quests share the same ExclusiveGroup, because of this, there's a bug where if a Paladin completes 4485 or 4486, he won't be able to get 1661 in order to learn the mount spell.