### PR TITLE
fix enemy stealth alert ignoring los

### DIFF
--- a/src/game/AI/CreatureAI.cpp
+++ b/src/game/AI/CreatureAI.cpp
@@ -490,6 +490,10 @@ void CreatureAI::TriggerAlert(Unit const* who)
     if (WorldTimer::getMSTimeDiffToNow(m_uLastAlertTime) < 10000)
         return;
 
+    // only alert if target is within line of sight
+    if (!m_creature->IsWithinLOSInMap(who, true, true))
+        return;
+
     // Send alert sound (if any) for this creature
     m_creature->SendAIReaction(AI_REACTION_ALERT);
 


### PR DESCRIPTION
## 🍰 Pullrequest
Npc's should not  get triggered and play alert sound, when player is not within line of sight

### Proof
- None

### Issues
- None

### How2Test
- create level 15 rogue and learn stealth
- .tele fenris
- enter castle building, clear enemies in ground level
- cast stealth (with gm off) and walk around in ground level
- enemies from floor above should not get triggered and play stealth detect sound


### Todo / Checklist
- [X] None
