### PR TITLE
Vanilla Araj's position.

### DIFF
--- a/sql/migrations/20200904173144_world.sql
+++ b/sql/migrations/20200904173144_world.sql
@@ -1,0 +1,30 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200904173144');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200904173144');
+-- Add your query below.
+
+
+-- Araj vanilla position 
+ UPDATE `creature` SET `position_x`=1381.25, `position_y`=-1543.54, `position_z`=58.6043, `orientation`=4.72984 WHERE `id`=1852;  
+ 
+-- Arajs minions 
+-- Skeletal Warlord 
+UPDATE `creature` SET `position_x`=1388.72, `position_y`=-1541.99, `position_z`=59.2163, `orientation`=0.541052 WHERE `guid`=45248;  
+UPDATE `creature` SET `position_x`=1373.54, `position_y`=-1539.18, `position_z`=58.1594, `orientation`=2.46091 WHERE `guid`=45249;  
+-- Spectral Attendant 
+UPDATE `creature` SET `position_x`=1381.89, `position_y`=-1539.46, `position_z`=58.6867, `orientation`=1.50098 WHERE `guid`=45252;  
+UPDATE `creature` SET `position_x`=1376.74, `position_y`=-1542.95, `position_z`=58.2789, `orientation`=5.55015 WHERE `guid`=45250;  
+UPDATE `creature` SET `position_x`=1385.66, `position_y`=-1544.23, `position_z`=59.1008, `orientation`=4.79965 WHERE `guid`=45247; 
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
This updates Araj and his minions spawn positions to classic sniff data.
His current spawn position is from patch 2.3.0 TBC.

Vanilla post 1.4.0:
![world-of-warcraft-gooty-017](https://user-images.githubusercontent.com/6137576/92271100-81c13380-eee7-11ea-9b11-9a3d4efd0339.jpg)
08-10-2006
![WoWScrnShot_081006_151103](https://user-images.githubusercontent.com/6137576/92271573-58ed6e00-eee8-11ea-9783-5c52e9c6eaf0.jpg)
TBC pre 2.3.0:
![42998-alas-andorhal](https://user-images.githubusercontent.com/6137576/92271209-ae754b00-eee7-11ea-81f8-ccb0df37757b.jpg)

