### PR TITLE
vmap doodad update

### DIFF
--- a/contrib/vmap_extractor/vmapextract/adtfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/adtfile.cpp
@@ -58,7 +58,7 @@ void fixnamen(char* name, size_t len)
         }
     }
     //extension in lowercase
-    for (size_t i = len - 3; i < len; i++)
+    for (size_t i = len - 4; i < len; i++) //offset set to 4 wmoN - TODO: there is no wmo with more than 9 doodadsets, but if there where - we should improve this logic.
         name[i] |= 0x20;
 }
 

--- a/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
+++ b/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
@@ -56,6 +56,7 @@ void ExtractGameobjectModels()
 
     for (DBCFile::Iterator it = dbc.begin(); it != dbc.end(); ++it)
     {
+        bool isWmo = false;
         path = it->getString(1);
 
         if (path.length() < 4)
@@ -74,7 +75,8 @@ void ExtractGameobjectModels()
         bool result = false;
         if (!strcmp(ch_ext, ".wmo"))
         {
-            result = ExtractSingleWmo(path);
+            isWmo = true;
+            result = ExtractSingleWmo(path, 0);
         }
         else if (!strcmp(ch_ext, ".mdl"))
         {
@@ -92,8 +94,19 @@ void ExtractGameobjectModels()
             uint32 displayId = it->getUInt(0);
             uint32 path_length = strlen(name);
             fwrite(&displayId, sizeof(uint32), 1, model_list);
-            fwrite(&path_length, sizeof(uint32), 1, model_list);
-            fwrite(name, sizeof(char), path_length, model_list);
+            if (isWmo)
+            {
+                char tempname[512];
+                sprintf(tempname, "%s0", name);
+                path_length++;
+                fwrite(&path_length, sizeof(uint32), 1, model_list);
+                fwrite(tempname, sizeof(char), path_length, model_list);
+            }
+            else
+            {
+                fwrite(&path_length, sizeof(uint32), 1, model_list);
+                fwrite(name, sizeof(char), path_length, model_list);
+            }
         }
     }
 

--- a/contrib/vmap_extractor/vmapextract/vmapexport.h
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.h
@@ -56,7 +56,8 @@ extern const char* szRawVMAPMagic;                          // vmap magic string
 bool FileExists(const char* file);
 void strToLower(char* str);
 
-bool ExtractSingleWmo(std::string& fname);
+bool ExtractSingleWmoWithAllConfig(std::string& fname);     //iterates thru all config variants and extract ALL - even unused doodadset configurations 
+bool ExtractSingleWmo(std::string& fname, int DoodadConfig);//Extracts WMO with specified doodadset
 
 /* @param origPath = original path of the model, cleaned with fixnamen and fixname2
  * @param fixedName = will store the translated name (if changed)

--- a/contrib/vmap_extractor/vmapextract/wmo.h
+++ b/contrib/vmap_extractor/vmapextract/wmo.h
@@ -66,6 +66,13 @@ public:
     void init(std::string fname, MPQFile &f);
 };
 
+struct WMODoodadSet
+{
+    char name[0x14]; // set name
+    int start; // index of first doodad instance in this set
+    uint32 size; // number of doodad instances in this set
+    int unused; // unused? (always 0)
+};
 
 class WMORoot
 {
@@ -74,6 +81,8 @@ class WMORoot
         unsigned int col;
         float bbcorn1[3];
         float bbcorn2[3];
+
+        std::vector<WMODoodadSet> doodadsets;
 
         WMORoot(std::string& filename);
         ~WMORoot();
@@ -109,14 +118,6 @@ struct WMOLiquidVert
     float height;
 };
 
-struct WMODoodadSet
-{
-    char name[0x14]; // set name
-    int start; // index of first doodad instance in this set
-    uint32 size; // number of doodad instances in this set
-    int unused; // unused? (always 0)
-};
-
 class WMOGroup
 {
     public:
@@ -145,6 +146,7 @@ class WMOGroup
         char* LiquBytes;
         uint32 liquflags;
 
+        int doodadset; //used for converting a wmo model with a specific doodadset
         int nDoodads;
         short* doodads;
 
@@ -155,6 +157,8 @@ class WMOGroup
         int ConvertToVMAPGroupWmo(FILE* output, WMORoot* rootWMO, bool pPreciseVectorData);
         void WriteDoodadsTriangles(FILE* output, int indexShift);
         void WriteDoodadsVertices(FILE* output);
+        void WriteDoodadsTriangles(FILE* output, int indexShift, WMORoot* rootWMO);
+        void WriteDoodadsVertices(FILE* output, WMORoot* rootWMO);
     private:
         std::string filename;
         char outfilename;
@@ -172,7 +176,7 @@ class WMOInstance
         Vec3D pos;
         Vec3D pos2, pos3, rot;
         uint32 indx, id, d2, d3;
-        int doodadset;
+        int16 doodadset;
 
         WMOInstance(MPQFile& f, const char* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile);
 


### PR DESCRIPTION
## 🍰 Pullrequest
Updates the vmap extractor to generate accurate vmaps for buildings. This fixes many line of sight and pathing issues in buildings.

Example: The Prisonlonghouse.wmo that is used in durnholde keep and westfall inn has 4 different doodad configurations.
Currently the extractor generates one vmo of the wmo that includes all the doodad sets.
![image](https://user-images.githubusercontent.com/2223066/108581651-308aec00-732f-11eb-815c-51e5317a1e7e.png)
This causes issues with LOS and pathing.

This PR changes how vmos are generated. Multiple vmo objects are generated for each building.
![image](https://user-images.githubusercontent.com/2223066/108581776-e5bda400-732f-11eb-85ff-14cd87e0b7f7.png)

Example continued: The Prisonlonghouse.wmo used in westfall inn uses doodadset 1 - and will be generated as Prisonlonghouse.wmo1.vmo.
![image](https://user-images.githubusercontent.com/2223066/108581829-1b628d00-7330-11eb-9645-d87f6b3392d8.png)

Any reference to the new vmo's are written to the mmtiles - so no core changes are needed

### Proof
- None

### Issues
- None

### How2Test
- Extract maps and vmaps as usual.
- Use movemapgen with "--debugOutput true"
- Inspect navmesh and vmap file generated with a 3D viewer

### Todo / Checklist
- [-] Improvement: A better naming policy for the new vmo. Not something i intend using time on.
