### PR TITLE
Fix Quest Fragments of the Past (5247)

### DIFF
--- a/sql/migrations/20200922094612_world.sql
+++ b/sql/migrations/20200922094612_world.sql
@@ -1,0 +1,24 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20200922094612');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20200922094612');
+-- Add your query below.
+
+
+INSERT INTO gameobject_template (entry, patch, type, displayId, name, faction, flags, size, data0, data1, data2, data3, data4, data5, data6, data7, data8, data9, data10, data11, data12, data13, data14, data15, data16, data17, data18, data19, data20, data21, data22, data23, mingold, maxgold, script_name) VALUES
+(178225, 0, 8, 2770, 'Dire Pool Spell Focus', 0, 0, 1, 1083, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '');
+
+INSERT INTO gameobject (guid, id, map, position_x, position_y, position_z, orientation, rotation0, rotation1, rotation2, rotation3, spawntimesecsmin, spawntimesecsmax, animprogress, state) VALUES
+(150000, 178225, 1, -4033.24, 1345.66, 152.989, 3.14159, 0, 0, 1, 0, 900, 900, 100, 1);
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
This PR fixes the quest Fragments of tha past by adding missing gameobjects. Taken from: https://github.com/cmangos/tbc-db/blob/ad999c52463aa822114ed846893469e78b0e9134/Updates/313_misc_fixes.sql