### PR TITLE
Remove incorrect gameobjects

### DIFF
--- a/sql/migrations/20200610185816_world.sql
+++ b/sql/migrations/20200610185816_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200610185816');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200610185816');
+-- Add your query below.
+
+-- remove incorrect gameobjects
+DELETE FROM `gameobject` WHERE `guid` IN (17426, 17761);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
This PR removes 2 incorrect gameobjects:
vmangos
![da](https://user-images.githubusercontent.com/22723839/84302051-a73edb00-ab4c-11ea-9fe5-ecd583568e42.png)

classic
![asdas](https://user-images.githubusercontent.com/22723839/84302076-b0c84300-ab4c-11ea-9407-e58040821251.png)
