### PR TITLE
Skip homebind confirmation pre-1.7

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -12409,7 +12409,11 @@ void Player::OnGossipSelect(WorldObject* pSource, uint32 gossipListId)
             break;
         case GOSSIP_OPTION_INNKEEPER:
             PlayerTalkClass->CloseGossip();
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_6_1
             SetBindPoint(guid);
+#else
+            GetSession()->SendBindPoint((Creature*)pSource);
+#endif
             break;
         case GOSSIP_OPTION_BANKER:
             GetSession()->SendShowBank(guid);


### PR DESCRIPTION
According to the [patch notes](https://web.archive.org/web/20070602172347/http://www.worldofwarcraft.com/patchnotes/patch-05-09-13.html), the confirmation dialog when changing the player's home location was added in patch 1.7.
> A confirmation dialog is now shown when you choose to make an Inn your home.

Pre-1.7, innkeepers now instantly cast the bind spell after the player clicks the gossip option.

Closes #569.