### PR TITLE
Updated Stonetalon Peak spawns for pre 1.11.0

### DIFF
--- a/sql/migrations/20200625235926_world.sql
+++ b/sql/migrations/20200625235926_world.sql
@@ -1,0 +1,30 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200625235926');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200625235926');
+-- Add your query below.
+
+
+-- Respawn Stonetalon Peak for pre 1.11
+-- Chylina
+UPDATE `creature` SET `patch_min`='9' WHERE  `guid`=32313;
+INSERT INTO `creature` VALUES (199603, 4084, 0, 0, 0, 1, 0, 0, 2735.39, 1489.98, 237.51, 3.038, 300, 300, 0, 100, 0, 0, 0, 0, 0, 8);
+
+-- Illyanie
+-- position wasn't changed in 1.11, fail in development by blizzard
+UPDATE `creature` SET `position_x`=2690.11, `position_y`=1516.39, `position_z`=235.247, `orientation`=4.93928 WHERE `guid`=29249; 
+
+-- No Mailbox at Stonetalon Peak pre 1.11
+UPDATE `gameobject` SET `patch_min`='9' WHERE  `guid`=47593;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20200625235926_world.sql
+++ b/sql/migrations/20200625235926_world.sql
@@ -12,7 +12,7 @@ INSERT INTO `migrations` VALUES ('20200625235926');
 -- Respawn Stonetalon Peak for pre 1.11
 -- Chylina
 UPDATE `creature` SET `patch_min`='9' WHERE  `guid`=32313;
-INSERT INTO `creature` VALUES (199603, 4084, 0, 0, 0, 1, 0, 0, 2735.39, 1489.98, 237.51, 3.038, 300, 300, 0, 100, 0, 0, 0, 0, 0, 8);
+INSERT INTO `creature` VALUES (32325, 4084, 0, 0, 0, 1, 0, 0, 2735.39, 1489.98, 237.51, 3.038, 300, 300, 0, 100, 0, 0, 0, 0, 0, 8);
 
 -- Illyanie
 -- position wasn't changed in 1.11, fail in development by blizzard


### PR DESCRIPTION
This updates spawns in Stonetalon Peak to be accurate for pre patch 1.11.0

It also updates Illyanie for patch 1.11.0+.
Reason being is that Blizzard forgot to update her spawn in 1.11.0 when they updated layout of the area and only later changed it in TBC.

Ignore all purple orb above NPCs in the following pictures, it's just for testing.
pre 1.11.0 Illyanie:
![WoW_dDWYVB3rHW](https://user-images.githubusercontent.com/6137576/85807355-f0e51380-b751-11ea-8059-c45451b44a05.png)

1.11.0 and beyond (same in classic):
![WoW_Z1kqkUiwtL](https://user-images.githubusercontent.com/6137576/85807480-51745080-b752-11ea-8ab4-a06223825b6c.png)

TBC (vmangos current spawn):
![nomacs_8lY3PVDteB](https://user-images.githubusercontent.com/6137576/85807582-9f895400-b752-11ea-8194-75beb85ec56d.png)



