### PR TITLE
Update Ragnaros' Wrath of Ragnaros Cast to also reset threat like on Classic

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_ragnaros.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_ragnaros.cpp
@@ -473,6 +473,7 @@ struct boss_ragnarosAI : ScriptedAI
         {
             if (DoCastSpellIfCan(m_creature, SPELL_WRATH_OF_RAGNAROS) == CAST_OK)
             {
+                DoResetThreat();
                 m_uiWrathOfRagnarosTimer = urand(25000, 30000);
                 DoScriptText(SAY_WRATH, m_creature);
             }


### PR DESCRIPTION
As Shown in:
[https://www.youtube.com/watch?v=Ad4LUHWhVUA](url), where a hunter pet takes aggro for a split second after cast,
[https://www.youtube.com/watch?v=277yEO2PXyo](url) the threat meter is reset every cast,
Every time Ragnaros casts his "Wrath of Ragnaros" spell on classic he does a complete threat reset.