### PR TITLE
Change std::set to std::vector in mapextract to avoid segfault on Linux

### DIFF
--- a/contrib/extractor/System.cpp
+++ b/contrib/extractor/System.cpp
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <deque>
-#include <set>
 #include <cstdlib>
 
 #ifdef _WIN32
@@ -900,7 +899,7 @@ void ExtractDBCFiles()
 {
     printf("Extracting dbc files...\n");
 
-    std::set<std::string> dbcfiles;
+    std::vector<std::string> dbcfiles;
 
     // get DBC file list
     for (ArchiveSet::iterator i = gOpenArchives.begin(); i != gOpenArchives.end(); ++i)
@@ -909,7 +908,7 @@ void ExtractDBCFiles()
         (*i)->GetFileListTo(files);
         for (vector<string>::iterator iter = files.begin(); iter != files.end(); ++iter)
             if (iter->rfind(".dbc") == iter->length() - strlen(".dbc"))
-                dbcfiles.insert(*iter);
+                dbcfiles.push_back(*iter);
     }
 
     std::string path = output_path;
@@ -918,7 +917,7 @@ void ExtractDBCFiles()
 
     // extract DBCs
     int count = 0;
-    for (set<string>::iterator iter = dbcfiles.begin(); iter != dbcfiles.end(); ++iter)
+    for (vector<string>::iterator iter = dbcfiles.begin(); iter != dbcfiles.end(); ++iter)
     {
         string filename = path;
         filename += (iter->c_str() + strlen("DBFilesClient\\"));


### PR DESCRIPTION
Change std::set to std::vector in mapextract to avoid segfault on Linux, GCC 10.1.0