### PR TITLE
Remove non-vanilla player flags

### DIFF
--- a/src/game/Objects/Object.cpp
+++ b/src/game/Objects/Object.cpp
@@ -3241,10 +3241,6 @@ ReputationRank WorldObject::GetReactionTo(WorldObject const* target) const
                                          // however client seems to allow mixed group parties, because in 13850 client it works like:
                                          // return GetFactionReactionTo(getFactionTemplateEntry(), target);
 
-                                         // Sanctuary
-                if (selfPlayerOwner->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY) && targetPlayerOwner->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY))
-                    return REP_FRIENDLY;
-
                 // Nostalrius: Hackfix because UNIT_BYTE2_FLAG_FFA_PVP is not implemented yet.
                 if (selfPlayerOwner->IsFFAPvP() && targetPlayerOwner->IsFFAPvP())
                     return REP_HOSTILE;

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -322,10 +322,6 @@ enum PlayerFlags
     PLAYER_FLAGS_PARTIAL_PLAY_TIME      = 0x00001000,       // played long time
     PLAYER_FLAGS_NO_PLAY_TIME           = 0x00002000,       // played too long time
     PLAYER_FLAGS_UNK15                  = 0x00004000,
-    PLAYER_FLAGS_UNK16                  = 0x00008000,       // strange visual effect (2.0.1), looks like PLAYER_FLAGS_GHOST flag
-    PLAYER_FLAGS_SANCTUARY              = 0x00010000,       // player entered sanctuary
-    PLAYER_FLAGS_TAXI_BENCHMARK         = 0x00020000,       // taxi benchmark mode (on/off) (2.0.1)
-    PLAYER_FLAGS_PVP_TIMER              = 0x00040000,       // 3.0.2, pvp timer active (after you disable pvp manually)
 };
 
 // used in (PLAYER_FIELD_BYTES, 0) byte values


### PR DESCRIPTION
Just a duplicate of #701 and #704 if you don't like deleted accounts. Then I will just leave my account and most likely never return because I decided to quit World of Warcraft.

---

This pull request removes non-vanilla player flags.