### PR TITLE
Fixes to Theradras

### DIFF
--- a/sql/migrations/20210107040717_world.sql
+++ b/sql/migrations/20210107040717_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210107040717');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210107040717');
+-- Add your query below.
+
+-- Princess Theradras is immune to nature damage
+UPDATE `creature_template` SET `school_immune_mask`='8' WHERE  `entry`=12201 AND `patch`=0;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
+++ b/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
@@ -79,8 +79,14 @@ struct boss_ptheradrasAI : public ScriptedAI
         //Dustfield_Timer
         if (Dustfield_Timer < diff)
         {
-            DoCastSpellIfCan(m_creature, SPELL_DUSTFIELD);
-            Dustfield_Timer = 14000;
+            std::list<Player*> players;
+            GetPlayersWithinRange(players, m_creature->GetMeleeReach());
+            //only cast Dust Field if a player is in melee range 
+            if (players.size() > 0)
+            {
+                DoCastSpellIfCan(m_creature, SPELL_DUSTFIELD);
+                Dustfield_Timer = 14000;
+            }
         }
         else Dustfield_Timer -= diff;
 

--- a/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
+++ b/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
@@ -81,14 +81,22 @@ struct boss_ptheradrasAI : public ScriptedAI
         {
 
             //only cast Dust Field if an attacker is in melee range 
+            bool m_bMeleeAttackers = false;
+
             Unit::AttackerSet attackers = m_creature->GetAttackers();
             for (const auto itr : attackers)
                 if (Unit* attacker = m_creature->GetMap()->GetUnit(itr->GetGUID()))
                     if (m_creature->IsInRange(attacker, 0.0f, m_creature->GetMeleeReach(), false))
                     {
-                        DoCastSpellIfCan(m_creature, SPELL_DUSTFIELD);
-                        Dustfield_Timer = 14000;
+                        m_bMeleeAttackers = true;
+                        break;
                     }
+            
+            if (m_bMeleeAttackers)
+            {
+                DoCastSpellIfCan(m_creature, SPELL_DUSTFIELD);
+                Dustfield_Timer = 14000;
+            }
 
         }
         else Dustfield_Timer -= diff;

--- a/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
+++ b/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
@@ -79,18 +79,21 @@ struct boss_ptheradrasAI : public ScriptedAI
         //Dustfield_Timer
         if (Dustfield_Timer < diff)
         {
-
             //only cast Dust Field if an attacker is in melee range 
             bool m_bMeleeAttackers = false;
 
             Unit::AttackerSet attackers = m_creature->GetAttackers();
             for (const auto itr : attackers)
+            {
                 if (Unit* attacker = m_creature->GetMap()->GetUnit(itr->GetGUID()))
+                {
                     if (m_creature->IsInRange(attacker, 0.0f, m_creature->GetMeleeReach(), false))
                     {
                         m_bMeleeAttackers = true;
                         break;
                     }
+                }
+            }
             
             if (m_bMeleeAttackers)
             {
@@ -104,15 +107,15 @@ struct boss_ptheradrasAI : public ScriptedAI
         //Boulder_Timer
         if (Boulder_Timer < diff)
         {
-            Unit* target = nullptr;
-            target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
-            if (target)
+            if (Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
+            {
                 if (DoCastSpellIfCan(target, SPELL_BOULDER) == CAST_OK)
                 {
                     m_creature->SetInFront(target);
                     m_creature->SetTargetGuid(target->GetObjectGuid());
                     RestoreTargetTimer = 2000 + 750; // cast time + 1/2 gcd ?
                 }
+            }
             Boulder_Timer = 10000;
         }
         else Boulder_Timer -= diff;

--- a/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
+++ b/src/scripts/kalimdor/desolace/maraudon/boss_princess_theradras.cpp
@@ -79,14 +79,17 @@ struct boss_ptheradrasAI : public ScriptedAI
         //Dustfield_Timer
         if (Dustfield_Timer < diff)
         {
-            std::list<Player*> players;
-            GetPlayersWithinRange(players, m_creature->GetMeleeReach());
-            //only cast Dust Field if a player is in melee range 
-            if (players.size() > 0)
-            {
-                DoCastSpellIfCan(m_creature, SPELL_DUSTFIELD);
-                Dustfield_Timer = 14000;
-            }
+
+            //only cast Dust Field if an attacker is in melee range 
+            Unit::AttackerSet attackers = m_creature->GetAttackers();
+            for (const auto itr : attackers)
+                if (Unit* attacker = m_creature->GetMap()->GetUnit(itr->GetGUID()))
+                    if (m_creature->IsInRange(attacker, 0.0f, m_creature->GetMeleeReach(), false))
+                    {
+                        DoCastSpellIfCan(m_creature, SPELL_DUSTFIELD);
+                        Dustfield_Timer = 14000;
+                    }
+
         }
         else Dustfield_Timer -= diff;
 


### PR DESCRIPTION
## 🍰 Pullrequest
Makes Theradras immune to nature damage
And only cast Dustfield if there is a player in range

### Proof
Princess Theradras should be immune to all nature spells according to Classic WoW and a comment posted by Mumba on 2005-11-04. Here's a few examples from Classic WoW:

1. https://youtu.be/1wpA97AycA8. The hunter in the video is using a bow called Verdant Keeper's Aim (as seen at 0:46 in the video) which has a Chance to strike your ranged target with Keeper's Sting for 15 to 21 Nature damage. At 7:29, 8:44 and 9:53 in the video his bow procs and the boss is immune every time. Watch for the green wrath-like visual effect on his character's hands followed by Immune text on the target frame.
2. https://youtu.be/x4Bb-wjnvaw?t=34435. Watch the fight and notice the boss is immune to the Deadly Poison effect on the character's main hand weapon (as seen applied at 9:30:35).
3. https://youtu.be/30ZU7RD-wSQ?t=37559. The druid casts Faerie Fire (Feral) and the boss is immune.

Princess Theradras should not cast Dust Field if nobody is in melee range of her according to Classic WoW. Here's a few examples:

1. https://youtu.be/1wpA97AycA8?t=405. Here the hunter starts explaining how he got Princess Theradras to cast Dust Field using his pet.
2. https://youtu.be/ORL-CpNVFzc?t=140. Watch the fight and notice Princess Theradras only casts Dust Field if she reaches her target.

### Issues

- fixes https://github.com/the-hyjal-project/bugtracker/issues/176


### How2Test
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->

