### PR TITLE
Create item instances with usable flag from template

### DIFF
--- a/src/game/Objects/Item.cpp
+++ b/src/game/Objects/Item.cpp
@@ -245,6 +245,8 @@ bool Item::Create(uint32 guidlow, uint32 itemid, ObjectGuid ownerGuid)
     if (!itemProto)
         return false;
 
+    ApplyModFlag(ITEM_FIELD_FLAGS, ITEM_DYNFLAG_UNK6, itemProto->Flags & ITEM_FLAG_UNK6);
+
     SetUInt32Value(ITEM_FIELD_STACK_COUNT, 1);
     SetUInt32Value(ITEM_FIELD_MAXDURABILITY, itemProto->MaxDurability);
     SetUInt32Value(ITEM_FIELD_DURABILITY, itemProto->MaxDurability);


### PR DESCRIPTION
Preserves flag 0x00000040 (64) from the item template when creating an instance of the item. The 1.6 client relies on this flag to enable players to use items that are applied to other items (e.g. skeleton keys, fishing lures, rogue poisons).

Closes #568.