### PR TITLE
Allow spells which have resistance modifier as first effect to be considered binary spells.

### DIFF
--- a/src/game/Spells/SpellEntry.cpp
+++ b/src/game/Spells/SpellEntry.cpp
@@ -305,6 +305,7 @@ void SpellEntry::ComputeBinary()
                     case SPELL_AURA_MOD_ROOT:
                     case SPELL_AURA_MOD_SILENCE:
                     case SPELL_AURA_MOD_DISARM:
+                    case SPELL_AURA_MOD_RESISTANCE:
                     case SPELL_AURA_MOD_DAMAGE_TAKEN:
                         foundNoDamageAura = true;
                         break;


### PR DESCRIPTION
## 🍰 Pullrequest
This pull request is being made to address the issue that effects which reduce resistances as the first effect and deal damage are not being considered binary spells, and thus, are being partially resisted.

Proof


According to:
http://web.archive.org/web/20061128170702/http://worldofwarcraft.com/info/basics/resistances.html

"The second chance to resist is based on your resistance score and the level of the caster. The higher your resistance score in relation to the level of the attacking caster, the higher your average resistance percentage, up to a maximum of 75%. Against most spells, this resistance percentage is the straight % chance to completely resist the spell. Against direct-damage spells (spells that deliver their full damage upon impact, such as Fireball, Mind Blast, and Earth Shock), this resistance is the percentage of damage you will resist on average. "

Partial resistance can only happen on non-binary spells. This is the reason why Frostbolt cannot partially resist. It applies the slow, and then it applies the damage, hence it is a binary spell as the damage is not applied first.

The Thunderfury chance on hit has 3 effects:

    reduce nature resistance by -25, and jump to 4 other targets.
    apply 300 nature damage to the target
    cast spell 27648, which applies the slow to the primary target.

As you can see, the Thunderfury spell does not deliver it's damage as the primary effect of the spell. Hence it should be considered a non-binary spell, like Frostbolt. This is also corroborated by classic data, such as this video here:

https://www.youtube.com/watch?v=gWLw9lpMDeQ

In which a warrior dps' for an entire MC and does not get a Thunderfury proc that does less than 300 damage (apart from the mobs which take -50% spell damage situationally like Shazzrah).

Currently in the code, while spells which reduce speed are considered binary spells, as Thunderfury's speed reduction is NOT connected to the spell that does the nature damage, and rather the damage is connected to the spell that reduces the nature resist, it is not being considered a binary spell, and thus partially resisting.
