### PR TITLE
Multiple improvements for Corrupted Ashbringer SM event.

### DIFF
--- a/sql/migrations/20200623153117_world.sql
+++ b/sql/migrations/20200623153117_world.sql
@@ -1,0 +1,32 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200623153117');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200623153117');
+-- Add your query below.
+
+-- Highlord Mograine Transform should not use any weapon
+-- https://www.youtube.com/watch?v=QViNP4cnPyM
+-- https://www.youtube.com/watch?v=m3E6W6-rRGA
+UPDATE `creature_template` SET `equipment_id` = 0 WHERE `entry` = 16440;
+DELETE FROM `creature_equip_template` WHERE `entry` = 16440;
+
+-- Deleted random, unused, non blizzlike equipment_id
+DELETE FROM `creature_equip_template` WHERE `entry` = 50001;
+
+-- Fix for Ashbringer texts
+UPDATE `broadcast_text` SET `chat_type` = 6 WHERE `entry` = 12389;
+UPDATE `broadcast_text` SET `emote_id1` = 25 WHERE `entry` = 12469;
+UPDATE `broadcast_text` SET `emote_id1` = 1 WHERE `entry` = 12470;
+UPDATE `broadcast_text` SET `emote_id1` = 6 WHERE `entry` = 12471;
+UPDATE `broadcast_text` SET `emote_id1` = 20 WHERE `entry` = 12472;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20200623153117_world.sql
+++ b/sql/migrations/20200623153117_world.sql
@@ -24,6 +24,9 @@ UPDATE `broadcast_text` SET `emote_id1` = 1 WHERE `entry` = 12470;
 UPDATE `broadcast_text` SET `emote_id1` = 6 WHERE `entry` = 12471;
 UPDATE `broadcast_text` SET `emote_id1` = 20 WHERE `entry` = 12472;
 
+-- Delete old script text
+DELETE FROM `script_texts` WHERE `entry` IN (-1999928, -1999916, -1999917, -1999918, -1999920, -1999921, -1999922, -1999923, -1999924, -1999925, -1999926);
+
 -- End of migration.
 END IF;
 END??

--- a/sql/migrations/20200623153117_world.sql
+++ b/sql/migrations/20200623153117_world.sql
@@ -8,14 +8,12 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20200623153117');
 -- Add your query below.
 
+
 -- Highlord Mograine Transform should not use any weapon
 -- https://www.youtube.com/watch?v=QViNP4cnPyM
 -- https://www.youtube.com/watch?v=m3E6W6-rRGA
 UPDATE `creature_template` SET `equipment_id` = 0 WHERE `entry` = 16440;
 DELETE FROM `creature_equip_template` WHERE `entry` = 16440;
-
--- Deleted random, unused, non blizzlike equipment_id
-DELETE FROM `creature_equip_template` WHERE `entry` = 50001;
 
 -- Fix for Ashbringer texts
 UPDATE `broadcast_text` SET `chat_type` = 6 WHERE `entry` = 12389;
@@ -26,6 +24,7 @@ UPDATE `broadcast_text` SET `emote_id1` = 20 WHERE `entry` = 12472;
 
 -- Delete old script text
 DELETE FROM `script_texts` WHERE `entry` IN (-1999928, -1999916, -1999917, -1999918, -1999920, -1999921, -1999922, -1999923, -1999924, -1999925, -1999926);
+
 
 -- End of migration.
 END IF;

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1491,7 +1491,6 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                 }
                 case 28441:                                 // AB Effect 000
                 {
-
                     return;
                 }
                 case 28697:                                 // Forgiveness (SM Ashbringer event)

--- a/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/instance_scarlet_monastery.cpp
+++ b/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/instance_scarlet_monastery.cpp
@@ -39,22 +39,22 @@ enum AshbringerEventMisc
     NPC_COMMANDER_MOGRAINE = 3976,
     NPC_HIGHLORD_MOGRAINE = 16062,
 
-    SAY_AND_SO_IT_BEG = -1999928,
-    SAY_ASHBRINGER    = -1999916,
-    SAY_KNEEL_BEFORE  = -1999917,
-    SAY_MY_LORD       = -1999918,
-    GO_CHAPPEL_DOOR   = 104591,
+    GO_CHAPEL_DOOR   = 104591,
+    GO_HIGH_INQUISITOR_DOOR = 104600,
 
-    SAY_COMMANDER1  = -1999920,
-    SAY_COMMANDER2  = -1999921,
-    SAY_COMMANDER3  = -1999922,
-    SAY_ASHBRINGER1 = -1999923,
-    SAY_ASHBRINGER2 = -1999924,
-    SAY_ASHBRINGER3 = -1999925,
+    ITEM_CORRUPTED_ASHBRINGER = 22691,
 
-    YELL_COMMANDER  = -1999926,
+    SAY_COMMANDER1  = 12390,
+    SAY_COMMANDER2  = 12470,
+    SAY_COMMANDER3  = 12472,
+    SAY_ASHBRINGER1 = 12469,
+    SAY_ASHBRINGER2 = 12471,
+    SAY_ASHBRINGER3 = 12473,
+    YELL_COMMANDER  = 12389,
+
+    SPELL_AB_EFFECT_000   = 28441,
     SPELL_FORGIVENESS     = 28697,
-    SPELL_MOGRAINE_COMETH = 28688,
+    SPELL_MOGRAINE_COMETH = 28688
 };
 
 enum eEvents
@@ -66,6 +66,8 @@ enum eEvents
     EVENT_STAND,
     EVENT_TALK3,
     EVENT_TALK4,
+    EVENT_SECOND_DOUBT,
+    EVENT_POINT,
     EVENT_ROAR,
     EVENT_TALK5,
     EVENT_SPELL,
@@ -75,9 +77,9 @@ enum eEvents
 
 struct instance_scarlet_monastery : ScriptedInstance
 {
-    explicit instance_scarlet_monastery(Map* pMap) : 
-        ScriptedInstance(pMap),
-        m_ashbringerActive(false)
+    explicit instance_scarlet_monastery(Map* pMap) :
+            ScriptedInstance(pMap),
+            m_ashbringerActive(false)
     {
         instance_scarlet_monastery::Initialize();
     }
@@ -88,11 +90,11 @@ struct instance_scarlet_monastery : ScriptedInstance
     uint64 m_uiWhitemaneGUID;
     uint64 m_uiVorrelGUID;
     uint64 m_uiDoorHighInquisitorGUID;
-    
+
     bool m_ashbringerActive;
+    Player* m_ashbringerWielder;
     uint32 m_ashbringerCheckTimer;
     std::set<ObjectGuid> m_ashbringerReactedNpcs;
-    uint32 m_ashbringerSayTimer;
     EventMap m_events;
 
     void Initialize() override
@@ -105,7 +107,7 @@ struct instance_scarlet_monastery : ScriptedInstance
         m_uiDoorHighInquisitorGUID = 0;
         m_ashbringerCheckTimer = 5000;
         m_ashbringerReactedNpcs.clear();
-        m_ashbringerSayTimer = 0;
+        m_ashbringerWielder = nullptr;
         m_events.Reset();
     }
 
@@ -127,8 +129,12 @@ struct instance_scarlet_monastery : ScriptedInstance
 
     void OnObjectCreate(GameObject* pGo) override
     {
-        if (pGo->GetEntry() == 104600)
+        if (pGo->GetEntry() == GO_HIGH_INQUISITOR_DOOR)
             m_uiDoorHighInquisitorGUID = pGo->GetGUID();
+
+        // Chapel door should be open if event is activated
+        if (pGo->GetEntry() == GO_CHAPEL_DOOR && m_ashbringerActive)
+            DoOpenDoor(pGo->GetGUID());
     }
 
     uint64 GetData64(uint32 data) override
@@ -169,76 +175,56 @@ struct instance_scarlet_monastery : ScriptedInstance
         return 0;
     }
 
-    uint32 GetRandomScarletText()
-    {
-        switch (urand(0, 6))
-        {
-            case 0:
-                return 12378;
-            case 1:
-                return 12379;
-            case 2:
-                return 12380;
-            case 3:
-                return 12381;
-            case 4:
-                return 12382;
-            case 5:
-                return 12383;
-        }
-        return 12384;
-    }
-
     void OnCreatureSpellHit(Unit* pCaster, Creature* receiver, SpellEntry const* spell) override
     {
         if (!m_ashbringerActive || !pCaster || !receiver || !spell)
             return;
-        if (!pCaster->IsPlayer() || spell->Id != 28441) // AB Effect 000
+        if (!pCaster->IsPlayer() || spell->Id != SPELL_AB_EFFECT_000)
             return;
         if (receiver->IsDead())
             return;
 
         switch (receiver->GetEntry())
         {
-        case NPC_SCARLET_MYRIDON:
-        case NPC_SCARLET_DEFENDER:
-        case NPC_SCARLET_CENTURION:
-        case NPC_SCARLET_SORCERER:
-        case NPC_SCARLET_WIZARD:
-        case NPC_SCARLET_ABBOT:
-        case NPC_SCARLET_MONK:
-        case NPC_SCARLET_CHAMPION:
-        case NPC_SCARLET_CHAPLAIN:
-        {
-            auto it = m_ashbringerReactedNpcs.find(receiver->GetObjectGuid());
-            if (it == m_ashbringerReactedNpcs.end())
-                m_ashbringerReactedNpcs.insert(receiver->GetObjectGuid());
-            else
-                return;
-            receiver->StopMoving(true);
-            receiver->SetFacingToObject(pCaster);
-            receiver->SetStandState(UNIT_STAND_STATE_KNEEL);
-            receiver->AddUnitState(UNIT_STAT_ROOT);
-            if (!m_ashbringerSayTimer && urand(0,1))
+            case NPC_COMMANDER_MOGRAINE:
             {
-                m_ashbringerSayTimer = 2000;
-                DoScriptText(GetRandomScarletText(), receiver);
+                auto it = m_ashbringerReactedNpcs.find(receiver->GetObjectGuid());
+                if (it == m_ashbringerReactedNpcs.end())
+                    m_ashbringerReactedNpcs.insert(receiver->GetObjectGuid());
+                else
+                    return;
+                receiver->SetFacingToObject(pCaster);
+                m_events.ScheduleEvent(EVENT_KNEEL, Seconds(1));
+                break;
             }
-            break;
-        }
-        case NPC_COMMANDER_MOGRAINE:
-        {
-            auto it = m_ashbringerReactedNpcs.find(receiver->GetObjectGuid());
-            if (it == m_ashbringerReactedNpcs.end())
-                m_ashbringerReactedNpcs.insert(receiver->GetObjectGuid());
-            else
+            case NPC_SCARLET_MYRIDON:
+            case NPC_SCARLET_DEFENDER:
+            case NPC_SCARLET_CENTURION:
+            case NPC_SCARLET_SORCERER:
+            case NPC_SCARLET_WIZARD:
+            case NPC_SCARLET_ABBOT:
+            case NPC_SCARLET_MONK:
+            case NPC_SCARLET_CHAMPION:
+            case NPC_SCARLET_CHAPLAIN:
+            {
+                auto it = m_ashbringerReactedNpcs.find(receiver->GetObjectGuid());
+                if (it == m_ashbringerReactedNpcs.end())
+                    m_ashbringerReactedNpcs.insert(receiver->GetObjectGuid());
+                else
+                    return;
+                receiver->StopMoving(true);
+                if (receiver->GetStandState() != UNIT_STAND_STATE_STAND)
+                    receiver->SetStandState(UNIT_STAND_STATE_STAND);
+                receiver->SetFacingToObject(pCaster);
+                receiver->SetStandState(UNIT_STAND_STATE_KNEEL);
+                receiver->AddUnitState(UNIT_STAT_ROOT);
+                if (m_ashbringerWielder && urand(0, 1))
+                    DoScriptText(PickRandomValue(12378, 12379, 12380, 12381, 12382, 12383, 12384),
+                            receiver, m_ashbringerWielder);
+                break;
+            }
+            default:
                 return;
-            receiver->SetFacingToObject(pCaster);
-            m_events.ScheduleEvent(EVENT_KNEEL, Seconds(1));
-            break;
-        }
-        default:
-            return;
         }
     }
 
@@ -247,14 +233,13 @@ struct instance_scarlet_monastery : ScriptedInstance
         // not bothering to check if player has unequipped weapon, dont know if its a thing
         if (m_ashbringerActive)
         {
-            // https://www.youtube.com/watch?v=nT6yE7vuCJc
-            // todo: emotes are a bit off, should be more of them too
             m_events.Update(diff);
             while (uint32 eventId = m_events.ExecuteEvent())
             {
                 Creature* pMograine = GetCreature(m_uiMograineGUID);
                 if (!pMograine)
                     continue;
+
                 Creature* pHighlord = GetClosestCreatureWithEntry(pMograine, NPC_HIGHLORD_MOGRAINE, 1000.0f);
                 switch (eventId)
                 {
@@ -264,7 +249,8 @@ struct instance_scarlet_monastery : ScriptedInstance
                         m_events.ScheduleEvent(EVENT_TALK1, Seconds(2));
                         break;
                     case EVENT_TALK1:
-                        DoScriptText(SAY_COMMANDER1, pMograine);
+                        if (m_ashbringerWielder)
+                            DoScriptText(SAY_COMMANDER1, pMograine, m_ashbringerWielder);
                         m_events.ScheduleEvent(EVENT_SUMMON, Seconds(10));
                         break;
                     case EVENT_SUMMON:
@@ -273,20 +259,23 @@ struct instance_scarlet_monastery : ScriptedInstance
                             pC->SetFactionTemporary(35, TEMPFACTION_RESTORE_RESPAWN);
                             pC->SetObjectScale(2.0f);
                             pC->CastSpell(pC, SPELL_MOGRAINE_COMETH, true);
+                            // TODO: The coordinates below appear to be guessed, set the correct ones once we have them.
                             pC->GetMotionMaster()->MovePoint(0, 1148.0f, 1398.71f, 32.0f, 0, 2.7f);
                         }
-                        m_events.ScheduleEvent(EVENT_TALK2, Seconds(30));
+                        m_events.ScheduleEvent(EVENT_TALK2, Seconds(31));
                         break;
                     case EVENT_TALK2:
                         if (pHighlord)
                         {
-                            pHighlord->HandleEmote(EMOTE_ONESHOT_POINT);
                             DoScriptText(SAY_ASHBRINGER1, pHighlord);
                             pMograine->SetFacingToObject(pHighlord);
+                            pHighlord->SetFacingToObject(pMograine);
                         }
                         m_events.ScheduleEvent(EVENT_STAND, Seconds(4));
                         break;
                     case EVENT_STAND:
+                        pMograine->SetSheath(SHEATH_STATE_MELEE);
+                        pMograine->HandleEmoteCommand(EMOTE_STATE_STAND);
                         pMograine->SetStandState(UNIT_STAND_STATE_STAND);
                         m_events.ScheduleEvent(EVENT_TALK3, Seconds(2));
                         break;
@@ -295,9 +284,19 @@ struct instance_scarlet_monastery : ScriptedInstance
                         m_events.ScheduleEvent(EVENT_TALK4, Seconds(4));
                         break;
                     case EVENT_TALK4:
-                        if(pHighlord)
+                        if (pHighlord)
                             DoScriptText(SAY_ASHBRINGER2, pHighlord);
-                        m_events.ScheduleEvent(EVENT_ROAR, Seconds(11));
+                        m_events.ScheduleEvent(EVENT_SECOND_DOUBT, Seconds(4));
+                        break;
+                    case EVENT_SECOND_DOUBT:
+                        if (pHighlord)
+                            pHighlord->HandleEmote(EMOTE_ONESHOT_QUESTION);
+                        m_events.ScheduleEvent(EVENT_POINT, Seconds(4));
+                        break;
+                    case EVENT_POINT:
+                        if (pHighlord)
+                            pHighlord->HandleEmote(EMOTE_ONESHOT_POINT);
+                        m_events.ScheduleEvent(EVENT_ROAR, Seconds(3));
                         break;
                     case EVENT_ROAR:
                         if (pHighlord)
@@ -305,10 +304,8 @@ struct instance_scarlet_monastery : ScriptedInstance
                         m_events.ScheduleEvent(EVENT_TALK5, Seconds(4));
                         break;
                     case EVENT_TALK5:
-                        pMograine->SetSheath(SHEATH_STATE_UNARMED);
-                        pMograine->HandleEmote(EMOTE_ONESHOT_BEG);
                         DoScriptText(SAY_COMMANDER3, pMograine);
-                        m_events.ScheduleEvent(EVENT_SPELL, Seconds(3));
+                        m_events.ScheduleEvent(EVENT_SPELL, Seconds(4));
                         break;
                     case EVENT_SPELL:
                         if (pHighlord)
@@ -318,76 +315,78 @@ struct instance_scarlet_monastery : ScriptedInstance
                     case EVENT_FORGIVEN:
                         if (pHighlord)
                             DoScriptText(SAY_ASHBRINGER3, pHighlord);
-                        m_events.ScheduleEvent(EVENT_DESPAWN, Seconds(5));
+                        m_events.ScheduleEvent(EVENT_DESPAWN, Seconds(4));
                         break;
                     case EVENT_DESPAWN:
                         if (pHighlord)
-                        {
                             ((TemporarySummon*)pHighlord)->UnSummon();
-                        }
+                        m_ashbringerWielder = nullptr;
                         break;
                 }
             }
-            m_ashbringerSayTimer -= std::min(m_ashbringerSayTimer, diff);
             return;
         }
 
-
-        if (m_ashbringerCheckTimer < diff)
+        if (!m_ashbringerActive)
         {
-            m_ashbringerCheckTimer = 5000;
-        }
-        else
-        {
-            m_ashbringerCheckTimer -= diff;
-            return;
+            if (m_ashbringerCheckTimer < diff)
+            {
+                m_ashbringerCheckTimer = 5000;
+            }
+            else
+            {
+                m_ashbringerCheckTimer -= diff;
+                return;
+            }
         }
 
         Map::PlayerList const& lPlayers = instance->GetPlayers();
         if (lPlayers.isEmpty())
             return;
-        bool anyAshbringerEquipped = false;
+
         for (const auto& itr : lPlayers)
         {
             if (Player* pPlayer = itr.getSource())
             {
+                // Ignore if player is in GM mode
+                if (pPlayer->IsGameMaster())
+                    continue;
+
                 Item* item = pPlayer->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
                 if (!item)
                     continue;
-                if (item->GetEntry() == 22691 && !m_ashbringerActive) // corrupted ashbringer
+
+                if (item->GetEntry() == ITEM_CORRUPTED_ASHBRINGER && !m_ashbringerActive)
                 {
-                    anyAshbringerEquipped = true;
                     m_ashbringerActive = true;
+                    m_ashbringerWielder = pPlayer;
+
                     std::list<Creature*> ScarletList;
                     GetCreatureListWithEntryInGrid(ScarletList, pPlayer,
-                    { 
-                        NPC_SCARLET_MYRIDON,
-                        NPC_SCARLET_DEFENDER,
-                        NPC_SCARLET_CENTURION,
-                        NPC_SCARLET_SORCERER,
-                        NPC_SCARLET_WIZARD,
-                        NPC_SCARLET_ABBOT,
-                        NPC_SCARLET_MONK, 
-                        NPC_SCARLET_CHAMPION,
-                        NPC_SCARLET_CHAPLAIN,
-                        NPC_FAIRBANKS,
-                        NPC_COMMANDER_MOGRAINE
-                    }, 2000.0f);
+                                                   {
+                                                           NPC_SCARLET_MYRIDON,
+                                                           NPC_SCARLET_DEFENDER,
+                                                           NPC_SCARLET_CENTURION,
+                                                           NPC_SCARLET_SORCERER,
+                                                           NPC_SCARLET_WIZARD,
+                                                           NPC_SCARLET_ABBOT,
+                                                           NPC_SCARLET_MONK,
+                                                           NPC_SCARLET_CHAMPION,
+                                                           NPC_SCARLET_CHAPLAIN,
+                                                           NPC_FAIRBANKS,
+                                                           NPC_COMMANDER_MOGRAINE
+                                                   }, 2000.0f);
 
                     for (Creature* pCreature : ScarletList)
                     {
                         pCreature->SetFactionTemplateId(35);
-                        if (pCreature->GetEntry() == NPC_COMMANDER_MOGRAINE)
-                            pCreature->SetCharmerGuid(pPlayer->GetObjectGuid());
                     }
 
-                    // Door should be open when event is activated
-                    if (GameObject* pDoor = GetClosestGameObjectWithEntry(pPlayer, GO_CHAPPEL_DOOR, 2000.0f))
-                        DoOpenDoor(pDoor->GetGUID());
-
-
-                    // bow down, kneel before the ashbringer... scripttext yell
+                    // Mograine's first yell.
                     DoOrSimulateScriptTextForThisInstance(YELL_COMMANDER, NPC_COMMANDER_MOGRAINE);
+
+                    // Exit loop if event is already activated
+                    break;
                 }
             }
         }

--- a/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/instance_scarlet_monastery.cpp
+++ b/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/instance_scarlet_monastery.cpp
@@ -90,10 +90,10 @@ struct instance_scarlet_monastery : ScriptedInstance
     uint64 m_uiWhitemaneGUID;
     uint64 m_uiVorrelGUID;
     uint64 m_uiDoorHighInquisitorGUID;
+    uint64 m_uiChapelDoorGUID;
 
     bool m_ashbringerActive;
     Player* m_ashbringerWielder;
-    GameObject* m_chapelDoor;
     uint32 m_ashbringerCheckTimer;
     std::set<ObjectGuid> m_ashbringerReactedNpcs;
     EventMap m_events;
@@ -106,10 +106,10 @@ struct instance_scarlet_monastery : ScriptedInstance
         m_uiWhitemaneGUID = 0;
         m_uiVorrelGUID = 0;
         m_uiDoorHighInquisitorGUID = 0;
+        m_uiChapelDoorGUID = 0;
         m_ashbringerCheckTimer = 5000;
         m_ashbringerReactedNpcs.clear();
         m_ashbringerWielder = nullptr;
-        m_chapelDoor = nullptr;
         m_events.Reset();
     }
 
@@ -135,7 +135,7 @@ struct instance_scarlet_monastery : ScriptedInstance
             m_uiDoorHighInquisitorGUID = pGo->GetGUID();
 
         if (pGo->GetEntry() == GO_CHAPEL_DOOR)
-            m_chapelDoor = pGo;
+            m_uiChapelDoorGUID = pGo->GetGUID();
     }
 
     uint64 GetData64(uint32 data) override
@@ -372,8 +372,8 @@ struct instance_scarlet_monastery : ScriptedInstance
                         pCreature->SetFactionTemplateId(35);
 
                     // Chapel door should be open if event is activated
-                    if (m_chapelDoor)
-                        m_chapelDoor->SetGoState(GO_STATE_ACTIVE);
+                    if (GameObject* chapelDoor = GetGameObject(m_uiChapelDoorGUID))
+                        chapelDoor->SetGoState(GO_STATE_ACTIVE);
 
                     // Mograine's first yell.
                     DoOrSimulateScriptTextForThisInstance(YELL_COMMANDER, NPC_COMMANDER_MOGRAINE);


### PR DESCRIPTION
Fixed:
- Wrong equipment for Highlord Mograine (shouldn't use any).
- Missing emotes.
- Wrong texts.
- Wrong timers.
- Some clean up in general.

Still needed:
- Highlord Mograine's final waypoint appears to be guessed, I have added a TODO to fix it once we have the correct position.
- The Cathedral door should be automatically opened, it wasn't working before and I haven't managed to make it work yet.
- Reactions from SM mobs are not working in a Blizzlike way, they should first look at the player, then slowly kneel (not just change the stand state) and then say the random text. Now everything happens at the same time, it should exist some delay between these actions.

Resources:
- https://www.youtube.com/watch?v=24iX8QD3pRA
- https://www.youtube.com/watch?v=QViNP4cnPyM
- https://www.youtube.com/watch?v=m3E6W6-rRGA