### PR TITLE
Make sure AFK status is removed BEFORE teleporting the player to the BG.

### DIFF
--- a/src/game/Battlegrounds/BattleGround.cpp
+++ b/src/game/Battlegrounds/BattleGround.cpp
@@ -959,10 +959,6 @@ void BattleGround::StartBattleGround()
 
 void BattleGround::AddPlayer(Player* pPlayer)
 {
-    // remove afk from player
-    if (pPlayer->IsAFK())
-        pPlayer->ToggleAFK();
-
     // score struct must be created in inherited class
 
     ObjectGuid guid = pPlayer->GetObjectGuid();

--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -1394,14 +1394,18 @@ void BattleGroundMgr::SendToBattleGround(Player* pl, uint32 instanceId, BattleGr
     if (bg)
     {
         uint32 mapid = bg->GetMapId();
-        float x, y, z, O;
+        float x, y, z, o;
         Team team = pl->GetBGTeam();
         if (team == 0)
             team = pl->GetTeam();
-        bg->GetTeamStartLoc(team, x, y, z, O);
+        bg->GetTeamStartLoc(team, x, y, z, o);
 
-        DETAIL_LOG("BATTLEGROUND: Sending %s to map %u, X %f, Y %f, Z %f, O %f", pl->GetName(), mapid, x, y, z, O);
-        pl->TeleportTo(mapid, x, y, z, O);
+        // Remove AFK from player before BG teleport
+        if (pl->IsAFK())
+            pl->ToggleAFK();
+
+        DETAIL_LOG("BATTLEGROUND: Sending %s to map %u, X %f, Y %f, Z %f, O %f", pl->GetName(), mapid, x, y, z, o);
+        pl->TeleportTo(mapid, x, y, z, o);
     }
     else
         sLog.outError("player %u trying to port to nonexistent bg instance %u", pl->GetGUIDLow(), instanceId);


### PR DESCRIPTION
## 🍰 Pullrequest
Since the AFK status was being removed after the teleport, on rare occasions it was causing the player to get kicked just after entering the Battleground. This change ensures the AFK status is removed before the teleport.
