### PR TITLE
Add rejuvenation spell when eating deviate fish, improve spell effect "Party Time"

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6234,7 +6234,14 @@ void Aura::PeriodicDummyTick()
                 }
                 case 8067:                                  // Party Time!
                 {
-                    target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH, EMOTE_ONESHOT_DANCE));
+                    if (!target->HasAura(8067))
+                    {
+                        if (target->IsMoving())
+                            target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH));
+                        else
+                            target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH, EMOTE_ONESHOT_DANCESPECIAL));
+                        // TODO: TrintiyCore: _player->m_Events.AddEventAtOffset(this, RAND(5s, 10s, 15s));
+                    }
                     return;
                 }
                 case 7057:                                  // Haunting Spirits

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6237,7 +6237,7 @@ void Aura::PeriodicDummyTick()
                     if (target->IsMoving())
                         target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH));
                     else
-                        target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH, EMOTE_ONESHOT_DANCESPECIAL));
+                        target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH, EMOTE_ONESHOT_DANCE));
                     return;
                 }
                 case 7057:                                  // Haunting Spirits

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6234,14 +6234,10 @@ void Aura::PeriodicDummyTick()
                 }
                 case 8067:                                  // Party Time!
                 {
-                    if (!target->HasAura(8067))
-                    {
-                        if (target->IsMoving())
-                            target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH));
-                        else
-                            target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH, EMOTE_ONESHOT_DANCESPECIAL));
-                        // TODO: TrintiyCore: _player->m_Events.AddEventAtOffset(this, RAND(5s, 10s, 15s));
-                    }
+                    if (target->IsMoving())
+                        target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH));
+                    else
+                        target->HandleEmoteCommand(PickRandomValue(EMOTE_ONESHOT_APPLAUD, EMOTE_ONESHOT_CHEER, EMOTE_ONESHOT_CHICKEN, EMOTE_ONESHOT_LAUGH, EMOTE_ONESHOT_DANCESPECIAL));
                     return;
                 }
                 case 7057:                                  // Haunting Spirits

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -847,7 +847,7 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     if (!pPlayer)
                         return;
 
-                    uint32 spellId = PickRandomValue(8064, 8065, 8066, 8067, 8068);
+                    uint32 spellId = PickRandomValue(8064, 8065, 8066, 8067, 8068, 8070);
                     pPlayer->CastSpell(pPlayer, spellId, true, nullptr);
                     return;
                 }


### PR DESCRIPTION
Credit goes to TrinityCore https://github.com/TrinityCore/TrinityCore/pull/25802/files

## 🍰 Pullrequest
Added missing random spell effect when eating a deviate fish 
https://classic.wowhead.com/spell=8070/rejuvenation

### How2Test
- eat a raw deviate fish 

### Todo / Checklist
-  I think currenlty Aura::PeriodicDummyTick() has some issues/ is not working ( this affects spell "Party Time"). 
Related issues: https://github.com/vmangos/core/issues/866, https://github.com/vmangos/core/issues/865
