### PR TITLE
Replace 'classic' with 'vanilla' in AuthSocket.cpp

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -558,7 +558,7 @@ bool AuthSocket::_HandleLogonChallenge()
                         EndianConvert(gridSeedPkt);
                         serverSecuritySalt.SetRand(16 * 8); // 16 bytes random
 
-                        pkt << uint8(1); // securityFlags, only '1' is available in classic (PIN input)
+                        pkt << uint8(1); // securityFlags, only '1' is available in vanilla (PIN input)
                         pkt << gridSeedPkt;
                         pkt.append(serverSecuritySalt.AsByteArray(16).data(), 16);
                     }


### PR DESCRIPTION
Just a duplicate of #721 if you don't like deleted accounts. Then I will just leave my account and most likely never return because I decided to quit World of Warcraft.

---

"Classic" (not really) != vanilla