### PR TITLE
Fix Lexlort gossip

### DIFF
--- a/sql/migrations/20210107205655_world.sql
+++ b/sql/migrations/20210107205655_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210107205655');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210107205655');
+-- Add your query below.
+
+-- Fix Lexlort (npc 9080) to provide shackles for players
+DELETE FROM `gossip_scripts` WHERE `id`=50406;
+INSERT INTO `gossip_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES (50406, 0, 15, 22941, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Grark Lorkrub\'s Thorium Shackles');
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20210107205655_world.sql
+++ b/sql/migrations/20210107205655_world.sql
@@ -10,7 +10,7 @@ INSERT INTO `migrations` VALUES ('20210107205655');
 
 -- Fix Lexlort (npc 9080) to provide shackles for players
 DELETE FROM `gossip_scripts` WHERE `id`=50406;
-INSERT INTO `gossip_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES (50406, 0, 15, 22941, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Grark Lorkrub\'s Thorium Shackles');
+INSERT INTO `gossip_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES (50406, 0, 15, 22941, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Grark Lorkrub\'s Thorium Shackles');
 
 
 -- End of migration.


### PR DESCRIPTION
## 🍰 Pullrequest
Npc [Lexlort ](https://classic.wowhead.com/npc=9080/lexlort) has a gossip option to provide players with a new pair of Thorium shackles for the quest [Grak Lokrub](https://classic.wowhead.com/quest=4122/grark-lorkrub)

This PR changes the gossip script from casting the spell on the npc to casting the spell on player. If its not casted on the player - the shackles will not be added to the players inventory.

### Proof
- None

### Issues
- None

### How2Test
- Log on with a GM account and try the gossip option

### Todo / Checklist

