### PR TITLE
Broadcast text for the barrens

### DIFF
--- a/sql/migrations/20210128145653_world.sql
+++ b/sql/migrations/20210128145653_world.sql
@@ -1,0 +1,53 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210128145653');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210128145653');
+-- Add your query below.
+
+-- Free From the Hold
+UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 1072;
+UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 1073;
+UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 1074;
+UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 1075;
+
+DELETE FROM `script_texts` WHERE `entry`= -1000370; 
+DELETE FROM `script_texts` WHERE `entry`= -1000371; 
+DELETE FROM `script_texts` WHERE `entry`= -1000372; 
+DELETE FROM `script_texts` WHERE `entry`= -1000373; 
+DELETE FROM `script_texts` WHERE `entry`= -1000374; 
+DELETE FROM `script_texts` WHERE `entry`= -1000375; 
+DELETE FROM `script_texts` WHERE `entry`= -1000376; 
+DELETE FROM `script_texts` WHERE `entry`= -1000377; 
+DELETE FROM `script_texts` WHERE `entry`= -1000378;
+DELETE FROM `script_texts` WHERE `entry`= -1000379;
+DELETE FROM `script_texts` WHERE `entry`= -1000380;
+
+-- The Affray
+UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 2354;
+
+DELETE FROM `script_texts` WHERE `entry`= -1000123;
+DELETE FROM `script_texts` WHERE `entry`= -1000124;
+DELETE FROM `script_texts` WHERE `entry`= -1000125;
+DELETE FROM `script_texts` WHERE `entry`= -1000126;
+DELETE FROM `script_texts` WHERE `entry`= -1000127;
+
+-- Wizzlecranks Shredder
+DELETE FROM `script_texts` WHERE `entry`= -1000298;
+DELETE FROM `script_texts` WHERE `entry`= -1000299;
+DELETE FROM `script_texts` WHERE `entry`= -1000300;
+DELETE FROM `script_texts` WHERE `entry`= -1000301;
+DELETE FROM `script_texts` WHERE `entry`= -1000302;
+DELETE FROM `script_texts` WHERE `entry`= -1000303;
+DELETE FROM `script_texts` WHERE `entry`= -1000304;
+DELETE FROM `script_texts` WHERE `entry`= -1000305;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20210128145653_world.sql
+++ b/sql/migrations/20210128145653_world.sql
@@ -8,6 +8,10 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20210128145653');
 -- Add your query below.
 
+-- Plundering the Plunderers
+UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 3170;
+UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 3164;
+
 -- Free From the Hold
 UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 1072;
 UPDATE `broadcast_text` SET `chat_type`=1 WHERE `entry` = 1073;

--- a/src/scripts/kalimdor/the_barrens/the_barrens.cpp
+++ b/src/scripts/kalimdor/the_barrens/the_barrens.cpp
@@ -210,7 +210,7 @@ enum
     SAY_TWIGGY_FRAY    = 2318,  
     SAY_TWIGGY_DOWN    = 2355,  
     SAY_TWIGGY_OVER    = 2320,  
-    // TODO (or done via db script?): Klannoc Macleod(id: 6236) - SAY_QUEST_TURN_IN  = 2354,  // Hail $n!  New Champion of The Affray!
+    SAY_QUEST_TURN_IN  = 2354, // TODO: implement Klannoc Macleod (id: 6236) yells after quest was turned in: Hail $n!  New Champion of The Affray!
 
     NPC_TWIGGY = 6248,
     NPC_BIG_WILL = 6238,

--- a/src/scripts/kalimdor/the_barrens/the_barrens.cpp
+++ b/src/scripts/kalimdor/the_barrens/the_barrens.cpp
@@ -32,6 +32,8 @@ EndContentData */
 
 enum
 {
+    SAY_SPAWN_1 = 3164,
+    SAY_SPAWN_2 = 3170, 
     SAY_CRACKER = 3167,
     SAY_SQUAWK  = 3165
 };
@@ -48,6 +50,18 @@ struct npc_pollyAI : public ScriptedAI
     void Reset() override
     {
         b_text = false;
+    }
+
+    void JustRespawned() override
+    {
+        if (urand(0, 1))
+        {
+            DoScriptText(SAY_SPAWN_1, m_creature); // SQUAWK! Polly wants to crack you!
+        }
+        else
+        {
+            DoScriptText(SAY_SPAWN_2, m_creature); // SQUAWK!
+        }
     }
 
     void Aggro(Unit* pWho) override

--- a/src/scripts/kalimdor/the_barrens/the_barrens.cpp
+++ b/src/scripts/kalimdor/the_barrens/the_barrens.cpp
@@ -32,8 +32,9 @@ EndContentData */
 
 enum
 {
-    SAY_SPAWN_1 = 3164,
-    SAY_SPAWN_2 = 3170, 
+    // TODO: implement random broadcast on spawn
+    //SAY_SPAWN_1 = 3164, 
+    //SAY_SPAWN_2 = 3170, 
     SAY_CRACKER = 3167,
     SAY_SQUAWK  = 3165
 };
@@ -50,18 +51,6 @@ struct npc_pollyAI : public ScriptedAI
     void Reset() override
     {
         b_text = false;
-    }
-
-    void JustRespawned() override
-    {
-        if (urand(0, 1))
-        {
-            DoScriptText(SAY_SPAWN_1, m_creature); // SQUAWK! Polly wants to crack you!
-        }
-        else
-        {
-            DoScriptText(SAY_SPAWN_2, m_creature); // SQUAWK!
-        }
     }
 
     void Aggro(Unit* pWho) override

--- a/src/scripts/kalimdor/the_barrens/the_barrens.cpp
+++ b/src/scripts/kalimdor/the_barrens/the_barrens.cpp
@@ -30,6 +30,12 @@ EndContentData */
 
 #include "scriptPCH.h"
 
+enum
+{
+    SAY_CRACKER = 3167,
+    SAY_SQUAWK  = 3165
+};
+
 struct npc_pollyAI : public ScriptedAI
 {
     npc_pollyAI(Creature* pCreature) : ScriptedAI(pCreature)
@@ -48,8 +54,8 @@ struct npc_pollyAI : public ScriptedAI
     {
         if (!b_text)
         {
-            m_creature->MonsterSay("MmmmmMmmmm... Enormous chemically altered cracker...", 0, 0);
-            m_creature->MonsterSay("What the squawk? Squawk squawk, squawk? SQUAWK!", 0, 0);
+            DoScriptText(SAY_CRACKER, m_creature);
+            DoScriptText(SAY_SQUAWK, m_creature);
             b_text = true;
         }
     }
@@ -67,17 +73,17 @@ CreatureAI* GetAI_npc_polly(Creature* pCreature)
 
 enum
 {
-    SAY_GIL_START               = -1000370,
-    SAY_GIL_AT_LAST             = -1000371,
-    SAY_GIL_PROCEED             = -1000372,
-    SAY_GIL_FREEBOOTERS         = -1000373,
-    SAY_GIL_AGGRO_1             = -1000374,
-    SAY_GIL_AGGRO_2             = -1000375,
-    SAY_GIL_AGGRO_3             = -1000376,
-    SAY_GIL_AGGRO_4             = -1000377,
-    SAY_GIL_ALMOST              = -1000378,
-    SAY_GIL_SWEET               = -1000379,
-    SAY_GIL_FREED               = -1000380,
+    SAY_GIL_START               = 1065,
+    SAY_GIL_AT_LAST             = 1066, 
+    SAY_GIL_PROCEED             = 1067, 
+    SAY_GIL_FREEBOOTERS         = 1068, 
+    SAY_GIL_AGGRO_1             = 1074, 
+    SAY_GIL_AGGRO_2             = 1075, 
+    SAY_GIL_AGGRO_3             = 1072, 
+    SAY_GIL_AGGRO_4             = 1073, 
+    SAY_GIL_ALMOST              = 1069, 
+    SAY_GIL_SWEET               = 1070, 
+    SAY_GIL_FREED               = 1071, 
 
     QUEST_FREE_FROM_HOLD        = 898,
     AREA_MERCHANT_COAST         = 391
@@ -185,11 +191,12 @@ bool QuestAccept_npc_gilthares(Player* pPlayer, Creature* pCreature, Quest const
 
 enum
 {
-    SAY_BIG_WILL_READY = -1000123,
-    SAY_TWIGGY_BEGIN = -1000124,
-    SAY_TWIGGY_FRAY = -1000125,
-    SAY_TWIGGY_DOWN = -1000126,
-    SAY_TWIGGY_OVER = -1000127,
+    SAY_BIG_WILL_READY = 2421, 
+    SAY_TWIGGY_BEGIN   = 2310,  
+    SAY_TWIGGY_FRAY    = 2318,  
+    SAY_TWIGGY_DOWN    = 2355,  
+    SAY_TWIGGY_OVER    = 2320,  
+    // TODO (or done via db script?): Klannoc Macleod(id: 6236) - SAY_QUEST_TURN_IN  = 2354,  // Hail $n!  New Champion of The Affray!
 
     NPC_TWIGGY = 6248,
     NPC_BIG_WILL = 6238,
@@ -350,7 +357,7 @@ struct npc_twiggy_flatheadAI : public ScriptedAI
                     if (Unit *will = m_creature->GetMap()->GetUnit(BigWillGUID))
                     {
                         will->SetFactionTemplateId(FACTION_CREATURE);
-                        DoScriptText(SAY_BIG_WILL_READY, will, pPlayer);
+                        DoScriptText(SAY_BIG_WILL_READY, will);
                     }
                     Event_Timer = 5000;
                     ++Step;
@@ -428,14 +435,14 @@ bool AreaTrigger_at_twiggy_flathead(Player* pPlayer, AreaTriggerEntry const* pAt
 
 enum
 {
-    SAY_START           = -1000298,
-    SAY_STARTUP1        = -1000299,
-    SAY_STARTUP2        = -1000300,
-    SAY_MERCENARY       = -1000301,
-    SAY_PROGRESS_1      = -1000302,
-    SAY_PROGRESS_2      = -1000303,
-    SAY_PROGRESS_3      = -1000304,
-    SAY_END             = -1000305,
+    SAY_START           = 1031,
+    SAY_STARTUP1        = 1039, 
+    SAY_STARTUP2        = 1032, 
+    SAY_MERCENARY       = 1040, 
+    SAY_PROGRESS_1      = 1033, 
+    SAY_PROGRESS_2      = 1043, 
+    SAY_PROGRESS_3      = 1041, 
+    SAY_END             = 1044, 
 
     QUEST_ESCAPE        = 863,
     FACTION_RATCHET     = 637,


### PR DESCRIPTION
## 🍰 Pullrequest
Converted script_texts to broadcast_text at barrens.cpp
Added some missing spawn texts ids

### Issues
- None

### How2Test
Following quests use broadcast text now:
- https://classic.wowhead.com/quest=2381/plundering-the-plunderers
- https://classic.wowhead.com/quest=898/free-from-the-hold
- https://classic.wowhead.com/quest=1719/the-affray
- https://classic.wowhead.com/quest=863/the-escape


### Todo / Checklist
After turing in warrior quest [The Affray], the quest giver (Klannoc Macleod, id: 6236)) should yell:
`Hail $n!  New Champion of The Affray!` https://youtu.be/nLsm_iVOp1Y?t=225
Boradcast text is added, but not the AI for the npc, probaly DB?
Plundering the Plunderers - polly text on spawn needs to be linked, I guesss this is DB as well?: https://youtu.be/HhAniJKPkfM?t=849