### PR TITLE
Update flame of ragnaros to despawn if the spell resists

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_ragnaros.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_ragnaros.cpp
@@ -658,6 +658,7 @@ struct boss_flame_of_ragnarosAI : ScriptedAI
 
     ScriptedInstance* m_pInstance;
     bool Explode;
+    int despawnTimer = 2000;
 
     void Reset() override
     {
@@ -676,10 +677,12 @@ struct boss_flame_of_ragnarosAI : ScriptedAI
             Explode = true;
     }
 
-    void UpdateAI(uint32 const /*diff*/) override
+    void UpdateAI(uint32 const diff) override
     {
-        if (Explode)
+        if (Explode || despawnTimer <= 0)
             m_creature->ForcedDespawn();
+        else
+            despawnTimer -= diff;
     }
 };
 


### PR DESCRIPTION
This Fix is to address the combat bug that occurs after Ragnaros is killed due to the Flame of Ragnaros NPCs not despawning if their casted spell "Intense Heat" resists (which on average happens at least once), by adding a 2 second timer for the npc to despawn. Normally the npc is spawned on the target of Ragnaros' "Might of Ragnaros", and will only despawn after it successfully lands the spell, else it will linger and keep players in combat.