### PR TITLE
Update Varimathras orientation and size.

### DIFF
--- a/sql/migrations/20200622012614_world.sql
+++ b/sql/migrations/20200622012614_world.sql
@@ -11,7 +11,7 @@ INSERT INTO `migrations` VALUES ('20200622012614');
 
 -- Varimathras
 UPDATE `creature` SET `orientation`='0.820305' WHERE  `guid`=31901;
-UPDATE `creature_template` SET `display_scale1`='1.2' WHERE  `entry`=2425
+UPDATE `creature_template` SET `display_scale1`='1.2' WHERE  `entry`=2425;
 
 
 -- End of migration.

--- a/sql/migrations/20200622012614_world.sql
+++ b/sql/migrations/20200622012614_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200622012614');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200622012614');
+-- Add your query below.
+
+
+-- Varimathras
+UPDATE `creature` SET `orientation`='0.820305' WHERE  `guid`=31901;
+UPDATE `creature_template` SET `display_scale1`='1.2' WHERE  `entry`=2425
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
Varimathras orientation was wrong in vmangos.
This corrects those values to be blizzlike.

Orientation source is sniff data.
Source for scale number is wowemu, confirmed that it was correct in classic.