### PR TITLE
Add trial opcodes patch

### DIFF
--- a/src/game/AuctionHouse/AuctionHouseMgr.h
+++ b/src/game/AuctionHouse/AuctionHouseMgr.h
@@ -48,7 +48,9 @@ enum AuctionError
     AUCTION_ERR_HIGHER_BID              = 5,                // ERR_AUCTION_HIGHER_BID
     AUCTION_ERR_BID_INCREMENT           = 7,                // ERR_AUCTION_BID_INCREMENT
     AUCTION_ERR_BID_OWN                 = 10,               // ERR_AUCTION_BID_OWN
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     AUCTION_ERR_RESTRICTED_ACCOUNT      = 13                // ERR_RESTRICTED_ACCOUNT
+#endif
 };
 
 enum AuctionAction

--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -1737,7 +1737,9 @@ enum MailResponseResult
     MAIL_ERR_RECIPIENT_NOT_FOUND       = 4,
     MAIL_ERR_NOT_YOUR_TEAM             = 5,
     MAIL_ERR_INTERNAL_ERROR            = 6,
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     MAIL_ERR_DISABLED_FOR_TRIAL_ACC    = 14,
+#endif
     MAIL_ERR_RECIPIENT_CAP_REACHED     = 15,
 };
 
@@ -1795,8 +1797,12 @@ enum TradeStatus
     TRADE_STATUS_TARGET_DEAD    = 18,
     TRADE_STATUS_YOU_LOGOUT     = 19,
     TRADE_STATUS_TARGET_LOGOUT  = 20,
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     TRADE_STATUS_TRIAL_ACCOUNT  = 21,                       // Trial accounts can not perform that action
+#endif
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
     TRADE_STATUS_ONLY_CONJURED  = 22                        // You can only trade conjured items... (cross realm BG related).
+#endif
 };
 
 // TrinityCore


### PR DESCRIPTION
Trial accounts were added in patch 1.6. Also adds cross-realm BG opcode patch.

GlobalStrings.lua of different patches are available [here](https://www.townlong-yak.com/framexml/builds).