### PR TITLE
Aura effect fixes

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -310,12 +310,7 @@ void Aura::Refresh(Unit* caster, Unit* target, SpellAuraHolder* pRefreshWithHold
     m_periodicTick = 0;
     Player* modOwner = caster ? caster->GetSpellModOwner() : nullptr;
     m_applyTime = time(nullptr);
-    // Refresh periodic period, but keep current timer.
-    // If we chain refresh a DoT, it should not prevent first damage tick!
-    int32 oldPeriodicTimer = m_periodicTimer;
     CalculatePeriodic(modOwner, true);
-    if (oldPeriodicTimer < m_periodicTimer)
-        m_periodicTimer = oldPeriodicTimer;
 
     // Re-calculation du montant de degats
     if (IsApplied() || !IsExclusive())


### PR DESCRIPTION
|Bug     |Possible Fix Implemented|Reviewed|
|---------|-----------------------------------|-------------|
|#1048 | yes                                   | no           |
|#1049 | no                                     | no          |

## Notes on #1048
As far as I can tell, it's just implemented the wrong way https://github.com/vmangos/core/blob/development/src/game/Spells/SpellAuras.cpp#L313
This comment in the code is generally wrong for player spells and this bug is fixed by simply removing a few lines, I have yet to check whether ~~doing that affects stacking auras (e.g. poison) or~~ there are exceptions.

## Notes on #1049
It needs a way to tell which spells are affected, either by using `SpellMgr::IsNoStackSpellDueToSpell` plus a way to tell apart pure effects over time form hybrids like Moonfire or Shaman's shocks, or using `Unit::HasMorePowerfulSpellActive` and rely on a database