### PR TITLE
Silithus world pvp fixes

### DIFF
--- a/sql/migrations/20210104121750_world.sql
+++ b/sql/migrations/20210104121750_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210104121750');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210104121750');
+-- Add your query below.
+
+
+-- Remove Speed limit from Traces of Silithyst (29534)
+DELETE FROM `spell_effect_mod` WHERE  `Id`=29534 AND `EffectIndex`=0;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20210105084615_world.sql
+++ b/sql/migrations/20210105084615_world.sql
@@ -1,0 +1,24 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210105084615');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210105084615');
+-- Add your query below.
+
+
+-- Buffs which are only active Silithus.
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_start_active`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`) VALUES (29519, 1377, 0, 0, 0, 0, 0, 2, 0);
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_start_active`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`) VALUES (29894, 1377, 0, 0, 0, 0, 0, 2, 0);
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_start_active`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`) VALUES (29895, 1377, 0, 0, 0, 0, 0, 2, 0);
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_start_active`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`) VALUES (30754, 1377, 0, 0, 0, 0, 0, 2, 0);
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20210105091011_world.sql
+++ b/sql/migrations/20210105091011_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210105091011');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210105091011');
+-- Add your query below.
+
+
+-- Fix gameobjects
+UPDATE `gameobject_template` SET `size`='0.3', `data10`='29518' WHERE  `entry`=181597 AND `patch`=10;
+UPDATE `gameobject_template` SET `data10`='29518' WHERE  `entry`=181598 AND `patch`=10;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20210105114022_world.sql
+++ b/sql/migrations/20210105114022_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210105114022');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210105114022');
+-- Add your query below.
+
+
+-- Silithyst-bring-in animation
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `conditionId`, `inverseEffectMask`, `build_min`, `build_max`) VALUES (29534, 0, 181603, 0, 0, 5875, 5875);
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `conditionId`, `inverseEffectMask`, `build_min`, `build_max`) VALUES (29534, 0, 181617, 0, 0, 5875, 5875);
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Objects/GameObject.cpp
+++ b/src/game/Objects/GameObject.cpp
@@ -2351,6 +2351,7 @@ bool GameObject::HasCustomAnim() const
         case 4491: // mortar in dun morogh
         case 6785: // plague fissure
         case 6747: // sapphiron birth
+        case 6871: // Silithyst bring in
             return true;
     }
 

--- a/src/game/OutdoorPvP/OutdoorPvPSI.h
+++ b/src/game/OutdoorPvP/OutdoorPvPSI.h
@@ -24,20 +24,23 @@
 
 enum OutdoorPvPSISpells
 {
-    SI_SILITHYST_FLAG_GO_SPELL       = 29518,
-    SI_SILITHYST_FLAG                = 29519,
-    SI_TRACES_OF_SILITHYST           = 29534,
-    SI_CENARION_FAVOR                = 30754
+    SI_SILITHYST_FLAG_GO_SPELL          = 29518,
+    SI_SILITHYST_FLAG                   = 29519,
+    SI_TRACES_OF_SILITHYST              = 29534,
+    SI_CENARION_FAVOR                   = 30754,
+    SILLITHUS_FLAG_HORDE_SPEED_LIMIT    = 29895,
+    SILLITHUS_FLAG_ALLIANCE_SPEED_LIMIT = 29894,
+    SILLITHUS_FLAG_DROP                 = 29533
 };
 
 uint32 const SI_MAX_RESOURCES_DEFAULT = 200;
 uint8 const OutdoorPvPSIBuffZonesNum = 3;
 uint32 const OutdoorPvPSIBuffZones[OutdoorPvPSIBuffZonesNum] = { 1377, 3428, 3429 };
-uint32 const SI_AREATRIGGER_H        = 4168;
-uint32 const SI_AREATRIGGER_A        = 4162;
-uint32 const SI_TURNIN_QUEST_CM_A    = 17090;
-uint32 const SI_TURNIN_QUEST_CM_H    = 18199;
-uint32 const SI_SILITHYST_MOUND      = 181597;
+uint32 const SI_AREATRIGGER_H       = 4168;
+uint32 const SI_AREATRIGGER_A       = 4162;
+uint32 const SI_TURNIN_QUEST_CM_A   = 17090;
+uint32 const SI_TURNIN_QUEST_CM_H   = 18199;
+uint32 const SI_SILITHYST_MOUND     = 181597;
 
 enum SI_WorldStates
 {
@@ -66,8 +69,6 @@ class OutdoorPvPSI : public OutdoorPvP
         bool HandleAreaTrigger(Player* plr, uint32 trigger);
 
         bool HandleDropFlag(Player* plr, uint32 spellId);
-
-        bool HandleCustomSpell(Player* plr, uint32 spellId, GameObject* go);
 
         void UpdateWorldState();
 

--- a/src/game/OutdoorPvP/OutdoorPvPSI.h
+++ b/src/game/OutdoorPvP/OutdoorPvPSI.h
@@ -30,7 +30,10 @@ enum OutdoorPvPSISpells
     SI_CENARION_FAVOR                   = 30754,
     SILLITHUS_FLAG_HORDE_SPEED_LIMIT    = 29895,
     SILLITHUS_FLAG_ALLIANCE_SPEED_LIMIT = 29894,
-    SILLITHUS_FLAG_DROP                 = 29533
+    SILLITHUS_FLAG_CAPTURE_TEST         = 29530,
+    SILLITHUS_FLAG_DROP                 = 29533,
+    HONOR_POINTS_199                    = 31420,
+    SILITHYST_CAP_REWARD                = 31247
 };
 
 uint32 const SI_MAX_RESOURCES_DEFAULT = 200;
@@ -41,6 +44,7 @@ uint32 const SI_AREATRIGGER_A       = 4162;
 uint32 const SI_TURNIN_QUEST_CM_A   = 17090;
 uint32 const SI_TURNIN_QUEST_CM_H   = 18199;
 uint32 const SI_SILITHYST_MOUND     = 181597;
+uint32 const SI_SILITHYST_GEYSER    = 181598;
 
 enum SI_WorldStates
 {

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2732,11 +2732,18 @@ void Aura::HandleForceReaction(bool apply, bool Real)
             player->StopAttackFaction(scarlet_crusade_faction_id);
     }
 
-    if (!apply && player->GetZoneId() == 1377 && GetId() == 29519 && (m_removeMode == AURA_REMOVE_BY_CANCEL || m_removeMode == AURA_REMOVE_BY_DEATH))
+    if (player->GetZoneId() == 1377 && GetId() == 29519)
     {
-        // OutdoorPVP Silithus : Perte du buff silithyste
-        if (ZoneScript* pScript = player->GetZoneScript())
-            pScript->HandleDropFlag(player, GetId());
+        if (apply)
+            player->CastSpell(player, (player->GetTeam() == ALLIANCE ? 29894 : 29895), true);
+        else
+        {
+            player->RemoveAurasDueToSpell((player->GetTeam() == ALLIANCE ? 29894 : 29895));
+            // Outdoor PVP Silithus : Loss of Silithyst Buff.
+            if (m_removeMode == AURA_REMOVE_BY_CANCEL || m_removeMode == AURA_REMOVE_BY_DEATH || m_removeMode == AURA_REMOVE_BY_DISPEL)
+                if (ZoneScript* pScript = player->GetZoneScript())
+                    pScript->HandleDropFlag(player, GetId());
+        }
     }
 
 }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2732,7 +2732,7 @@ void Aura::HandleForceReaction(bool apply, bool Real)
             player->StopAttackFaction(scarlet_crusade_faction_id);
     }
 
-    if (player->GetZoneId() == 1377 && GetId() == 29519)
+    if (GetId() == 29519 && player->GetZoneId() == 1377)
     {
         if (apply)
             player->CastSpell(player, (player->GetTeam() == ALLIANCE ? 29894 : 29895), true);

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1576,6 +1576,14 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                         unitTarget->AddCooldown(*spellInfo, itemProto);
                     return;
                 }
+                case 29518: // Sillithus Flag Click (DND)
+                {
+                    // Also mark player with pvp on
+                    unitTarget->CastSpell(unitTarget, 29519, true);
+                    unitTarget->SetPvPContested(true);
+
+                    return;
+                }
                 case 17190: // Ras Frostwhisper Visual Dummy
                 {
                     if (unitTarget)


### PR DESCRIPTION
**fixes:**
#608 

- remove speed limit form Traces of Silithyst (29534).
- adds speed limit to Silithyst (29519).
- some clean up and DB fixes.
