### PR TITLE
Fix Razuvious leash height

### DIFF
--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
@@ -152,7 +152,7 @@ bool instance_naxxramas::HandleEvadeOutOfHome(Creature* pWho)
             break;
         }
         case NPC_RAZUVIOUS:
-            if (pWho->GetPositionZ() > 275.0f)
+            if (pWho->GetPositionZ() > 285.0f)
             {
                 pWho->AI()->EnterEvadeMode();
                 return false;


### PR DESCRIPTION
Increased the height at which Razuvious resets to the mid-way point of the stairs, instead of the foot of the stairs.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Increased the height at which Razuvious starts evading from 275.f to 285.f, which corresponds to the middle platform of the stairway.

### Proof
<!-- Link resources as proof -->
- See issue

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
Fixes https://github.com/vmangos/core/issues/1044

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Pull Razuvious up the stairs before the Patch and afterwards
### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Independently test this modification. I've ported this over from my own investigation into Boss leashes for CMaNGOS and I don't actually have a VMaNGOS server running.
