### PR TITLE
DB PULL REQUEST: Add Threat values to paladin blessings based on the level the spell is learned

### DIFF
--- a/sql/migrations/20210121063854_world.sql
+++ b/sql/migrations/20210121063854_world.sql
@@ -8,41 +8,44 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20210121063854');
 -- Add your query below.
 
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19740', '4', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19834', '12', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19835', '22', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19836', '32', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19837', '42', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19838', '52', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25291', '60', '1', '0', '5086', '5875');
-UPDATE `spell_threat` SET `Threat` = '14', `multiplier` = '1' WHERE `spell_threat`.`entry` = 19742; 
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19850', '24', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19852', '34', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19853', '44', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19854', '54', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25290', '60', '1', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20911', '30', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20912', '40', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20913', '50', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20914', '60', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19977', '40', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19978', '50', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19979', '60', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('1022', '10', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('5599', '24', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('10278', '38', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('6940', '46', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20729', '54', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('1038', '26', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('1044', '18', '1', '0', '0', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25782', '52', '1', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25916', '60', '1', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25899', '60', '1', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25894', '0', '0', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25918', '0', '0', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25890', '60', '1', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25895', '60', '1', '0', '5086', '5875');
-INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25898', '60', '1', '0', '5086', '5875');
+
+-- Add threat for paladin blessings equal to their level.
+-- Blessing of Wisdom never generates any threat.
+-- https://classic.wowhead.com/guides/lights-bulwark-protection-paladin-tanking
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19740, 4, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19834, 12, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19835, 22, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19836, 32, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19837, 42, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19838, 52, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25291, 60, 1, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19850, 0, 0, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19852, 0, 0, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19853, 0, 0, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19854, 0, 0, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25290, 0, 0, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (20911, 30, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (20912, 40, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (20913, 50, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (20914, 60, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19977, 40, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19978, 50, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (19979, 60, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (1022, 10, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (5599, 24, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (10278, 38, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (6940, 46, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (20729, 54, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (1038, 26, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (1044, 18, 1, 0, 0, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25782, 52, 1, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25916, 60, 1, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25899, 60, 1, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25894, 0, 0, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25918, 0, 0, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25890, 60, 1, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25895, 60, 1, 0, 5086, 5875);
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (25898, 60, 1, 0, 5086, 5875);
 
 
 -- End of migration.

--- a/sql/migrations/20210121063854_world.sql
+++ b/sql/migrations/20210121063854_world.sql
@@ -1,0 +1,53 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210121063854');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210121063854');
+-- Add your query below.
+
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19740', '4', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19834', '12', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19835', '22', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19836', '32', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19837', '42', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19838', '52', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25291', '60', '1', '0', '5086', '5875');
+UPDATE `spell_threat` SET `Threat` = '14', `multiplier` = '1' WHERE `spell_threat`.`entry` = 19742; 
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19850', '24', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19852', '34', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19853', '44', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19854', '54', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25290', '60', '1', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20911', '30', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20912', '40', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20913', '50', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20914', '60', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19977', '40', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19978', '50', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('19979', '60', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('1022', '10', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('5599', '24', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('10278', '38', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('6940', '46', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('20729', '54', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('1038', '26', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('1044', '18', '1', '0', '0', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25782', '52', '1', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25916', '60', '1', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25899', '60', '1', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25894', '0', '0', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25918', '0', '0', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25890', '60', '1', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25895', '60', '1', '0', '5086', '5875');
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES ('25898', '60', '1', '0', '5086', '5875');
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
As per research and testing on the Pretty Lame Paladin Sheet, all blessings on Classic were tested to have threat values equal to the level the spell could be learned at. The only exception being Greater Blessing of Wisdom which does 0 aggro for both ranks.

Proof

As evidenced by https://www.youtube.com/watch?v=6Qv-Povncwo, each cast of greater blessing of kings was doing 60 aggro multiplied by the number of players and righteous fury. This is consistent with the following data for Blessing threat values:

https://gyazo.com/5fa7f9296ff586a64276094123afefe3

and this one:

https://gyazo.com/93edc4eface554b4e44f390c76a3098f

As such, I have updated the threat values in the database to match these.
