### PR TITLE
Fix dual wield penalty when Yellow (Special attack) is queued up

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2569,6 +2569,9 @@ float Unit::MeleeMissChanceCalc(Unit const* pVictim, WeaponAttackType attType) c
         }
         if (!isNormal && !m_currentSpells[CURRENT_MELEE_SPELL])
             missChance += 19.0f;
+
+        if (IsNextSwingSpellCasted())
+            missChance -= 19.0f;
     }
 
     int32 skillDiff = int32(GetWeaponSkillValue(attType, pVictim)) - int32(pVictim->GetDefenseSkillValue(this));


### PR DESCRIPTION
All off-hand attacks that occur while Heroic Strike is queued should not suffer the dual wield penalty.

Source: https://us.forums.blizzard.com/en/wow/t/wow-classic-%E2%80%9Cnot-a-bug%E2%80%9D-list-updated-feb-19-2020/175887

Offhand attacks that occur while on-next-hit abilities such as Heroic Strike are queued do not suffer the dual wield to-hit penalty.