### PR TITLE
Fix patch downloading

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -682,6 +682,9 @@ bool AuthSocket::_HandleLogonProof()
         xferh.file_size = file_size;
 
         send((const char*)&xferh, sizeof(xferh));
+        
+        InitPatch();
+        
         return true;
     }
     /// </ul>


### PR DESCRIPTION
Just a duplicate of #700 if you don't like deleted accounts. Then I will just leave my account and most likely never return because I decided to quit World of Warcraft.

---

This pull request makes patch downloading actually work by sending patch itself after its info