### PR TITLE
Default to old PCH implementation when using MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,16 @@ else()
   option(USE_PCH "Use precompiled headers" ON)
 endif()
 
+if(PCHSupport_FOUND AND (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16"))
+    if(MSVC)
+      option(USE_PCH_OLD "Use old precompiled headers implementation" ON)
+    else()
+      option(USE_PCH_OLD "Use old precompiled headers implementation" OFF)
+    endif()
+else()
+  unset(USE_PCH_OLD CACHE)
+endif()
+
 if(USE_LIBCURL)
   find_package(CURL REQUIRED)
   #add_definitions(-D_HAS_AUTO_PTR_ETC) # for VS2017 ACE support, won't do any harm to other compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if(WIN32)
 endif()
 
 # Add options for compile of mangos
-if(${CMAKE_VERSION} VERSION_LESS "3.16")
+if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   if(PCHSupport_FOUND)
     if(WIN32)
       option(USE_PCH "Use precompiled headers" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,8 @@ option(USE_SCRIPTS "Compile scripts" ON)
 option(USE_EXTRACTORS "Compile extractors" OFF)
 option(USE_LIBCURL "Compile with libcurl for email support" OFF)
 
-if(${CMAKE_VERSION} VERSION_LESS "3.16")
-  find_package(PCHSupport)
-else()
+find_package(PCHSupport)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
   option(USE_PCH "Use precompiled headers" ON)
 endif()
 

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -556,7 +556,7 @@ target_link_libraries(game
 #add_dependencies(game revision.h)
 
 # Generate precompiled header
-if(${CMAKE_VERSION} VERSION_LESS "3.16")
+if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   if(USE_PCH)
     if(MSVC OR XCODE)
       if(MSVC)

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -407,7 +407,7 @@ set (game_SRCS
 
 )
 
-if(${CMAKE_VERSION} VERSION_LESS "3.16")
+if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   list(APPEND game_SRCS
       pchdef.cpp
       pchdef.h

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -275,7 +275,7 @@ set (SCRIPTS_SRCS
 
 )
 
-if(${CMAKE_VERSION} VERSION_LESS "3.16")
+if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   list(APPEND SCRIPTS_SRCS
         PrecompiledHeaders/scriptPCH.cpp
     )

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -359,7 +359,7 @@ target_link_libraries(scripts
 
 #add_dependencies(${LIBRARY_NAME} revision.h)
 
-if(${CMAKE_VERSION} VERSION_LESS "3.16")
+if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   if(USE_PCH)
     if(MSVC OR XCODE)
       if(MSVC)


### PR DESCRIPTION
## 🍰 Pullrequest
Default to old PCH implementation when using MSVC.

A couple of people reported the following errors while compiling with the new implementation:
```
c1xx : error C3859: virtual memory range for PCH exceeded; please recompile with a command line option of '-Zm315' or greater
c1xx : fatal error C1076: compiler limit: internal heap limit reached; use /Zm to specify a higher limit
```
This PR should be tested on windows.