### PR TITLE
AQ fixes

### DIFF
--- a/sql/migrations/20210218152035_world.sql
+++ b/sql/migrations/20210218152035_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210218152035');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210218152035');
+-- Add your query below.
+
+UPDATE `creature_template` SET `call_for_help_range` = 0 WHERE `entry` IN (15344, 15385, 15386, 15387, 15388, 15389, 15390, 15392, 15391);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -550,6 +550,19 @@ void Spell::FillTargetMap()
                                         ++itr;
                                 }
                                 break;
+                            case 25676:                                         // Drain Mana
+                            case 25754:
+                            case 26457:
+                            case 26559:
+                                // Avoid targeting players with no mana
+                                for (UnitList::iterator itr = tmpUnitMap.begin(); itr != tmpUnitMap.end();)
+                                {
+                                    if ((*itr)->GetPowerType() != POWER_MANA || (*itr)->GetPowerPercent(POWER_MANA) < 1.0f)
+                                        itr = tmpUnitMap.erase(itr);
+                                    else
+                                        ++itr;
+                                }
+                                break;
                             case 27831:
                                 // Shadow Bolt volley which should only target players with the Shadow Mark debuff
                                 for (UnitList::iterator itr = tmpUnitMap.begin(); itr != tmpUnitMap.end();)
@@ -2058,6 +2071,14 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
                 case 24781:                                 // Dream Fog (Emerald Dragons)
                 //case 28560:                                 // Summon Blizzard (Naxx, Sapphiron)
                     unMaxTargets = 1;
+                    break;
+                case 25676:                                 // Drain Mana
+                case 25754:
+                    unMaxTargets = 6;
+                    break;
+                case 26457:                                 // Drain Mana
+                case 26559:
+                    unMaxTargets = 12;
                     break;
                 case 10258:                                 // Awaken Vault Warder (Uldaman)
                     unMaxTargets = 2;

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -4762,6 +4762,25 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                     }
                     return;
                 }
+                case 25671:                                 // Drain Mana
+                case 25755:
+                {
+                    if (m_casterUnit)
+                        unitTarget->CastSpell(m_casterUnit, 26639, true);
+                    return;
+                }
+                case 25676: // Moam                         // Drain Mana
+                case 26559: // Obsidian Nullifier
+                {
+                    m_caster->CastSpell(unitTarget, 25671, true);
+                    return;
+                }
+                case 25754: // Obsidian Destroyer           // Drain Mana
+                case 26457: // Obsidian Eradicator
+                {
+                    m_caster->CastSpell(unitTarget, 25755, true);
+                    return;
+                }
                 case 26004:                                 // Mistletoe
                 {
                     if (!unitTarget)

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ayamiss.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ayamiss.cpp
@@ -33,7 +33,7 @@ enum
     SPELL_FRENZY                =  8269,
     SPELL_LASH                  =  25852,
 
-    EMOTE_FRENZY                =  -1000002,
+    EMOTE_FRENZY                =  10645,
 
     SPELL_FEED                  =  25721,
 

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ayamiss.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ayamiss.cpp
@@ -35,10 +35,9 @@ enum
 
     EMOTE_FRENZY                =  -1000002,
 
-    NPC_HIVEZARA_LARVA          =  15555,
-
     SPELL_FEED                  =  25721,
 
+    NPC_HIVEZARA_LARVA          =  15555,
     NPC_HIVEZARA_HORNET         =  15934,
     NPC_HIVEZARA_SWARMER        =  15546
 };
@@ -160,8 +159,6 @@ struct boss_ayamissAI : public ScriptedAI
             if (pCaster->GetTypeId() != TYPEID_PLAYER)
                 return;
 
-//                    DoTeleportPlayer(pCaster, -9717.2, 1517.81, 27.4683, pCaster->GetOrientation());
-
             m_uiSacrificeGuid = pCaster->GetObjectGuid();
             m_fSacrificeAggro = m_creature->GetThreatManager().getThreat(pCaster);
             m_creature->GetThreatManager().modifyThreatPercent(pCaster, -100);
@@ -195,7 +192,7 @@ struct boss_ayamissAI : public ScriptedAI
         else
             m_uiRelocate_Timer -= uiDiff;
 
-        if (!m_bIsInPhaseTwo && ((m_creature->GetHealth() * 100) / m_creature->GetMaxHealth()) < 70)
+        if (m_creature->GetHealthPercent() <= 70 && !m_bIsInPhaseTwo)
         {
             SetCombatMovement(true);
             m_creature->GetMotionMaster()->MoveChase(m_creature->GetVictim());
@@ -213,11 +210,13 @@ struct boss_ayamissAI : public ScriptedAI
             }
         }
 
-        if (!m_bIsEnraged && ((m_creature->GetHealth() * 100) / m_creature->GetMaxHealth()) < 20)
+        if (m_creature->GetHealthPercent() <= 20 && !m_bIsEnraged)
         {
-            DoCast(m_creature, SPELL_FRENZY);
-            DoScriptText(EMOTE_FRENZY, m_creature);
-            m_bIsEnraged = true;
+            if (DoCastSpellIfCan(m_creature, SPELL_FRENZY) == CAST_OK)
+            {
+                DoScriptText(EMOTE_FRENZY, m_creature);
+                m_bIsEnraged = true;
+            }
         }
 
         if (m_uiSummonSwarmer_Timer < uiDiff)

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_kurinnaxx.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_kurinnaxx.cpp
@@ -26,15 +26,15 @@ EndScriptData */
 
 enum
 {
+    EMOTE_FRENZY            = -1000002,
+
     GO_TRAP                 =   180647,
 
     SPELL_MORTALWOUND       =   25646,
-    SPELL_SUMMON_SANDTRAP   =   25648,
-    SPELL_SANDTRAP_EFFECT   =   25656,
+    SPELL_SUMMON_SANDTRAP   =   26524,
     SPELL_ENRAGE            =   26527,
     SPELL_WIDE_SLASH        =   25814,
     SPELL_TRASH             =   3391,
-    SPELL_INVOCATION        =   26446,
 
     SAY_BREACHED            =   11720
 };
@@ -49,7 +49,6 @@ struct boss_kurinnaxxAI : public ScriptedAI
 
     ScriptedInstance* m_pInstance;
 
-    uint32 m_uiInvocation_Timer;
     uint32 m_uiMortalWound_Timer;
     uint32 m_uiSandTrap_Timer;
     uint32 m_uiCleanSandTrap_Timer;
@@ -59,7 +58,6 @@ struct boss_kurinnaxxAI : public ScriptedAI
 
     void Reset() override
     {
-        m_uiInvocation_Timer = 10000;
         m_uiMortalWound_Timer = 7000;
         m_uiSandTrap_Timer = 7000;
         m_uiCleanSandTrap_Timer = 0;
@@ -87,15 +85,6 @@ struct boss_kurinnaxxAI : public ScriptedAI
         m_pInstance->SetData(TYPE_KURINNAXX, DONE);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32 &uiDamage) override
-    {
-        if (!m_bHasEnraged && ((m_creature->GetHealth() * 100) / m_creature->GetMaxHealth()) <= 30 && !m_creature->IsNonMeleeSpellCasted(false))
-        {
-            DoCast(m_creature->GetVictim(), SPELL_ENRAGE);
-            m_bHasEnraged = true;
-        }
-    }
-
     void UpdateAI(uint32 const uiDiff) override
     {
         // if no one gets to the trap in 5 seconds delete the trap
@@ -113,7 +102,17 @@ struct boss_kurinnaxxAI : public ScriptedAI
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
             return;
 
-        /* Moral wound */
+        /* Enrage */
+        if (m_creature->GetHealthPercent() <= 30 && !m_bHasEnraged)
+        {
+            if (DoCastSpellIfCan(m_creature, SPELL_ENRAGE) == CAST_OK)
+            {
+                DoScriptText(EMOTE_FRENZY, m_creature);
+                m_bHasEnraged = true;
+            }
+        }
+
+        /* Mortal wound */
         if (m_uiMortalWound_Timer < uiDiff)
         {
             if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_MORTALWOUND) == CAST_OK)
@@ -122,6 +121,7 @@ struct boss_kurinnaxxAI : public ScriptedAI
         else
             m_uiMortalWound_Timer -= uiDiff;
 
+        // TODO: Should use 26524 instead
         /* Summon trap */
         if (m_uiSandTrap_Timer < uiDiff)
         {
@@ -144,24 +144,6 @@ struct boss_kurinnaxxAI : public ScriptedAI
         }
         else
             m_uiWideSlash_Timer -= uiDiff;
-
-        /** Invoque player in front of him */
-        if (m_uiInvocation_Timer < uiDiff)
-        {
-            if (Unit* pUnit = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
-            {
-
-                float x, y, z;
-
-                m_creature->SendSpellGo(pUnit, 25681);
-                m_creature->GetRelativePositions(10.0f, 0.0f, 0.0f, x, y, z);
-                pUnit->NearLandTo(x, y, z+3.5f, pUnit->GetOrientation());
-                m_uiInvocation_Timer = urand(5000, 10000);
-            }
-        }
-        else
-            m_uiInvocation_Timer -= uiDiff;
-
 
         /* Trash */
         if (m_uiTrash_Timer < uiDiff)

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_kurinnaxx.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_kurinnaxx.cpp
@@ -26,7 +26,7 @@ EndScriptData */
 
 enum
 {
-    EMOTE_FRENZY            = -1000002,
+    EMOTE_FRENZY            = 10645,
 
     GO_TRAP                 =   180647,
 

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_rajaxx.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_rajaxx.cpp
@@ -81,19 +81,7 @@ enum
 #endif
 
 #define ANDOROV_WAYPOINT_MAX  7
-#define OOC_BETWEEN_WAVE 1000
-
-struct RespawnAndEvadeHelper
-{
-    explicit RespawnAndEvadeHelper(Creature* _pCreature) : pCreature(_pCreature) {}
-    void operator()() const
-    {
-        if (!pCreature->IsAlive())
-            pCreature->Respawn();
-        pCreature->AI()->EnterEvadeMode();
-    }
-    Creature* pCreature;
-};
+#define OOC_BETWEEN_WAVE 5000
 
 struct boss_rajaxxAI : public ScriptedAI
 {
@@ -143,7 +131,6 @@ struct boss_rajaxxAI : public ScriptedAI
         if (waveIndex >= WAVE_MAX)
             return;
 
-        DEBUG_EMOTE_YELL(m_creature, "DEBUG : Wave Reset");
         uint64 leaderGUID = GetLeaderGuidFromWaveIndex(waveIndex);
         if (Creature* pLeader = m_pInstance->GetCreature(leaderGUID))
             if (CreatureGroup* group = pLeader->GetCreatureGroup())
@@ -319,14 +306,13 @@ struct boss_rajaxxAI : public ScriptedAI
         {
             if (IsCurrentWaveDead())
                 m_uiNextWave_Timer += uiDiff;
-            else
-                m_uiNextWave_Timer = 0;
 
             if (m_uiNextWaveIndex < WAVE_MAX)
             {
-                if ((m_uiWave_Timer < uiDiff) || (m_uiNextWave_Timer > OOC_BETWEEN_WAVE))
+                if (m_uiWave_Timer < uiDiff || m_uiNextWave_Timer > OOC_BETWEEN_WAVE)
                 {
                     StartWave(m_uiNextWaveIndex);
+                    m_uiNextWave_Timer = 0;
                     m_uiNextWaveIndex++;
                     m_uiWave_Timer = DELAY_BETWEEN_WAVE;
                 }

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/instance_ruins_of_ahnqiraj.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/instance_ruins_of_ahnqiraj.cpp
@@ -391,11 +391,10 @@ void instance_ruins_of_ahnqiraj::SetData(uint32 uiType, uint32 uiData)
             else
                 m_uiGladiatorDeath = 0;
             return;
-            break;
         case TYPE_KURINNAXX:
             /** Spawn Andorov 3 minutes after Kurinaxx death */
             if (uiData == DONE)
-                SetAndorovSquadRespawnTime(6);//AQ_RESPAWN_3_MINUTES);
+                SetAndorovSquadRespawnTime(AQ_RESPAWN_3_MINUTES);
 
             m_auiEncounter[TYPE_KURINNAXX] = uiData;
             break;

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/instance_ruins_of_ahnqiraj.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/instance_ruins_of_ahnqiraj.cpp
@@ -24,20 +24,6 @@ EndScriptData */
 #include "scriptPCH.h"
 #include "ruins_of_ahnqiraj.h"
 
-enum
-{
-    WAVE1_LINK_ID = 112,
-    WAVE2_LINK_ID = 115,
-    WAVE3_LINK_ID = 117,
-    WAVE4_LINK_ID = 116,
-    WAVE5_LINK_ID = 118,
-    WAVE6_LINK_ID = 120,
-    WAVE7_LINK_ID = 119,
-
-    GO_ENTRANCE = 210347
-};
-
-
 instance_ruins_of_ahnqiraj::instance_ruins_of_ahnqiraj(Map* pMap) : ScriptedInstance(pMap)
 {
     Initialize();
@@ -342,7 +328,7 @@ void instance_ruins_of_ahnqiraj::OnCreatureDeath(Creature* pCreature)
                 pCreature->ForcedDespawn(3000);
                 pCreature->SetRespawnTime(AQ_RESPAWN_FOUR_DAYS);
             }
-            // Count deathes in Rajaxx's waves
+            // Count deaths in Rajaxx's waves
             if (GetWaveFromCreature(pCreature) > 0)
             {
                 uint8 waveIndex = GetWaveFromCreature(pCreature) - 1;
@@ -437,7 +423,7 @@ void instance_ruins_of_ahnqiraj::SetData(uint32 uiType, uint32 uiData)
                 if (m_auiEncounter[TYPE_KURINNAXX] == DONE)
                     SetAndorovSquadRespawnTime(AQ_RESPAWN_15_MINUTES);
 
-                /** Reset waves casualities count */
+                /** Reset waves casualties count */
                 for (uint32 & waveIndex : m_uiWaveMembersCount)
                     waveIndex = WAVE_MEMBERS_INIT_COUNT;
             }

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
@@ -30,7 +30,7 @@ enum
 };
 
 /* Ce type de data = le compte des mobs vivants dans chaque vague.
-    L'instance fait le décompte grace a OnCreatureDeath */
+    L'instance fait le dï¿½compte grace a OnCreatureDeath */
 #define WAVE_MAX 7
 #define WAVE_OFFSET 10
 #define WAVE_MEMBERS_INIT_COUNT 7
@@ -197,7 +197,7 @@ enum
 #else
 enum
 {
-    AQ_RESPAWN_3_MINUTES    = 60,
+    AQ_RESPAWN_3_MINUTES    = 180,
     AQ_RESPAWN_5_MINUTES    = 300,
     AQ_RESPAWN_15_MINUTES   = 900,
     AQ_RESPAWN_FOUR_DAYS    = 345600

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
@@ -29,8 +29,8 @@ enum
     TYPE_QIRAJI_GLADIATOR   = 8,
 };
 
-/* Ce type de data = le compte des mobs vivants dans chaque vague.
-    L'instance fait le d�compte grace a OnCreatureDeath */
+/* This type of data = the count of living mobs in each wave.
+     The instance counts down thanks to OnCreatureDeath  */
 #define WAVE_MAX 7
 #define WAVE_OFFSET 10
 #define WAVE_MEMBERS_INIT_COUNT 7

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
@@ -176,7 +176,10 @@ struct boss_skeramAI : public ScriptedAI
         // Prophet Skeram will only cast Arcane Explosion if a given number of players are in melee range
         // Initial value was 4+ but it was changed in patch 1.12 to be less dependant on raid
         // We assume value is number of players / 10 (raid of 40 people in Classic -> value of 4)
-        m_maxMeleeAllowed = m_pInstance->GetMap()->GetPlayersCountExceptGMs() / 10;
+        if (sWorld.GetWowPatch() == WOW_PATCH_112)
+            m_maxMeleeAllowed = m_pInstance->GetMap()->GetPlayersCountExceptGMs() / 10;
+        else
+            m_maxMeleeAllowed = 4;
     }
 
     void JustReachedHome() override

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
@@ -67,6 +67,7 @@ struct boss_skeramAI : public ScriptedAI
     }
 
     ScriptedInstance* m_pInstance;
+    uint32 m_maxMeleeAllowed;
 
     uint32 ArcaneExplosion_Timer;
     uint32 EarthShock_Timer;
@@ -83,7 +84,7 @@ struct boss_skeramAI : public ScriptedAI
     void Reset() override
     {
         ArcaneExplosion_Timer = urand(6000, 8000);
-        EarthShock_Timer = 1000;
+        EarthShock_Timer = 2000;
         FullFillment_Timer = urand(10000, 15000);
         Blink_Timer = urand(15000, 20000);
 
@@ -171,6 +172,11 @@ struct boss_skeramAI : public ScriptedAI
 
         if (m_pInstance)
             m_pInstance->SetData(TYPE_SKERAM, IN_PROGRESS);
+
+        // Prophet Skeram will only cast Arcane Explosion if a given number of players are in melee range
+        // Initial value was 4+ but it was changed in patch 1.12 to be less dependant on raid
+        // We assume value is number of players / 10 (raid of 40 people in Classic -> value of 4)
+        m_maxMeleeAllowed = m_pInstance->GetMap()->GetPlayersCountExceptGMs() / 10;
     }
 
     void JustReachedHome() override
@@ -200,15 +206,19 @@ struct boss_skeramAI : public ScriptedAI
             std::list<Player*> players;
             GetPlayersWithinRange(players, m_creature->GetMeleeReach());
 
-            if (players.size() > 4)
+            if (players.size() > m_maxMeleeAllowed)
             {
                 if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_ARCANE_EXPLOSION) == CAST_OK)
                     ArcaneExplosion_Timer = urand(6000, 14000);
             }
+            // Recheck in 1 second
+            else
+                ArcaneExplosion_Timer = 1000;
         }
-        else ArcaneExplosion_Timer -= diff;
+        else
+            ArcaneExplosion_Timer -= diff;
 
-        //If we are within range, melee the target
+        // If we are within range, melee the target
         if (m_creature->CanReachWithMeleeAutoAttack(m_creature->GetVictim()))
             DoMeleeAttackIfReady();
         else
@@ -217,7 +227,7 @@ struct boss_skeramAI : public ScriptedAI
             if (EarthShock_Timer < diff)
             {
                 if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_EARTH_SHOCK) == CAST_OK)
-                    EarthShock_Timer = 1000;
+                    EarthShock_Timer = 2000;
             }
             else
                 EarthShock_Timer -= diff;
@@ -272,19 +282,22 @@ struct boss_skeramAI : public ScriptedAI
         if (boss_skeramAI* imageAI = dynamic_cast<boss_skeramAI*>(skeramImage->AI()))
             imageAI->IsImage = true;
 
-        float skeramPercent = m_creature->GetHealthPercent()/100.0f;
+        float healthPct = m_creature->GetHealthPercent();
+        float maxHealthPct;
 
-        // Set health to look like the True Prophet. Will have 12.5%, 15% and 17.5% of max Skeram HP.
-        float percent = 0.2 * (1 - skeramPercent) + 0.1 * skeramPercent;
-        float maxHealth = m_creature->GetMaxHealth() * percent / skeramPercent;
+        // The max health depends on the split phase. It's percent * original boss health
+        if (healthPct < 25.0f)
+            maxHealthPct = 0.50f;
+        else if (healthPct < 50.0f)
+            maxHealthPct = 0.20f;
+        else
+            maxHealthPct = 0.10f;
 
-        skeramImage->SetMaxHealth(maxHealth);
-        skeramImage->SetHealthPercent(skeramPercent*100.0f);
+        // Set the same health percent as the original boss
+        skeramImage->SetMaxHealth(skeramImage->GetMaxHealth() * maxHealthPct);;
+        skeramImage->SetHealthPercent(healthPct);
         skeramImage->SetInCombatWithZone();
         skeramImage->SetVisibility(VISIBILITY_OFF);
-
-        // Set illusion mana to be the same as the real one
-        skeramImage->SetPower(POWER_MANA, m_creature->GetPower(POWER_MANA));
 
         if (!ImageA)
             ImageA = skeramImage;
@@ -348,6 +361,8 @@ struct boss_skeramAI : public ScriptedAI
         }
 
         DoResetThreat();
+        // Reset Earthshock timer on blink.
+        static_cast<boss_skeramAI*>(caster->AI())->EarthShock_Timer = 2000;
         caster->SetVisibility(VISIBILITY_ON);
     }
 

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
@@ -176,7 +176,7 @@ struct boss_skeramAI : public ScriptedAI
         // Prophet Skeram will only cast Arcane Explosion if a given number of players are in melee range
         // Initial value was 4+ but it was changed in patch 1.12 to be less dependant on raid
         // We assume value is number of players / 10 (raid of 40 people in Classic -> value of 4)
-        if (sWorld.GetWowPatch() == WOW_PATCH_112)
+        if (sWorld.GetWowPatch() >= WOW_PATCH_112)
             m_maxMeleeAllowed = m_pInstance->GetMap()->GetPlayersCountExceptGMs() / 10;
         else
             m_maxMeleeAllowed = 4;


### PR DESCRIPTION
## 🍰 Pullrequest
This PR improves some fight mechanics from both AQ20 and AQ40.

### Fixes
 - Proper Drain Mana behavior for AQ20 and AQ40 mobs.
 - Fixed Andorov spawn time.
 - Fixed an issue that was causing two waves of Rajaxx event to come at once.
 - Remove random player teleport mechanic from Kurinnax.
 - Kurinnaxx and Ayamiss will now perform the Enrage emote.
 - Skeram will now have the CD of Earth Shock reset on Blink + proper Arcane Explosion logic.
