### PR TITLE
Naxxramas bct texts fixes

### DIFF
--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
@@ -1314,31 +1314,31 @@ void instance_naxxramas::Update(uint32 diff)
                 break;
             }
             case EVENT_4HM_DIALOGUE_1:
-                DoOrSimulateScriptTextForMap(-1533059, NPC_ZELIEK, GetMap(), GetSingleCreatureFromStorage(NPC_ZELIEK));
+                DoOrSimulateScriptTextForMap(SAY_4HM_DIALOGUE_1, NPC_ZELIEK, GetMap(), GetSingleCreatureFromStorage(NPC_ZELIEK));
                 m_events.ScheduleEvent(EVENT_4HM_DIALOGUE_2, Seconds(7));
                 break;
             case EVENT_4HM_DIALOGUE_2:
-                DoOrSimulateScriptTextForMap(-1533045, NPC_BLAUMEUX, GetMap(), GetSingleCreatureFromStorage(NPC_BLAUMEUX));
+                DoOrSimulateScriptTextForMap(SAY_4HM_DIALOGUE_2, NPC_BLAUMEUX, GetMap(), GetSingleCreatureFromStorage(NPC_BLAUMEUX));
                 m_events.ScheduleEvent(EVENT_4HM_DIALOGUE_3, Seconds(7));
                 break;
             case EVENT_4HM_DIALOGUE_3:
-                DoOrSimulateScriptTextForMap(-1533071, NPC_MOGRAINE, GetMap(), GetSingleCreatureFromStorage(NPC_MOGRAINE));
+                DoOrSimulateScriptTextForMap(SAY_4HM_DIALOGUE_3, NPC_MOGRAINE, GetMap(), GetSingleCreatureFromStorage(NPC_MOGRAINE));
                 m_events.ScheduleEvent(EVENT_4HM_DIALOGUE_4, Seconds(7));
                 break;
             case EVENT_4HM_DIALOGUE_4:
-                DoOrSimulateScriptTextForMap(-1533046, NPC_BLAUMEUX, GetMap(), GetSingleCreatureFromStorage(NPC_BLAUMEUX));
+                DoOrSimulateScriptTextForMap(SAY_4HM_DIALOGUE_4, NPC_BLAUMEUX, GetMap(), GetSingleCreatureFromStorage(NPC_BLAUMEUX));
                 m_events.ScheduleEvent(EVENT_4HM_DIALOGUE_5, Seconds(7));
                 break;
             case EVENT_4HM_DIALOGUE_5:
-                DoOrSimulateScriptTextForMap(-1533060, NPC_ZELIEK, GetMap(), GetSingleCreatureFromStorage(NPC_ZELIEK));
+                DoOrSimulateScriptTextForMap(SAY_4HM_DIALOGUE_5, NPC_ZELIEK, GetMap(), GetSingleCreatureFromStorage(NPC_ZELIEK));
                 m_events.ScheduleEvent(EVENT_4HM_DIALOGUE_6, Seconds(6));
                 break;
             case EVENT_4HM_DIALOGUE_6:
-                DoOrSimulateScriptTextForMap(-1533053, NPC_THANE, GetMap(), GetSingleCreatureFromStorage(NPC_THANE));
+                DoOrSimulateScriptTextForMap(SAY_4HM_DIALOGUE_6, NPC_THANE, GetMap(), GetSingleCreatureFromStorage(NPC_THANE));
                 m_events.ScheduleEvent(EVENT_4HM_DIALOGUE_7, Seconds(7));
                 break;
             case EVENT_4HM_DIALOGUE_7:
-                DoOrSimulateScriptTextForMap(-1533072, NPC_MOGRAINE, GetMap(), GetSingleCreatureFromStorage(NPC_MOGRAINE));
+                DoOrSimulateScriptTextForMap(SAY_4HM_DIALOGUE_7, NPC_MOGRAINE, GetMap(), GetSingleCreatureFromStorage(NPC_MOGRAINE));
                 break;
             case EVENT_DKWING_INTRO_2:
                 DoOrSimulateScriptTextForMap(SAY_ZELI_TAUNT3, NPC_ZELIEK, GetMap(), GetSingleCreatureFromStorage(NPC_ZELIEK));

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/naxxramas.h
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/naxxramas.h
@@ -258,7 +258,15 @@ enum NaxxZoneScriptTexts
     SAY_KORT_TAUNT1         = 13038, // To arms, ye roustabouts! We've got company!
     SAY_ZELI_TAUNT3         = 13103, // Do not continue! Turn back while there's still time!
     SAY_MOG_TAUNT3          = 13060, // Life is meaningless. It is in death that we are truly tested.
-    SAY_BLAU_TAUNT3         = 13016  // The first kill goes to me! Anyone care to wager?
+    SAY_BLAU_TAUNT3         = 13016, // The first kill goes to me! Anyone care to wager?
+
+    SAY_4HM_DIALOGUE_1      = 13101,
+    SAY_4HM_DIALOGUE_2      = 13014,
+    SAY_4HM_DIALOGUE_3      = 13058,
+    SAY_4HM_DIALOGUE_4      = 13015,
+    SAY_4HM_DIALOGUE_5      = 13102,
+    SAY_4HM_DIALOGUE_6      = 13039,
+    SAY_4HM_DIALOGUE_7      = 13059
 };
 
 struct GothTrigger


### PR DESCRIPTION
Partially fix: #809

<pre>
DoOrSimulateScriptTextForMap with source entry 16063 for map 533 could not find script text entry -1533059.
DoOrSimulateScriptTextForMap with source entry 16065 for map 533 could not find script text entry -1533045.
DoOrSimulateScriptTextForMap with source entry 16062 for map 533 could not find script text entry -1533071.
DoOrSimulateScriptTextForMap with source entry 16065 for map 533 could not find script text entry -1533046.
DoOrSimulateScriptTextForMap with source entry 16063 for map 533 could not find script text entry -1533060.
DoOrSimulateScriptTextForMap with source entry 16064 for map 533 could not find script text entry -1533053.
DoOrSimulateScriptTextForMap with source entry 16062 for map 533 could not find script text entry -1533072.
</pre>