### PR TITLE
Output mmap navmesh as wavefront 3d obj

### DIFF
--- a/contrib/mmap/readme
+++ b/contrib/mmap/readme
@@ -35,7 +35,7 @@ Generator command line args
 
                                     false: skip battlegrounds (default)
 
---debugOutput       [true|false]    create debugging files for use with RecastDemo
+--debugOutput       [true|false]    create debugging files for use with RecastDemo and Wavefront obj files of the navmesh
                                     if you are only creating mmaps for use with MaNGOS,
                                     you don't want debugging files
 
@@ -48,7 +48,9 @@ Generator command line args
 
                     [#]             Build only the map specified by #
                                     this command will build the map regardless of --skip* option settings
-                                    if you do not specify a map number, builds all maps that pass the filters specified by --skip* options
+
+                                    If you do not specify a map number, builds all maps that pass the filters specified by --skip* options
+                                    Maps that only consists of a wmo and no terrain will not be built unless specified with ID. Ex. Ragefire Chasm
 
 
 examples:

--- a/contrib/mmap/src/MapBuilder.h
+++ b/contrib/mmap/src/MapBuilder.h
@@ -82,6 +82,9 @@ namespace MMAP
             void buildGameObject(std::string modelName, uint32 displayId);
             void buildTransports();
 
+            bool duDumpPolyMeshToObj(rcPolyMesh& pmesh, uint32 mapID, uint32 tileY, uint32 tileX);
+            bool duDumpPolyMeshDetailToObj(rcPolyMeshDetail& dmesh, uint32 mapID, uint32 tileY, uint32 tileX);
+
         private:
             // detect maps and tiles
             void discoverTiles();


### PR DESCRIPTION
## 🍰 Pullrequest
Adds functionality to the movemap generator. Movemapgen can already output the vmap as 3D obj for debugging, this pr adds navmesh as a seperate output file.

Running movemapgen with "--debugOutput true" will output mmap navmesh and mmap detailed navmesh as wavefront obj files in the mesh folder.

wavefront obj files can be viewed in various 3d applications like Blender and Windows 3D viewer in windows 10.
The vertices in the output are in worldcoords.

### Proof
- None

### Issues
- None

### How2Test
movemapgen.exe 0 --tile 29,30 --debugOutput=true
Should ouput following files in \meshes\
![image](https://user-images.githubusercontent.com/2223066/108573537-2bb93e80-7315-11eb-9017-a91d823f89b9.png)
Contents of "map0003029navmesh.obj"
![image](https://user-images.githubusercontent.com/2223066/108573573-47bce000-7315-11eb-9d79-30ad9cd501a8.png)


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [-] I initially wanted to add colorings for various climbheights - but i scraped that part due to how wavefront has materials defined in a seperate file - and i felt it was counterintuitive. 
