### PR TITLE
[WIP] Added old levels for Duskwood bosses.

### DIFF
--- a/sql/migrations/20210222173358_world.sql
+++ b/sql/migrations/20210222173358_world.sql
@@ -1,0 +1,29 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210222173358');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210222173358');
+-- Add your query below.
+
+-- Morbent fel should be level 35 pre patch 1.6
+UPDATE `creature_template` SET `patch`='4' WHERE  `entry`=1200 AND `patch`=0;
+INSERT INTO `creature_template` VALUES (1200, 0, 4272, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 'Morbent Fel', '', 0, 35, 35, 3609, 3609, 3543, 3543, 694, 21, 0, 1, 1.14286, 20, 5, 0, 1, 1, 193, 249, 0, 128, 1, 2000, 2000, 8, 32832, 0, 0, 0, 0, 0, 0, 44.84, 61.655, 100, 7, 0, 1200, 1200, 0, 0, 0, 0, 0, 0, 0, 3108, 3109, 8909, 0, 12000, 0, NULL, 209, 277, 'EventAI', 1, 3, 0, 0, 3, 1200, 0, 0, 0, 0, 0, 'spell_dummy_npc');
+
+-- Stalvan Mistmantle should be level 35 pre patch 1.6
+UPDATE `creature_template` SET `patch`='4' WHERE  `entry`=315 AND `patch`=0;
+INSERT INTO `creature_template` VALUES (315, 0, 1562, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 'Stalvan Mistmantle', '', 0, 35, 35, 1585, 1585, 0, 0, 1270, 14, 0, 1, 1.14286, 20, 5, 0, 0, 1, 59, 72, 0, 128, 1, 1500, 2000, 1, 32768, 0, 0, 0, 0, 0, 0, 53.8384, 74.0278, 100, 6, 0, 315, 315, 0, 0, 0, 0, 0, 0, 0, 3105, 0, 0, 0, 3150, 0, NULL, 58, 81, 'EventAI', 0, 3, 0, 0, 3, 315, 0, 0, 8388624, 0, 0, '');
+
+-- Zzarc' Vul should be level 33 pre patch 1.6
+UPDATE `creature_template` SET `patch`='4' WHERE  `entry`=300 AND `patch`=0;
+INSERT INTO `creature_template` VALUES (300, 0, 655, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 'Zzarc\' Vul', '', 0, 33, 33, 1050, 1050, 0, 0, 1200, 45, 0, 1, 1.14286, 20, 5, 0, 0, 1, 43, 53, 0, 132, 1, 2000, 2000, 1, 0, 0, 0, 0, 0, 0, 0, 53.8384, 74.0278, 100, 7, 0, 300, 300, 0, 0, 0, 0, 0, 0, 0, 8716, 0, 0, 0, 3000, 0, NULL, 44, 62, '', 0, 3, 0, 0, 3, 300, 0, 0, 0, 0, 0, '');
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Updates level values for Duskwood bosses below patch 1.6.
### Proof
<!-- Link resources as proof -->
https://wow.gamepedia.com/Patch_1.6.0#World_Environment
> Morbent Fel's level was slightly reduced to better fit the level range of Duskwood.
https://web.archive.org/web/20041231112935/http://wow.allakhazam.com/db/mob.html?wmob=1200

The other two bosses aren't found in any patch note, however when looking at allakhazam their level seems to be have been changed at the same time as Morben Fel.

> Stalvan Mistmantle 
https://web.archive.org/web/20050413234203/http://wow.allakhazam.com/db/mob.html?wmob=315
> Zzarc' Vul
https://web.archive.org/web/20050106062657/http://wow.allakhazam.com/db/mob.html?wmob=300

There is also this old leveling guide, which confirms both Zzarc’Vul and Stalvan Mistmantle level values :
https://www.paullynch.org/wowblog/?p=18


- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Use a patch below 1.6 and go to the creature locations to see if level changed.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Update stats
