### PR TITLE
adding github actions workflow and badge

### DIFF
--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -1,0 +1,27 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: befor install
+      run: |
+          sudo apt-get -qq install libmysql++-dev libace-dev libtbb-dev
+          sudo apt-get -qq install cmake build-essential cppcheck git make binutils-dev libiberty-dev openssl libssl-dev
+    - uses: actions/checkout@v2
+    - name: Build & install
+      run: |
+        mkdir build
+        mkdir _install
+        cd build
+        cmake ../ -DCMAKE_INSTALL_PREFIX=../_install -DCMAKE_C_COMPILER="gcc" -DCMAKE_CXX_COMPILER="g++" -DSERVERS=1 -DTOOLS=1 -DSCRIPTS=1 -DWITH_DOCS=1 -DWITH_WARNINGS=0 -DELUNA=0 -DWITH_COREDEBUG=0
+        make -j2
+        make install

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 [10]: https://travis-ci.com/github/vmangos/core
 
 
+![C/C++ CI](https://github.com/vmangos/core/workflows/C/C++%20CI/badge.svg)
+
+
 # Progressive Vanilla
 This project is an independent continuation of the Elysium / LightsHope codebases, focused on delivering the most complete and accurate content progression system possible, including support for the patch appropriate game clients.
 


### PR DESCRIPTION
adding github workflow due to travis billing plan changes
https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing

not sure whethter if it would add workflow to the main repo if i make pr. 
if not please try to add and just copy paste the content inside the vmangos.yml
then change the readme file

get the badge link from here:

![image](https://user-images.githubusercontent.com/10232727/100715479-3806bd00-33f2-11eb-9009-bdd612e6a3b2.png)

example build result:

![image](https://user-images.githubusercontent.com/10232727/100716030-1954f600-33f3-11eb-83ef-64ed6d885a24.png)

example badge status:

![C/C++ CI](https://github.com/coolzoom/w1x-vmcore/workflows/C/C++%20CI/badge.svg)
