### PR TITLE
Update position of old Northpass NPCs.

### DIFF
--- a/sql/migrations/20200904165642_world.sql
+++ b/sql/migrations/20200904165642_world.sql
@@ -1,0 +1,25 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200904165642');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200904165642');
+-- Add your query below.
+
+
+-- Kriss Goldenlight
+UPDATE `creature` SET `position_x`=3166.53, `position_y`=-4372.88, `position_z`=139.715, `orientation`=1.22173 WHERE `guid`=53732; 
+
+-- Aurora Skycaller
+UPDATE `creature` SET `position_x`=3172.21, `position_y`=-4372.37, `position_z`=139.715, `orientation`=1.85005 WHERE `guid`=53733; 
+
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
This updates the old spawn positions for Northpass Tower NPCs to use sniff data.
Previously used data based on imagery, it wasn't completely accurate even when comparing to images from vanilla.

Source for the sniff data is WoWD-DB.

From pre 1.12.0 vanilla:
![WoWScrnShot_091005_200827](https://user-images.githubusercontent.com/6137576/92268134-1de83c00-eee2-11ea-9c19-213a6225b9e2.jpg)
From vmangos after applying this sql:
![WoW_hxqGMOmwgU](https://user-images.githubusercontent.com/6137576/92268119-188af180-eee2-11ea-8196-2007e19c2d00.png)

