### PR TITLE
immoltar setdata wasnt called

### DIFF
--- a/src/scripts/kalimdor/feralas/dire_maul/instance_dire_maul.cpp
+++ b/src/scripts/kalimdor/feralas/dire_maul/instance_dire_maul.cpp
@@ -176,6 +176,8 @@ void instance_dire_maul::OnCreatureDeath(Creature* pCreature)
         case NPC_IMMOL_THAR:
             if (Creature* pTortheldrin = instance->GetCreature(m_uiTortheldrinGUID))
                 pTortheldrin->MonsterYell(SAY_IMMOL_THAR_DEAD);
+            if (GetData(TYPE_IMMOL_THAR) != DONE)
+                SetData(TYPE_IMMOL_THAR, DONE);
             break;
         case NPC_GUARD_MOLDAR:
             SetData(TYPE_MOLDAR, DONE); 


### PR DESCRIPTION
This fix will allow Tortheldrin to be attackable after Immoltar is killed.
#806 