### PR TITLE
Update boss_ouro.cpp

### DIFF
--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
@@ -77,7 +77,7 @@ const uint32_t SANDBLAST_TIMER_INITIAL_MIN = 30000;
 const uint32_t SANDBLAST_TIMER_INITIAL_MAX = 45000;
 const uint32_t SANDBLAST_TIMER_MIN         = 12000;
 const uint32_t SANDBLAST_TIMER_MAX         = 17000;
-const uint32_t SUBMERGE_TIMER              = 60000;
+const uint32_t SUBMERGE_TIMER              = 90000;
 const uint32_t SUBMERGE_ANIMATION_INVIS    = 2000;
 const uint32_t SWEEP_TIMER                 = 15000;
 


### PR DESCRIPTION
## 🍰 Pullrequest

In reference to https://github.com/vmangos/core/issues/963, "Incorrect Ouro Submerge Timer", I have changed the submerge timer to be 90 seconds (1.5 minutes) instead of 60 seconds

### Proof

Proof:
Source : http://wowwiki.wikia.com/wiki/Ouro

https://www.youtube.com/watch?v=hJXUVjlFNqQ&feature=emb_title

In this video, The fight starts at 0:15, and the first submerge is at about 3:20. So ouro skipped the first submerge due to a sand blast at 1:45, and he decided to at this point, 1.5 mins later. Possibly a delay calculated after he sandblasted, which is currently reflected in the code, but this decision happened at about a 1.5 minute interval.

### Issues

Fixes the early submerge at 1 minute.

### How2Test

1. Start ouro encounter
2. Wait 1 minute
3. He should not submerge
4. ...
5. Profit


