### PR TITLE
Extractors - libmpq update

### DIFF
--- a/contrib/extractor/mpq_libmpq.cpp
+++ b/contrib/extractor/mpq_libmpq.cpp
@@ -69,7 +69,7 @@ MPQFile::MPQFile(const char* filename):
         uint32 filenum;
         if (libmpq__file_number(mpq_a, filename, &filenum)) continue;
         libmpq__off_t transferred;
-        libmpq__file_unpacked_size(mpq_a, filenum, &size);
+        libmpq__file_size_unpacked(mpq_a, filenum, &size);
 
         // HACK: in patch.mpq some files don't want to open and give 1 for filesize
         if (size <= 1)

--- a/contrib/extractor/mpq_libmpq.h
+++ b/contrib/extractor/mpq_libmpq.h
@@ -44,7 +44,7 @@ class MPQArchive
             uint32 filenum;
             if (libmpq__file_number(mpq_a, "(listfile)", &filenum)) return;
             libmpq__off_t size, transferred;
-            libmpq__file_unpacked_size(mpq_a, filenum, &size);
+            libmpq__file_size_unpacked(mpq_a, filenum, &size);
 
             char* buffer = new char[size];
 

--- a/contrib/vmap_extractor/vmapextract/mpq_libmpq.cpp
+++ b/contrib/vmap_extractor/vmapextract/mpq_libmpq.cpp
@@ -73,7 +73,7 @@ MPQFile::MPQFile(const char* filename):
         uint32 filenum;
         if (libmpq__file_number(mpq_a, filename, &filenum)) continue;
         libmpq__off_t transferred;
-        libmpq__file_unpacked_size(mpq_a, filenum, &size);
+        libmpq__file_size_unpacked(mpq_a, filenum, &size);
 
         // HACK: in patch.mpq some files don't want to open and give 1 for filesize
         if (size <= 1)

--- a/contrib/vmap_extractor/vmapextract/mpq_libmpq04.h
+++ b/contrib/vmap_extractor/vmapextract/mpq_libmpq04.h
@@ -44,7 +44,7 @@ class MPQArchive
             uint32 filenum;
             if (libmpq__file_number(mpq_a, "(listfile)", &filenum)) return;
             libmpq__off_t size, transferred;
-            libmpq__file_unpacked_size(mpq_a, filenum, &size);
+            libmpq__file_size_unpacked(mpq_a, filenum, &size);
 
             char* buffer = new char[size];
 

--- a/dep/libmpq/AUTHORS
+++ b/dep/libmpq/AUTHORS
@@ -1,10 +1,10 @@
 Project Initiator:
 
-    * Maik Broemme <mbroemme@plusserver.de>
+    * Maik Broemme <mbroemme@libmpq.org>
 
 Developers:
 
-    * Maik Broemme <mbroemme@plusserver.de>
+    * Maik Broemme <mbroemme@libmpq.org>
     * Tilman Sauerbeck <tilman@code-monkey.de>
     * Forrest Voight <voights@gmail.com>
     * Georg Lukas <georg@op-co.de>

--- a/dep/libmpq/FAQ
+++ b/dep/libmpq/FAQ
@@ -57,7 +57,7 @@ A: Of course :) The example below takes first parameter as mpq archive
            libmpq__archive_open(&mpq_archive, argv[1], -1);
 
            /* get size of first file (0) and malloc output buffer. */
-           libmpq__file_unpacked_size(mpq_archive, 0, &out_size);
+           libmpq__file_size_unpacked(mpq_archive, 0, &out_size);
            out_buf = malloc(out_size);
 
            /* read, decrypt and unpack file to output buffer. */

--- a/dep/libmpq/INSTALL
+++ b/dep/libmpq/INSTALL
@@ -1,0 +1,182 @@
+Basic Installation
+==================
+
+   These are generic installation instructions.
+
+   The `configure' shell script attempts to guess correct values for
+various system-dependent variables used during compilation.  It uses
+those values to create a `Makefile' in each directory of the package.
+It may also create one or more `.h' files containing system-dependent
+definitions.  Finally, it creates a shell script `config.status' that
+you can run in the future to recreate the current configuration, a file
+`config.cache' that saves the results of its tests to speed up
+reconfiguring, and a file `config.log' containing compiler output
+(useful mainly for debugging `configure').
+
+   If you need to do unusual things to compile the package, please try
+to figure out how `configure' could check whether to do them, and mail
+diffs or instructions to the address given in the `README' so they can
+be considered for the next release.  If at some point `config.cache'
+contains results you don't want to keep, you may remove or edit it.
+
+   The file `configure.in' is used to create `configure' by a program
+called `autoconf'.  You only need `configure.in' if you want to change
+it or regenerate `configure' using a newer version of `autoconf'.
+
+The simplest way to compile this package is:
+
+  1. `cd' to the directory containing the package's source code and type
+     `./configure' to configure the package for your system.  If you're
+     using `csh' on an old version of System V, you might need to type
+     `sh ./configure' instead to prevent `csh' from trying to execute
+     `configure' itself.
+
+     Running `configure' takes awhile.  While running, it prints some
+     messages telling which features it is checking for.
+
+  2. Type `make' to compile the package.
+
+  3. Optionally, type `make check' to run any self-tests that come with
+     the package.
+
+  4. Type `make install' to install the programs and any data files and
+     documentation.
+
+  5. You can remove the program binaries and object files from the
+     source code directory by typing `make clean'.  To also remove the
+     files that `configure' created (so you can compile the package for
+     a different kind of computer), type `make distclean'.  There is
+     also a `make maintainer-clean' target, but that is intended mainly
+     for the package's developers.  If you use it, you may have to get
+     all sorts of other programs in order to regenerate files that came
+     with the distribution.
+
+Compilers and Options
+=====================
+
+   Some systems require unusual options for compilation or linking that
+the `configure' script does not know about.  You can give `configure'
+initial values for variables by setting them in the environment.  Using
+a Bourne-compatible shell, you can do that on the command line like
+this:
+     CC=c89 CFLAGS=-O2 LIBS=-lposix ./configure
+
+Or on systems that have the `env' program, you can do it like this:
+     env CPPFLAGS=-I/usr/local/include LDFLAGS=-s ./configure
+
+Compiling For Multiple Architectures
+====================================
+
+   You can compile the package for more than one kind of computer at the
+same time, by placing the object files for each architecture in their
+own directory.  To do this, you must use a version of `make' that
+supports the `VPATH' variable, such as GNU `make'.  `cd' to the
+directory where you want the object files and executables to go and run
+the `configure' script.  `configure' automatically checks for the
+source code in the directory that `configure' is in and in `..'.
+
+   If you have to use a `make' that does not supports the `VPATH'
+variable, you have to compile the package for one architecture at a time
+in the source code directory.  After you have installed the package for
+one architecture, use `make distclean' before reconfiguring for another
+architecture.
+
+Installation Names
+==================
+
+   By default, `make install' will install the package's files in
+`/usr/local/bin', `/usr/local/man', etc.  You can specify an
+installation prefix other than `/usr/local' by giving `configure' the
+option `--prefix=PATH'.
+
+   You can specify separate installation prefixes for
+architecture-specific files and architecture-independent files.  If you
+give `configure' the option `--exec-prefix=PATH', the package will use
+PATH as the prefix for installing programs and libraries.
+Documentation and other data files will still use the regular prefix.
+
+   In addition, if you use an unusual directory layout you can give
+options like `--bindir=PATH' to specify different values for particular
+kinds of files.  Run `configure --help' for a list of the directories
+you can set and what kinds of files go in them.
+
+   If the package supports it, you can cause programs to be installed
+with an extra prefix or suffix on their names by giving `configure' the
+option `--program-prefix=PREFIX' or `--program-suffix=SUFFIX'.
+
+Optional Features
+=================
+
+   Some packages pay attention to `--enable-FEATURE' options to
+`configure', where FEATURE indicates an optional part of the package.
+They may also pay attention to `--with-PACKAGE' options, where PACKAGE
+is something like `gnu-as' or `x' (for the X Window System).  The
+`README' should mention any `--enable-' and `--with-' options that the
+package recognizes.
+
+   For packages that use the X Window System, `configure' can usually
+find the X include and library files automatically, but if it doesn't,
+you can use the `configure' options `--x-includes=DIR' and
+`--x-libraries=DIR' to specify their locations.
+
+Specifying the System Type
+==========================
+
+   There may be some features `configure' can not figure out
+automatically, but needs to determine by the type of host the package
+will run on.  Usually `configure' can figure that out, but if it prints
+a message saying it can not guess the host type, give it the
+`--host=TYPE' option.  TYPE can either be a short name for the system
+type, such as `sun4', or a canonical name with three fields:
+     CPU-COMPANY-SYSTEM
+
+See the file `config.sub' for the possible values of each field.  If
+`config.sub' isn't included in this package, then this package doesn't
+need to know the host type.
+
+   If you are building compiler tools for cross-compiling, you can also
+use the `--target=TYPE' option to select the type of system they will
+produce code for and the `--build=TYPE' option to select the type of
+system on which you are compiling the package.
+
+Sharing Defaults
+================
+
+   If you want to set default values for `configure' scripts to share,
+you can create a site shell script called `config.site' that gives
+default values for variables like `CC', `cache_file', and `prefix'.
+`configure' looks for `PREFIX/share/config.site' if it exists, then
+`PREFIX/etc/config.site' if it exists.  Or, you can set the
+`CONFIG_SITE' environment variable to the location of the site script.
+A warning: not all `configure' scripts look for a site script.
+
+Operation Controls
+==================
+
+   `configure' recognizes the following options to control how it
+operates.
+
+`--cache-file=FILE'
+     Use and save the results of the tests in FILE instead of
+     `./config.cache'.  Set FILE to `/dev/null' to disable caching, for
+     debugging `configure'.
+
+`--help'
+     Print a summary of the options to `configure', and exit.
+
+`--quiet'
+`--silent'
+`-q'
+     Do not print messages saying which checks are being made.  To
+     suppress all normal output, redirect it to `/dev/null' (any error
+     messages will still be shown).
+
+`--srcdir=DIR'
+     Look for the package's source code in directory DIR.  Usually
+     `configure' can determine that directory automatically.
+
+`--version'
+     Print the version of Autoconf used to generate the `configure'
+     script, and exit.
+
+`configure' also accepts some other, not widely useful, options.

--- a/dep/libmpq/README
+++ b/dep/libmpq/README
@@ -26,9 +26,9 @@ Reporting Bugs
 
 Bug reports for 'libmpq' can be send to me directly.
 
-    * Maik Broemme <mbroemme@plusserver.de>
+    * Maik Broemme <mbroemme@libmpq.org>
 
 Enjoy!
 
-Maik Broemme <mbroemme@plusserver.de>
-http://www.babelize.org/
+Maik Broemme <mbroemme@libmpq.org>
+http://libmpq.org/

--- a/dep/libmpq/THANKS
+++ b/dep/libmpq/THANKS
@@ -1,4 +1,4 @@
-'libmpq' was originaly created by Maik Broemme <mbroemme@plusserver.de>
+'libmpq' was originaly created by Maik Broemme <mbroemme@libmpq.org>
 and i want to thank some people which helped by supplying knowledge, code or
 something else.
 

--- a/dep/libmpq/bindings/d/mpq.d
+++ b/dep/libmpq/bindings/d/mpq.d
@@ -1,7 +1,7 @@
 /*
  *  mpq.d -- D programming language module for libmpq
  *
- *  Copyright (c) 2008 Georg Lukas <georg@op-co.de>
+ *  Copyright (c) 2008-2011 Georg Lukas <georg@op-co.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -58,15 +58,15 @@ char *libmpq__version();
 /* libmpq__generic mpq archive information. */
 int libmpq__archive_open(mpq_archive_s **mpq_archive, char *mpq_filename, off_t archive_offset);
 int libmpq__archive_close(mpq_archive_s *mpq_archive);
-int libmpq__archive_packed_size(mpq_archive_s *mpq_archive, off_t *packed_size);
-int libmpq__archive_unpacked_size(mpq_archive_s *mpq_archive, off_t *unpacked_size);
+int libmpq__archive_size_packed(mpq_archive_s *mpq_archive, off_t *packed_size);
+int libmpq__archive_size_unpacked(mpq_archive_s *mpq_archive, off_t *unpacked_size);
 int libmpq__archive_offset(mpq_archive_s *mpq_archive, off_t *offset);
 int libmpq__archive_version(mpq_archive_s *mpq_archive, uint *version_);
 int libmpq__archive_files(mpq_archive_s *mpq_archive, uint *files);
 
 /* libmpq__generic file processing functions. */
-int libmpq__file_packed_size(mpq_archive_s *mpq_archive, uint file_number, off_t *packed_size);
-int libmpq__file_unpacked_size(mpq_archive_s *mpq_archive, uint file_number, off_t *unpacked_size);
+int libmpq__file_size_packed(mpq_archive_s *mpq_archive, uint file_number, off_t *packed_size);
+int libmpq__file_size_unpacked(mpq_archive_s *mpq_archive, uint file_number, off_t *unpacked_size);
 int libmpq__file_offset(mpq_archive_s *mpq_archive, uint file_number, off_t *offset);
 int libmpq__file_blocks(mpq_archive_s *mpq_archive, uint file_number, uint *blocks);
 int libmpq__file_encrypted(mpq_archive_s *mpq_archive, uint file_number, uint *encrypted);
@@ -78,7 +78,7 @@ int libmpq__file_read(mpq_archive_s *mpq_archive, uint file_number, ubyte *out_b
 /* libmpq__generic block processing functions. */
 int libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint file_number);
 int libmpq__block_close_offset(mpq_archive_s *mpq_archive, uint file_number);
-int libmpq__block_unpacked_size(mpq_archive_s *mpq_archive, uint file_number, uint block_number, off_t *unpacked_size);
+int libmpq__block_size_unpacked(mpq_archive_s *mpq_archive, uint file_number, uint block_number, off_t *unpacked_size);
 int libmpq__block_read(mpq_archive_s *mpq_archive, uint file_number, uint block_number, ubyte *out_buf, off_t out_size, off_t *transferred);
 
 }

--- a/dep/libmpq/bindings/python/mpq.py
+++ b/dep/libmpq/bindings/python/mpq.py
@@ -50,14 +50,14 @@ libmpq.libmpq__version.restype = ctypes.c_char_p
 
 libmpq.libmpq__archive_open.errcheck = check_error
 libmpq.libmpq__archive_close.errcheck = check_error
-libmpq.libmpq__archive_packed_size.errcheck = check_error
-libmpq.libmpq__archive_unpacked_size.errcheck = check_error
+libmpq.libmpq__archive_size_packed.errcheck = check_error
+libmpq.libmpq__archive_size_unpacked.errcheck = check_error
 libmpq.libmpq__archive_offset.errcheck = check_error
 libmpq.libmpq__archive_version.errcheck = check_error
 libmpq.libmpq__archive_files.errcheck = check_error
 
-libmpq.libmpq__file_packed_size.errcheck = check_error
-libmpq.libmpq__file_unpacked_size.errcheck = check_error
+libmpq.libmpq__file_size_packed.errcheck = check_error
+libmpq.libmpq__file_size_unpacked.errcheck = check_error
 libmpq.libmpq__file_offset.errcheck = check_error
 libmpq.libmpq__file_blocks.errcheck = check_error
 libmpq.libmpq__file_encrypted.errcheck = check_error
@@ -68,7 +68,7 @@ libmpq.libmpq__file_read.errcheck = check_error
 
 libmpq.libmpq__block_open_offset.errcheck = check_error
 libmpq.libmpq__block_close_offset.errcheck = check_error
-libmpq.libmpq__block_unpacked_size.errcheck = check_error
+libmpq.libmpq__block_size_unpacked.errcheck = check_error
 libmpq.libmpq__block_read.errcheck = check_error
 
 __version__ = libmpq.libmpq__version()
@@ -112,7 +112,7 @@ class Reader(object):
     
     def _read_block(self, ctypes=ctypes, libmpq=libmpq):
         block_size = ctypes.c_uint64()
-        libmpq.libmpq__block_unpacked_size(self._file._archive._mpq,
+        libmpq.libmpq__block_size_unpacked(self._file._archive._mpq,
             self._file.number, self._cur_block, ctypes.byref(block_size))
         block_data = ctypes.create_string_buffer(block_size.value)
         libmpq.libmpq__block_read(self._file._archive._mpq,

--- a/dep/libmpq/configure.ac
+++ b/dep/libmpq/configure.ac
@@ -1,5 +1,6 @@
 # the autoconf initilization.
-AC_INIT(libmpq, 0.4.2, [mbroemme@plusserver.de], [libmpq])
+AC_INIT(libmpq, 0.4.2, [mbroemme@libmpq.org], [libmpq])
+AC_SUBST(LIBMPQ_ABI, [1:0:0])
 
 # detect the canonical host and target build environment.
 AC_CANONICAL_SYSTEM

--- a/dep/libmpq/debian/control
+++ b/dep/libmpq/debian/control
@@ -4,7 +4,7 @@ Maintainer: Georg Lukas <georg@op-co.de>
 Build-Depends: debhelper (>= 7), autotools-dev, libbz2-dev
 Standards-Version: 3.7.3
 Section: libs
-Homepage: https://libmpq.org/
+Homepage: http://libmpq.org/
 
 Package: libmpq-dev
 Section: libdevel

--- a/dep/libmpq/debian/copyright
+++ b/dep/libmpq/debian/copyright
@@ -1,15 +1,15 @@
 This package was debianized by Georg Lukas <georg@op-co.de> on
 Fri, 04 Jul 2008 18:17:08 +0200.
 
-It was downloaded from <https://libmpq.org/>
+It was downloaded from <http://libmpq.org/>
 
 Upstream Author:
 
-    Maik Broemme <mbroemme@plusserver.de>
+    Maik Broemme <mbroemme@libmpq.org>
 
 Copyright:
 
-    Copyright (C) 2008 Maik Broemme
+    Copyright (C) 2003-2011 Maik Broemme
 
 License:
 
@@ -19,5 +19,5 @@ License:
     (at your option) any later version.
 
 
-The Debian packaging is (C) 2008, Georg Lukas <georg@op-co.de> and
+The Debian packaging is (C) 2008-2011, Georg Lukas <georg@op-co.de> and
 is licensed under the GPL, see `/usr/share/common-licenses/GPL'.

--- a/dep/libmpq/debian/rules
+++ b/dep/libmpq/debian/rules
@@ -41,7 +41,7 @@ endif
 ifneq "$(wildcard /usr/share/misc/config.guess)" ""
 	cp -f /usr/share/misc/config.guess config.guess
 endif
-	./configure $(CROSS) --prefix=/usr --mandir=\$${prefix}/share/man --infodir=\$${prefix}/share/info CFLAGS="$(CFLAGS)" LDFLAGS="-Wl,-z,defs"
+	./configure $(CROSS) --prefix=/usr --mandir=\$${prefix}/share/man --infodir=\$${prefix}/share/info CFLAGS="$(CFLAGS) -ggdb" LDFLAGS="-Wl,-z,defs"
 
 
 build: build-stamp

--- a/dep/libmpq/doc/man1/libmpq-config.1
+++ b/dep/libmpq/doc/man1/libmpq-config.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 1 2008-02-10 "The MoPaQ archive library"
+.TH libmpq 1 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq-config \- script to get information about the installed version of libmpq.
 .SH SYNOPSIS
@@ -63,7 +63,7 @@ Instead of using this configuration script you should better use the pkg-config 
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/Makefile.am
+++ b/dep/libmpq/doc/man3/Makefile.am
@@ -11,20 +11,21 @@ man_MANS =				\
 	libmpq__archive_files.3		\
 	libmpq__archive_offset.3	\
 	libmpq__archive_open.3		\
-	libmpq__archive_packed_size.3	\
-	libmpq__archive_unpacked_size.3	\
+	libmpq__archive_size_packed.3	\
+	libmpq__archive_size_unpacked.3	\
 	libmpq__archive_version.3	\
 	libmpq__block_close_offset.3	\
 	libmpq__block_open_offset.3	\
 	libmpq__block_read.3		\
-	libmpq__block_unpacked_size.3	\
+	libmpq__block_size_unpacked.3	\
 	libmpq__file_blocks.3		\
 	libmpq__file_compressed.3	\
 	libmpq__file_encrypted.3	\
 	libmpq__file_imploded.3		\
 	libmpq__file_number.3		\
 	libmpq__file_offset.3		\
-	libmpq__file_packed_size.3	\
 	libmpq__file_read.3		\
-	libmpq__file_unpacked_size.3	\
+	libmpq__file_size_packed.3	\
+	libmpq__file_size_unpacked.3	\
+	libmpq__strerror.3		\
 	libmpq__version.3

--- a/dep/libmpq/doc/man3/libmpq.3
+++ b/dep/libmpq/doc/man3/libmpq.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-04-29 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -28,6 +28,8 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 #include <mpq.h>
 .sp
 .BI "const char *libmpq__version();"
+.sp
+.BI "const char *libmpq__strerror(int32_t returncode);"
 .sp
 .BI "int32_t libmpq__archive_open("
 .BI "        mpq_archive_s **" "mpq_archive",
@@ -39,12 +41,12 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .BI "        mpq_archive_s  *" "mpq_archive"
 .BI ");"
 .sp
-.BI "int32_t libmpq__archive_packed_size("
+.BI "int32_t libmpq__archive_size_packed("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        off_t          *" "packed_size"
 .BI ");"
 .sp
-.BI "int32_t libmpq__archive_unpacked_size("
+.BI "int32_t libmpq__archive_size_unpacked("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        off_t          *" "unpacked_size"
 .BI ");"
@@ -64,13 +66,13 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .BI "        uint32_t       *" "files"
 .BI ");"
 .sp
-.BI "int32_t libmpq__file_packed_size("
+.BI "int32_t libmpq__file_size_packed("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        uint32_t        " "file_number",
 .BI "        off_t          *" "packed_size"
 .BI ");"
 .sp
-.BI "int32_t libmpq__file_unpacked_size("
+.BI "int32_t libmpq__file_size_unpacked("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        uint32_t        " "file_number",
 .BI "        off_t          *" "unpacked_size"
@@ -130,14 +132,14 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .BI "        uint32_t        " "file_number"
 .BI ");"
 .sp
-.BI "int32_t libmpq__block_packed_size("
+.BI "int32_t libmpq__block_size_packed("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        uint32_t        " "file_number",
 .BI "        uint32_t        " "block_number",
 .BI "        off_t          *" "packed_size"
 .BI ");"
 .sp
-.BI "int32_t libmpq__block_unpacked_size("
+.BI "int32_t libmpq__block_size_unpacked("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        uint32_t        " "file_number",
 .BI "        uint32_t        " "block_number",
@@ -172,15 +174,16 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 The \fIlibmpq\fP library supports decrypting, decompressing, exploding and various manipulations of the MoPaQ archive files. It uses \fIzlib(3)\fP and \fIbzip2(1)\fP compression library. At this moment \fIlibmpq\fP is not able to create MoPaQ archives, this limitation will be removed in a future version.
 .SH SEE ALSO
 .BR libmpq__version (3),
+.BR libmpq__strerror (3),
 .BR libmpq__archive_open (3),
 .BR libmpq__archive_close (3),
-.BR libmpq__archive_packed_size (3),
-.BR libmpq__archive_unpacked_size (3),
+.BR libmpq__archive_size_packed (3),
+.BR libmpq__archive_size_unpacked (3),
 .BR libmpq__archive_offset (3),
 .BR libmpq__archive_version (3),
 .BR libmpq__archive_files (3),
-.BR libmpq__file_packed_size (3),
-.BR libmpq__file_unpacked_size (3),
+.BR libmpq__file_size_packed (3),
+.BR libmpq__file_size_unpacked (3),
 .BR libmpq__file_offset (3),
 .BR libmpq__file_blocks (3),
 .BR libmpq__file_encrypted (3),
@@ -190,15 +193,15 @@ The \fIlibmpq\fP library supports decrypting, decompressing, exploding and vario
 .BR libmpq__file_read (3),
 .BR libmpq__block_open_offset (3),
 .BR libmpq__block_close_offset (3),
-.BR libmpq__block_packed_size (3),
-.BR libmpq__block_unpacked_size (3),
+.BR libmpq__block_size_packed (3),
+.BR libmpq__block_size_unpacked (3),
 .BR libmpq__block_offset (3),
 .BR libmpq__block_seed (3),
 .BR libmpq__block_read (3)
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__archive_close.3
+++ b/dep/libmpq/doc/man3/libmpq__archive_close.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-04-29 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -43,15 +43,15 @@ On success, a zero is returned and on error one of the following constants.
 The given file could not be closed.
 .SH SEE ALSO
 .BR libmpq__archive_open (3),
-.BR libmpq__archive_packed_size (3),
-.BR libmpq__archive_unpacked_size (3),
+.BR libmpq__archive_size_packed (3),
+.BR libmpq__archive_size_unpacked (3),
 .BR libmpq__archive_offset (3),
 .BR libmpq__archive_version (3),
 .BR libmpq__archive_files (3)
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__archive_files.3
+++ b/dep/libmpq/doc/man3/libmpq__archive_files.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-14 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -44,7 +44,7 @@ On success, a zero is returned.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__archive_offset.3
+++ b/dep/libmpq/doc/man3/libmpq__archive_offset.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-14 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -45,7 +45,7 @@ On success, a zero is returned.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__archive_open.3
+++ b/dep/libmpq/doc/man3/libmpq__archive_open.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-04-29 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -57,15 +57,15 @@ The given file is no valid mpq archive.
 Reading in archive failed.
 .SH SEE ALSO
 .BR libmpq__archive_close (3),
-.BR libmpq__archive_packed_size (3),
-.BR libmpq__archive_unpacked_size (3),
+.BR libmpq__archive_size_packed (3),
+.BR libmpq__archive_size_unpacked (3),
 .BR libmpq__archive_offset (3),
 .BR libmpq__archive_version (3),
 .BR libmpq__archive_files (3)
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__archive_size_packed.3
+++ b/dep/libmpq/doc/man3/libmpq__archive_size_packed.3
@@ -27,24 +27,21 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .B
 #include <mpq.h>
 .sp
-.BI "int32_t libmpq__file_blocks("
+.BI "int32_t libmpq__archive_size_packed("
 .BI "        mpq_archive_s  *" "mpq_archive",
-.BI "        uint32_t        " "file_number",
-.BI "        uint32_t       *" "blocks"
+.BI "        off_t          *" "packed_size"
 .BI ");"
 .fi
 .SH DESCRIPTION
 .PP
-Call \fBlibmpq__file_blocks\fP() to get the number of blocks for a given file. It will count all blocks for files stored in multiple sectors or count one for files stored in single sector.
+Call \fBlibmpq__archive_size_packed\fP() to get the packed size of all files in the archive. It will count compressed and imploded files as well as stored only.
 .LP
-The \fBlibmpq__file_blocks\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the number of \fIblocks\fP of the file.
+The \fBlibmpq__archive_size_packed\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument is a reference to the compressed, imploded or stored size \fIpacked_size\fP of file.
 .SH RETURN VALUE
-On success, a zero is returned and on error one of the following constants.
-.TP 
-.B LIBMPQ_ERROR_EXIST
-File does not exist in archive.
+On success, a zero is returned.
 .SH SEE ALSO
-.BR libmpq__archive_files (3)
+.BR libmpq__file_size_packed (3),
+.BR libmpq__block_size_packed (3)
 .SH AUTHOR
 Check documentation.
 .TP

--- a/dep/libmpq/doc/man3/libmpq__archive_size_unpacked.3
+++ b/dep/libmpq/doc/man3/libmpq__archive_size_unpacked.3
@@ -27,24 +27,21 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .B
 #include <mpq.h>
 .sp
-.BI "int32_t libmpq__file_blocks("
+.BI "int32_t libmpq__archive_size_unpacked("
 .BI "        mpq_archive_s  *" "mpq_archive",
-.BI "        uint32_t        " "file_number",
-.BI "        uint32_t       *" "blocks"
+.BI "        off_t          *" "unpacked_size"
 .BI ");"
 .fi
 .SH DESCRIPTION
 .PP
-Call \fBlibmpq__file_blocks\fP() to get the number of blocks for a given file. It will count all blocks for files stored in multiple sectors or count one for files stored in single sector.
+Call \fBlibmpq__archive_size_unpacked\fP() to get the unpacked size of all files in the archive. It will count uncompressed and exploded files as well as stored only.
 .LP
-The \fBlibmpq__file_blocks\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the number of \fIblocks\fP of the file.
+The \fBlibmpq__archive_size_unpacked\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument is a reference to the uncompressed, exploded or stored size \fIunpacked_size\fP of file.
 .SH RETURN VALUE
-On success, a zero is returned and on error one of the following constants.
-.TP 
-.B LIBMPQ_ERROR_EXIST
-File does not exist in archive.
+On success, a zero is returned.
 .SH SEE ALSO
-.BR libmpq__archive_files (3)
+.BR libmpq__file_size_unpacked (3),
+.BR libmpq__block_size_unpacked (3)
 .SH AUTHOR
 Check documentation.
 .TP

--- a/dep/libmpq/doc/man3/libmpq__archive_version.3
+++ b/dep/libmpq/doc/man3/libmpq__archive_version.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-14 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -42,7 +42,7 @@ On success, a zero is returned.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__block_close_offset.3
+++ b/dep/libmpq/doc/man3/libmpq__block_close_offset.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -47,7 +47,7 @@ File or block does not exist in archive.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__block_open_offset.3
+++ b/dep/libmpq/doc/man3/libmpq__block_open_offset.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -59,7 +59,7 @@ Decrypting block failed.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__block_read.3
+++ b/dep/libmpq/doc/man3/libmpq__block_read.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -72,7 +72,7 @@ Unpacking block failed.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__block_size_unpacked.3
+++ b/dep/libmpq/doc/man3/libmpq__block_size_unpacked.3
@@ -27,24 +27,29 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .B
 #include <mpq.h>
 .sp
-.BI "int32_t libmpq__file_blocks("
+.BI "int32_t libmpq__block_size_unpacked("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        uint32_t        " "file_number",
-.BI "        uint32_t       *" "blocks"
+.BI "        uint32_t        " "block_number",
+.BI "        off_t          *" "unpacked_size"
 .BI ");"
 .fi
 .SH DESCRIPTION
 .PP
-Call \fBlibmpq__file_blocks\fP() to get the number of blocks for a given file. It will count all blocks for files stored in multiple sectors or count one for files stored in single sector.
+Call \fBlibmpq__block_size_unpacked\fP() to get the unpacked size of a given block in the file. It will return a valid size for compressed and imploded blocks as well as stored only.
 .LP
-The \fBlibmpq__file_blocks\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the number of \fIblocks\fP of the file.
+The \fBlibmpq__block_size_unpacked\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file, the third argument \fIblock_number\fP is the number of block and the fourth argument is a reference to the uncompressed, exploded or stored size \fIunpacked_size\fP of block.
 .SH RETURN VALUE
 On success, a zero is returned and on error one of the following constants.
-.TP 
+.TP
 .B LIBMPQ_ERROR_EXIST
-File does not exist in archive.
+File or block does not exist in archive.
+.TP
+.B LIBMPQ_ERROR_OPEN
+Block offset table was not opened by calling \fBlibmpq__block_open_offset\fP(), or it was closed by an \fBlibmpq__block_close_offset\fP() call.
 .SH SEE ALSO
-.BR libmpq__archive_files (3)
+.BR libmpq__archive_size_unpacked (3),
+.BR libmpq__file_size_unpacked (3)
 .SH AUTHOR
 Check documentation.
 .TP

--- a/dep/libmpq/doc/man3/libmpq__file_compressed.3
+++ b/dep/libmpq/doc/man3/libmpq__file_compressed.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -48,7 +48,7 @@ File does not exist in archive.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__file_encrypted.3
+++ b/dep/libmpq/doc/man3/libmpq__file_encrypted.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -48,7 +48,7 @@ File does not exist in archive.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__file_imploded.3
+++ b/dep/libmpq/doc/man3/libmpq__file_imploded.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -48,7 +48,7 @@ File does not exist in archive.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__file_number.3
+++ b/dep/libmpq/doc/man3/libmpq__file_number.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -46,7 +46,7 @@ File does not exist in archive.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__file_offset.3
+++ b/dep/libmpq/doc/man3/libmpq__file_offset.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-15 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -49,7 +49,7 @@ File does not exist in archive.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__file_read.3
+++ b/dep/libmpq/doc/man3/libmpq__file_read.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-05-16 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -71,7 +71,7 @@ Unpacking file failed.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/doc/man3/libmpq__file_size_packed.3
+++ b/dep/libmpq/doc/man3/libmpq__file_size_packed.3
@@ -27,24 +27,25 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .B
 #include <mpq.h>
 .sp
-.BI "int32_t libmpq__file_blocks("
+.BI "int32_t libmpq__file_size_packed("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        uint32_t        " "file_number",
-.BI "        uint32_t       *" "blocks"
+.BI "        off_t          *" "packed_size"
 .BI ");"
 .fi
 .SH DESCRIPTION
 .PP
-Call \fBlibmpq__file_blocks\fP() to get the number of blocks for a given file. It will count all blocks for files stored in multiple sectors or count one for files stored in single sector.
+Call \fBlibmpq__file_size_packed\fP() to get the packed size of a given file in the archive. It will return a valid size for compressed and imploded files as well as stored only.
 .LP
-The \fBlibmpq__file_blocks\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the number of \fIblocks\fP of the file.
+The \fBlibmpq__file_size_packed\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the compressed, imploded or stored size \fIpacked_size\fP of file.
 .SH RETURN VALUE
 On success, a zero is returned and on error one of the following constants.
-.TP 
+.TP
 .B LIBMPQ_ERROR_EXIST
 File does not exist in archive.
 .SH SEE ALSO
-.BR libmpq__archive_files (3)
+.BR libmpq__archive_size_packed (3),
+.BR libmpq__block_size_packed (3)
 .SH AUTHOR
 Check documentation.
 .TP

--- a/dep/libmpq/doc/man3/libmpq__file_size_unpacked.3
+++ b/dep/libmpq/doc/man3/libmpq__file_size_unpacked.3
@@ -27,24 +27,25 @@ libmpq \- cross-platform C library for manipulating mpq archives.
 .B
 #include <mpq.h>
 .sp
-.BI "int32_t libmpq__file_blocks("
+.BI "int32_t libmpq__file_size_unpacked("
 .BI "        mpq_archive_s  *" "mpq_archive",
 .BI "        uint32_t        " "file_number",
-.BI "        uint32_t       *" "blocks"
+.BI "        off_t          *" "unpacked_size"
 .BI ");"
 .fi
 .SH DESCRIPTION
 .PP
-Call \fBlibmpq__file_blocks\fP() to get the number of blocks for a given file. It will count all blocks for files stored in multiple sectors or count one for files stored in single sector.
+Call \fBlibmpq__file_size_unpacked\fP() to get the unpacked size of a given file in the archive. It will return a valid size for compressed and imploded files as well as stored only.
 .LP
-The \fBlibmpq__file_blocks\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the number of \fIblocks\fP of the file.
+The \fBlibmpq__file_size_unpacked\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the uncompressed, exploded or stored size \fIunpacked_size\fP of file.
 .SH RETURN VALUE
 On success, a zero is returned and on error one of the following constants.
-.TP 
+.TP
 .B LIBMPQ_ERROR_EXIST
 File does not exist in archive.
 .SH SEE ALSO
-.BR libmpq__archive_files (3)
+.BR libmpq__archive_size_unpacked (3),
+.BR libmpq__block_size_unpacked (3)
 .SH AUTHOR
 Check documentation.
 .TP

--- a/dep/libmpq/doc/man3/libmpq__strerror.3
+++ b/dep/libmpq/doc/man3/libmpq__strerror.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
+.\" Copyright (c) 2010-2011 Georg Lukas <georg@op-co.de>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -21,30 +21,21 @@
 .\" USA.
 .TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
-libmpq \- cross-platform C library for manipulating mpq archives.
+libmpq__strerror \- return string describing libmpq error number
 .SH SYNOPSIS
 .nf
 .B
 #include <mpq.h>
 .sp
-.BI "int32_t libmpq__file_blocks("
-.BI "        mpq_archive_s  *" "mpq_archive",
-.BI "        uint32_t        " "file_number",
-.BI "        uint32_t       *" "blocks"
-.BI ");"
+.BI "const char *libmpq__strerror(int32_t returncode);"
 .fi
 .SH DESCRIPTION
 .PP
-Call \fBlibmpq__file_blocks\fP() to get the number of blocks for a given file. It will count all blocks for files stored in multiple sectors or count one for files stored in single sector.
-.LP
-The \fBlibmpq__file_blocks\fP() function takes as first argument the archive structure \fImpq_archive\fP which have to be allocated first and opened by \fBlibmpq__archive_open\fP(). The second argument \fIfile_number\fP is the number of file and the third argument is a reference to the number of \fIblocks\fP of the file.
+Call \fBlibmpq__strerror\fP() to get a string message for the return code of one of the other libmpq functions.
 .SH RETURN VALUE
-On success, a zero is returned and on error one of the following constants.
-.TP 
-.B LIBMPQ_ERROR_EXIST
-File does not exist in archive.
+The function returns a string pointer to non-writable memory or NULL if \fBreturncode\fP is not a return code of a libmpq function.
 .SH SEE ALSO
-.BR libmpq__archive_files (3)
+.BR libmpq (3), strerror (3)
 .SH AUTHOR
 Check documentation.
 .TP

--- a/dep/libmpq/doc/man3/libmpq__version.3
+++ b/dep/libmpq/doc/man3/libmpq__version.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+.\" Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
 .\"
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
 .\" USA.
-.TH libmpq 3 2008-03-31 "The MoPaQ archive library"
+.TH libmpq 3 2011-11-06 "The MoPaQ archive library"
 .SH NAME
 libmpq \- cross-platform C library for manipulating mpq archives.
 .SH SYNOPSIS
@@ -39,7 +39,7 @@ The function returns the library version.
 .SH AUTHOR
 Check documentation.
 .TP
-libmpq is (c) 2003-2008
-.B Maik Broemme <mbroemme@plusserver.de>
+libmpq is (c) 2003-2011
+.B Maik Broemme <mbroemme@libmpq.org>
 .PP
 The above e-mail address can be used to send bug reports, feedbacks or library enhancements.

--- a/dep/libmpq/libmpq/Makefile.am
+++ b/dep/libmpq/libmpq/Makefile.am
@@ -12,7 +12,7 @@ libmpq_includedir		= $(includedir)/libmpq
 libmpq_include_HEADERS		= mpq.h
 
 libmpq_la_SOURCES		= $(GENERAL_SRCS)
-libmpq_la_LDFLAGS		= -release $(PACKAGE_VERSION)
+libmpq_la_LDFLAGS		= -version-info @LIBMPQ_ABI@
 
 GENERAL_SRCS =			\
 	common.c		\

--- a/dep/libmpq/libmpq/common.c
+++ b/dep/libmpq/libmpq/common.c
@@ -1,7 +1,7 @@
 /*
  *  common.c -- shared functions used by mpq-tools.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 
 /* generic includes. */
 #include <ctype.h>
-//#include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -101,7 +100,7 @@ int32_t libmpq__decrypt_block(uint32_t *in_buf, uint32_t in_size, uint32_t seed)
 }
 
 /* function to detect decryption key. */
-int32_t libmpq__decrypt_key(uint8_t *in_buf, uint32_t in_size, uint32_t block_size) {
+int32_t libmpq__decrypt_key(uint8_t *in_buf, uint32_t in_size, uint32_t block_size, uint32_t *key) {
 
 	/* some common variables. */
 	uint32_t saveseed1;
@@ -149,7 +148,8 @@ int32_t libmpq__decrypt_key(uint8_t *in_buf, uint32_t in_size, uint32_t block_si
 		if ((ch - ch2) <= block_size) {
 
 			/* file seed found, so return it. */
-			return saveseed1;
+			*key = saveseed1;
+			return LIBMPQ_SUCCESS;
 		}
 	}
 
@@ -175,7 +175,7 @@ int32_t libmpq__decompress_block(uint8_t *in_buf, uint32_t in_size, uint8_t *out
 
 	/* check if one compression mode is used. */
 	else if (compression_type == LIBMPQ_FLAG_COMPRESS_PKZIP ||
-	    compression_type == LIBMPQ_FLAG_COMPRESS_MULTI) {
+	         compression_type == LIBMPQ_FLAG_COMPRESS_MULTI) {
 
 		/* check if block is really compressed, some blocks have set the compression flag, but are not compressed. */
 		if (in_size < out_size) {

--- a/dep/libmpq/libmpq/common.h
+++ b/dep/libmpq/libmpq/common.h
@@ -1,7 +1,7 @@
 /*
  *  common.h -- header functions used by mpq-tools.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -45,7 +45,8 @@ int32_t libmpq__decrypt_block(
 int32_t libmpq__decrypt_key(
 	uint8_t		*in_buf,
 	uint32_t	in_size,
-	uint32_t	block_size
+	uint32_t	block_size,
+	uint32_t	*key
 );
 
 /* function to decompress or explode block from archive. */

--- a/dep/libmpq/libmpq/explode.c
+++ b/dep/libmpq/libmpq/explode.c
@@ -1,7 +1,7 @@
 /*
  *  explode.c -- explode function of pkware data compression library.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This source was adepted from the C++ version of pkware.cpp included
  *  in stormlib. The C++ version belongs to the following authors:

--- a/dep/libmpq/libmpq/explode.h
+++ b/dep/libmpq/libmpq/explode.h
@@ -2,7 +2,7 @@
  *  explode.h -- header file for pkware data decompression library
  *               used by mpq-tools.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This source was adepted from the C++ version of pklib.h included
  *  in stormlib. The C++ version belongs to the following authors:

--- a/dep/libmpq/libmpq/extract.c
+++ b/dep/libmpq/libmpq/extract.c
@@ -2,7 +2,7 @@
  *  extract.c -- global extracting function for all known file compressions
  *               in a mpq archive.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -52,16 +52,14 @@ int32_t libmpq__decompress_huffman(uint8_t *in_buf, uint32_t in_size, uint8_t *o
 	/* TODO: make typdefs of this structs? */
 	/* some common variables. */
 	int32_t tb     = 0;
-	struct huffman_tree_s *ht = NULL;
-	struct huffman_input_stream_s *is = NULL;
+	struct huffman_tree_s *ht;
+	struct huffman_input_stream_s *is;
 
 	/* allocate memory for the huffman tree. */
 	if ((ht = malloc(sizeof(struct huffman_tree_s))) == NULL ||
 	    (is = malloc(sizeof(struct huffman_input_stream_s))) == NULL) {
 
 		/* memory allocation problem. */
-        free(ht);
-        free(is);
 		return LIBMPQ_ERROR_MALLOC;
 	}
 

--- a/dep/libmpq/libmpq/extract.h
+++ b/dep/libmpq/libmpq/extract.h
@@ -1,7 +1,7 @@
 /*
  *  extract.h -- header for the extraction functions used by mpq-tools.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/dep/libmpq/libmpq/huffman.c
+++ b/dep/libmpq/libmpq/huffman.c
@@ -2,7 +2,7 @@
  *  huffman.c -- functions do decompress files in mpq files which
  *               uses a modified huffman version.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  Differences between C++ and C version:
  *
@@ -229,7 +229,7 @@ void libmpq__huffman_insert_item(struct huffman_tree_item_s **p_item, struct huf
 	struct huffman_tree_item_s *prev2;
 
 	/* pointer to next item. */
-	void* next2;
+	long next2;
 
 	/* check the first item already has next one. */
 	if (next != 0) {
@@ -284,7 +284,7 @@ void libmpq__huffman_insert_item(struct huffman_tree_item_s **p_item, struct huf
 			item->prev = item2->prev;
 
 			/* usually NULL. */
-			next2      = (void*)PTR_INT(p_item[0]);
+			next2      = PTR_INT(p_item[0]);
 
 			/* previous item to the second (or last tree item). */
 			prev2      = item2->prev;
@@ -307,11 +307,11 @@ void libmpq__huffman_insert_item(struct huffman_tree_item_s **p_item, struct huf
 			if (next2 < 0) {
 
 				/* set next item. */
-				next2 =  (void*)(item2 - item2->next->prev);
+				next2 = item2 - item2->next->prev;
 			}
 
 			/* add next item to previous one. */
-			prev2       += (unsigned long long)next2;
+			prev2       += next2;
 			prev2->next  = item;
 
 			/* set the next and last item. */

--- a/dep/libmpq/libmpq/huffman.h
+++ b/dep/libmpq/libmpq/huffman.h
@@ -1,7 +1,7 @@
 /*
  *  huffman.h -- structures used for huffman compression.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This source was adepted from the C++ version of huffman.h included
  *  in stormlib. The C++ version belongs to the following authors:
@@ -31,9 +31,9 @@
 #define LIBMPQ_HUFF_DECOMPRESS			0		/* we want to decompress using huffman trees. */
 
 /* define pointer conversions. */
-#define PTR_NOT(ptr)				(struct huffman_tree_item_s *)(~(unsigned long long)(ptr))
+#define PTR_NOT(ptr)				(struct huffman_tree_item_s *)(~(unsigned long)(ptr))
 #define PTR_PTR(ptr)				((struct huffman_tree_item_s *)(ptr))
-#define PTR_INT(ptr)				(long long)(ptr)
+#define PTR_INT(ptr)				(long)(ptr)
 
 /* define item handling. */
 #define INSERT_ITEM				1		/* insert item into huffman tree. */

--- a/dep/libmpq/libmpq/mpq-internal.h
+++ b/dep/libmpq/libmpq/mpq-internal.h
@@ -2,7 +2,7 @@
  *  mpq-internal.h -- some default types and defines, but only required for
  *                    compilation of the library.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@
 #define LIBMPQ_FLAG_COMPRESS_MULTI		0x00000200	/* multiple compressions. */
 #define LIBMPQ_FLAG_COMPRESS_NONE		0x00000300	/* no compression (no blizzard flag used by myself). */
 #define LIBMPQ_FLAG_SINGLE			0x01000000	/* file is stored in one single sector, first seen in world of warcraft. */
-#define LIBMPQ_FLAG_EXTRA			0x04000000	/* compressed block offset table has one extra entry. */
+#define LIBMPQ_FLAG_CRC				0x04000000	/* compressed block offset table has CRC checksum. */
 
 /* define generic hash values. */
 #define LIBMPQ_HASH_FREE			0xFFFFFFFF	/* hash table entry is empty and has always been empty. */

--- a/dep/libmpq/libmpq/mpq.c
+++ b/dep/libmpq/libmpq/mpq.c
@@ -1,7 +1,7 @@
 /*
  *  mpq.c -- functions for developers using libmpq.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -37,23 +37,49 @@
 /* support for platform specific things */
 #include "platform.h"
 
+/* static error constants. */
+static const char *__libmpq_error_strings[] = {
+	"success",
+	"open error on file",
+	"close error on file",
+	"lseek error on file",
+	"read error on file",
+	"write error on file",
+	"memory allocation error",
+	"format errror",
+	"init() wasn't called",
+	"buffer size is to small",
+	"file or block does not exist in archive",
+	"we don't know the decryption seed",
+	"error on unpacking file"
+};
+
 /* this function returns the library version information. */
 const char *libmpq__version(void) {
 
 	/* return version information. */
-    //Giperion Elysium: libmpq has several fixes, relative to x64 building
-	return "0.4.3_Elys";
+	return "4.3.4";
+}
+
+/* this function returns a string message for a return code. */
+const char *libmpq__strerror(int32_t return_code) {
+
+	/* check for array bounds */
+	if (-return_code < 0 || -return_code > sizeof(__libmpq_error_strings)/sizeof(char*))
+		return NULL;
+
+	/* return appropriate string */
+	return __libmpq_error_strings[-return_code];
 }
 
 /* this function read a file and verify if it is a valid mpq archive, then it read and decrypt the hash table. */
 int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filename, libmpq__off_t archive_offset) {
 
 	/* some common variables. */
-	uint32_t rb             = 0;
-	uint32_t i              = 0;
-	uint32_t count          = 0;
-	int32_t result          = 0;
-	uint32_t header_search	= FALSE;
+	uint32_t i             = 0;
+	uint32_t count         = 0;
+	int32_t result         = 0;
+	uint32_t header_search = FALSE;
 
 	if (archive_offset == -1) {
 		archive_offset = 0;
@@ -93,7 +119,7 @@ int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filena
 		}
 
 		/* read header from file. */
-		if ((rb = fread(&(*mpq_archive)->mpq_header, 1, sizeof(mpq_header_s), (*mpq_archive)->fp)) != sizeof(mpq_header_s)) {
+		if (fread(&(*mpq_archive)->mpq_header, 1, sizeof(mpq_header_s), (*mpq_archive)->fp) != sizeof(mpq_header_s)) {
 
 			/* no valid mpq archive. */
 			result = LIBMPQ_ERROR_FORMAT;
@@ -157,7 +183,7 @@ int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filena
 		}
 
 		/* read header from file. */
-		if ((rb = fread(&(*mpq_archive)->mpq_header_ex, 1, sizeof(mpq_header_ex_s), (*mpq_archive)->fp)) != sizeof(mpq_header_ex_s)) {
+		if (fread(&(*mpq_archive)->mpq_header_ex, 1, sizeof(mpq_header_ex_s), (*mpq_archive)->fp) != sizeof(mpq_header_ex_s)) {
 
 			/* no valid mpq archive. */
 			result = LIBMPQ_ERROR_FORMAT;
@@ -186,7 +212,7 @@ int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filena
 	}
 
 	/* read the hash table into the buffer. */
-	if ((rb = fread((*mpq_archive)->mpq_hash, 1, (*mpq_archive)->mpq_header.hash_table_count * sizeof(mpq_hash_s), (*mpq_archive)->fp)) < 0) {
+	if (fread((*mpq_archive)->mpq_hash, 1, (*mpq_archive)->mpq_header.hash_table_count * sizeof(mpq_hash_s), (*mpq_archive)->fp) != (*mpq_archive)->mpq_header.hash_table_count * sizeof(mpq_hash_s)) {
 
 		/* something on read failed. */
 		result = LIBMPQ_ERROR_READ;
@@ -205,7 +231,7 @@ int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filena
 	}
 
 	/* read the block table into the buffer. */
-	if ((rb = fread((*mpq_archive)->mpq_block, 1, (*mpq_archive)->mpq_header.block_table_count * sizeof(mpq_block_s), (*mpq_archive)->fp)) < 0) {
+	if (fread((*mpq_archive)->mpq_block, 1, (*mpq_archive)->mpq_header.block_table_count * sizeof(mpq_block_s), (*mpq_archive)->fp) != (*mpq_archive)->mpq_header.block_table_count * sizeof(mpq_block_s)) {
 
 		/* something on read failed. */
 		result = LIBMPQ_ERROR_READ;
@@ -227,7 +253,7 @@ int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filena
 		}
 
 		/* read header from file. */
-		if ((rb = fread((*mpq_archive)->mpq_block_ex, 1, (*mpq_archive)->mpq_header.block_table_count * sizeof(mpq_block_ex_s), (*mpq_archive)->fp)) < 0) {
+		if (fread((*mpq_archive)->mpq_block_ex, 1, (*mpq_archive)->mpq_header.block_table_count * sizeof(mpq_block_ex_s), (*mpq_archive)->fp) != (*mpq_archive)->mpq_header.block_table_count * sizeof(mpq_block_ex_s)) {
 
 			/* no valid mpq archive. */
 			result = LIBMPQ_ERROR_FORMAT;
@@ -302,7 +328,7 @@ int32_t libmpq__archive_close(mpq_archive_s *mpq_archive) {
 }
 
 /* this function return the packed size of all files in the archive. */
-int32_t libmpq__archive_packed_size(mpq_archive_s *mpq_archive, libmpq__off_t *packed_size) {
+int32_t libmpq__archive_size_packed(mpq_archive_s *mpq_archive, libmpq__off_t *packed_size) {
 
 	/* some common variables. */
 	uint32_t i;
@@ -317,7 +343,7 @@ int32_t libmpq__archive_packed_size(mpq_archive_s *mpq_archive, libmpq__off_t *p
 }
 
 /* this function return the unpacked size of all files in the archive. */
-int32_t libmpq__archive_unpacked_size(mpq_archive_s *mpq_archive, libmpq__off_t *unpacked_size) {
+int32_t libmpq__archive_size_unpacked(mpq_archive_s *mpq_archive, libmpq__off_t *unpacked_size) {
 
 	/* some common variables. */
 	uint32_t i;
@@ -361,15 +387,21 @@ int32_t libmpq__archive_files(mpq_archive_s *mpq_archive, uint32_t *files) {
 	return LIBMPQ_SUCCESS;
 }
 
+#define CHECK_FILE_NUM(file_number, mpq_archive) \
+	if (file_number < 0 || file_number > mpq_archive->files - 1) { \
+		return LIBMPQ_ERROR_EXIST; \
+	}
+
+#define CHECK_BLOCK_NUM(block_number, mpq_archive) \
+	if (block_number < 0 || block_number >= ((mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_SINGLE) != 0 ? 1 : (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].unpacked_size + mpq_archive->block_size - 1) / mpq_archive->block_size)) { \
+		return LIBMPQ_ERROR_EXIST; \
+	}
+
 /* this function return the packed size of the given files in the archive. */
-int32_t libmpq__file_packed_size(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *packed_size) {
+int32_t libmpq__file_size_packed(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *packed_size) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* get the packed size of file. */
 	*packed_size = mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].packed_size;
@@ -379,14 +411,10 @@ int32_t libmpq__file_packed_size(mpq_archive_s *mpq_archive, uint32_t file_numbe
 }
 
 /* this function return the unpacked size of the given file in the archive. */
-int32_t libmpq__file_unpacked_size(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *unpacked_size) {
+int32_t libmpq__file_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *unpacked_size) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* get the unpacked size of file. */
 	*unpacked_size = mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].unpacked_size;
@@ -399,11 +427,7 @@ int32_t libmpq__file_unpacked_size(mpq_archive_s *mpq_archive, uint32_t file_num
 int32_t libmpq__file_offset(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *offset) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* return file offset relative to archive start. */
 	*offset = mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].offset + (((long long)mpq_archive->mpq_block_ex[mpq_archive->mpq_map[file_number].block_table_indices].offset_high) << 32);
@@ -416,11 +440,7 @@ int32_t libmpq__file_offset(mpq_archive_s *mpq_archive, uint32_t file_number, li
 int32_t libmpq__file_blocks(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *blocks) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* return the number of blocks for the given file. */
 	*blocks = (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_SINGLE) != 0 ? 1 : (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].unpacked_size + mpq_archive->block_size - 1) / mpq_archive->block_size;
@@ -433,11 +453,7 @@ int32_t libmpq__file_blocks(mpq_archive_s *mpq_archive, uint32_t file_number, ui
 int32_t libmpq__file_encrypted(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *encrypted) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* return the encryption status of file. */
 	*encrypted = (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_ENCRYPTED) != 0 ? TRUE : FALSE;
@@ -450,11 +466,7 @@ int32_t libmpq__file_encrypted(mpq_archive_s *mpq_archive, uint32_t file_number,
 int32_t libmpq__file_compressed(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *compressed) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* return the compression status of file. */
 	*compressed = (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_COMPRESS_MULTI) != 0 ? TRUE : FALSE;
@@ -467,11 +479,7 @@ int32_t libmpq__file_compressed(mpq_archive_s *mpq_archive, uint32_t file_number
 int32_t libmpq__file_imploded(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *imploded) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* return the implosion status of file. */
 	*imploded = (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_COMPRESS_PKZIP) != 0 ? TRUE : FALSE;
@@ -527,22 +535,18 @@ int32_t libmpq__file_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint
 
 	/* some common variables. */
 	uint32_t i;
-	uint32_t blocks         = 0;
-	int32_t result          = 0;
+	uint32_t blocks                 = 0;
+	int32_t result                  = 0;
 	libmpq__off_t file_offset       = 0;
 	libmpq__off_t unpacked_size     = 0;
 	libmpq__off_t transferred_block = 0;
 	libmpq__off_t transferred_total = 0;
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* get target size of block. */
-	libmpq__file_unpacked_size(mpq_archive, file_number, &unpacked_size);
+	libmpq__file_size_unpacked(mpq_archive, file_number, &unpacked_size);
 
 	/* check if target buffer is to small. */
 	if (unpacked_size > out_size) {
@@ -571,7 +575,7 @@ int32_t libmpq__file_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint
 		unpacked_size = 0;
 
 		/* get unpacked block size. */
-		libmpq__block_unpacked_size(mpq_archive, file_number, i, &unpacked_size);
+		libmpq__block_size_unpacked(mpq_archive, file_number, i, &unpacked_size);
 
 		/* read block. */
 		if ((result = libmpq__block_read(mpq_archive, file_number, i, out_buf + transferred_total, unpacked_size, &transferred_block)) < 0) {
@@ -607,15 +611,10 @@ int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_numb
 	/* some common variables. */
 	uint32_t i;
 	uint32_t packed_size;
-	int32_t rb     = 0;
 	int32_t result = 0;
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	if (mpq_archive->mpq_file[file_number]) {
 
@@ -636,7 +635,7 @@ int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_numb
 	}
 
 	/* check if data has one extra entry. */
-	if ((mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_EXTRA) != 0) {
+	if ((mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_CRC) != 0) {
 
 		/* add one uint32_t. */
 		packed_size += sizeof(uint32_t);
@@ -674,15 +673,18 @@ int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_numb
 		}
 
 		/* read block positions from begin of file. */
-		if ((rb = fread(mpq_archive->mpq_file[file_number]->packed_offset, 1, packed_size, mpq_archive->fp)) < 0) {
+		if (fread(mpq_archive->mpq_file[file_number]->packed_offset, 1, packed_size, mpq_archive->fp) != packed_size) {
 
 			/* something on read from archive failed. */
 			result = LIBMPQ_ERROR_READ;
 			goto error;
 		}
 
-		/* check if the archive is protected some way, sometimes the file appears not to be encrypted, but it is. */
-		if (mpq_archive->mpq_file[file_number]->packed_offset[0] != rb) {
+		/* check if the archive is protected some way, sometimes the file appears not to be encrypted, but it is.
+		 * a special case are files with an additional sector but LIBMPQ_FLAG_CRC not set. we don't want to handle
+		 * them as encrypted. */
+		if (mpq_archive->mpq_file[file_number]->packed_offset[0] != packed_size &&
+		    mpq_archive->mpq_file[file_number]->packed_offset[0] != packed_size + 4) {
 
 			/* file is encrypted. */
 			mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags |= LIBMPQ_FLAG_ENCRYPTED;
@@ -692,7 +694,7 @@ int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_numb
 		if (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_ENCRYPTED) {
 
 			/* check if we don't know the file seed, try to find it. */
-			if ((mpq_archive->mpq_file[file_number]->seed = libmpq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size)) < 0) {
+			if (libmpq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size, &mpq_archive->mpq_file[file_number]->seed) < 0) {
 
 				/* sorry without seed, we cannot extract file. */
 				result = LIBMPQ_ERROR_DECRYPT;
@@ -759,11 +761,7 @@ error:
 int32_t libmpq__block_close_offset(mpq_archive_s *mpq_archive, uint32_t file_number) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	if (mpq_archive->mpq_file[file_number] == NULL) {
 
@@ -791,21 +789,13 @@ int32_t libmpq__block_close_offset(mpq_archive_s *mpq_archive, uint32_t file_num
 }
 
 /* this function return the unpacked size of the given file and block in the archive. */
-int32_t libmpq__block_unpacked_size(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size) {
+int32_t libmpq__block_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* check if given block number is not out of range. */
-	if (block_number < 0 || block_number >= ((mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_SINGLE) != 0 ? 1 : (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].unpacked_size + mpq_archive->block_size - 1) / mpq_archive->block_size)) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_BLOCK_NUM(block_number, mpq_archive)
 
 	/* check if packed block offset table is opened. */
 	if (mpq_archive->mpq_file[file_number] == NULL ||
@@ -845,18 +835,10 @@ int32_t libmpq__block_unpacked_size(mpq_archive_s *mpq_archive, uint32_t file_nu
 int32_t libmpq__block_seed(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, uint32_t *seed) {
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* check if given block number is not out of range. */
-	if (block_number < 0 || block_number >= ((mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_SINGLE) != 0 ? 1 : (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].unpacked_size + mpq_archive->block_size - 1) / mpq_archive->block_size)) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_BLOCK_NUM(block_number, mpq_archive)
 
 	/* check if packed block offset table is opened. */
 	if (mpq_archive->mpq_file[file_number] == NULL ||
@@ -878,28 +860,20 @@ int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uin
 
 	/* some common variables. */
 	uint8_t *in_buf;
-	uint32_t seed       = 0;
-	uint32_t encrypted  = 0;
-	uint32_t compressed = 0;
-	uint32_t imploded   = 0;
-	int32_t tb          = 0;
+	uint32_t seed               = 0;
+	uint32_t encrypted          = 0;
+	uint32_t compressed         = 0;
+	uint32_t imploded           = 0;
+	int32_t tb                  = 0;
 	libmpq__off_t block_offset  = 0;
-	off_t in_size       = 0;
+	libmpq__off_t in_size       = 0;
 	libmpq__off_t unpacked_size = 0;
 
 	/* check if given file number is not out of range. */
-	if (file_number < 0 || file_number > mpq_archive->files - 1) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_FILE_NUM(file_number, mpq_archive)
 
 	/* check if given block number is not out of range. */
-	if (block_number < 0 || block_number >= ((mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_SINGLE) != 0 ? 1 : (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].unpacked_size + mpq_archive->block_size - 1) / mpq_archive->block_size)) {
-
-		/* file number is out of range. */
-		return LIBMPQ_ERROR_EXIST;
-	}
+	CHECK_BLOCK_NUM(block_number, mpq_archive)
 
 	/* check if packed block offset table is opened. */
 	if (mpq_archive->mpq_file[file_number] == NULL ||
@@ -910,7 +884,7 @@ int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uin
 	}
 
 	/* get target size of block. */
-	libmpq__block_unpacked_size(mpq_archive, file_number, block_number, &unpacked_size);
+	libmpq__block_size_unpacked(mpq_archive, file_number, block_number, &unpacked_size);
 
 	/* check if target buffer is to small. */
 	if (unpacked_size > out_size) {
@@ -938,7 +912,7 @@ int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uin
 	}
 
 	/* read block from file. */
-	if (fread(in_buf, 1, in_size, mpq_archive->fp) < 0) {
+	if (fread(in_buf, 1, in_size, mpq_archive->fp) != in_size) {
 
 		/* free buffers. */
 		free(in_buf);
@@ -951,7 +925,7 @@ int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uin
 	libmpq__file_encrypted(mpq_archive, file_number, &encrypted);
 
 	/* check if file is encrypted. */
-	if (encrypted == 1) {
+	if (encrypted) {
 
 		/* get decryption key. */
 		libmpq__block_seed(mpq_archive, file_number, block_number, &seed);
@@ -971,7 +945,7 @@ int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uin
 	libmpq__file_compressed(mpq_archive, file_number, &compressed);
 
 	/* check if file is compressed. */
-	if (compressed == 1) {
+	if (compressed) {
 
 		/* decompress block. */
 		if ((tb = libmpq__decompress_block(in_buf, in_size, out_buf, out_size, LIBMPQ_FLAG_COMPRESS_MULTI)) < 0) {
@@ -988,7 +962,7 @@ int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uin
 	libmpq__file_imploded(mpq_archive, file_number, &imploded);
 
 	/* check if file is imploded. */
-	if (imploded == 1) {
+	if (imploded) {
 
 		/* explode block. */
 		if ((tb = libmpq__decompress_block(in_buf, in_size, out_buf, out_size, LIBMPQ_FLAG_COMPRESS_PKZIP)) < 0) {
@@ -1001,8 +975,17 @@ int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uin
 		}
 	}
 
+	/* files should not be compressed and imploded */
+	if (compressed && imploded) {
+		/* free temporary buffer. */
+		free(in_buf);
+
+		/* something on decompressing block failed. */
+		return LIBMPQ_ERROR_UNPACK;
+	}
+
 	/* check if file is neither compressed nor imploded. */
-	if (compressed == 0 && imploded == 0) {
+	if (!compressed && !imploded) {
 
 		/* copy block. */
 		if ((tb = libmpq__decompress_block(in_buf, in_size, out_buf, out_size, LIBMPQ_FLAG_COMPRESS_NONE)) < 0) {

--- a/dep/libmpq/libmpq/mpq.c
+++ b/dep/libmpq/libmpq/mpq.c
@@ -58,7 +58,7 @@ static const char *__libmpq_error_strings[] = {
 const char *libmpq__version(void) {
 
 	/* return version information. */
-	return "4.3.4";
+	return "0.4.2";
 }
 
 /* this function returns a string message for a return code. */

--- a/dep/libmpq/libmpq/mpq.h
+++ b/dep/libmpq/libmpq/mpq.h
@@ -1,7 +1,7 @@
 /*
  *  mpq.h -- some default types and defines.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  Some parts (the encryption and decryption stuff) were adapted from
  *  the C++ version of StormLib.h and StormPort.h included in stormlib.
@@ -65,18 +65,21 @@ typedef int64_t libmpq__off_t;
 /* generic information about library. */
 extern LIBMPQ_API const char *libmpq__version(void);
 
+/* string error message for a libmpq return code. */
+extern LIBMPQ_API const char *libmpq__strerror(int32_t return_code);
+
 /* generic mpq archive information. */
 extern LIBMPQ_API int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filename, libmpq__off_t archive_offset);
 extern LIBMPQ_API int32_t libmpq__archive_close(mpq_archive_s *mpq_archive);
-extern LIBMPQ_API int32_t libmpq__archive_packed_size(mpq_archive_s *mpq_archive, libmpq__off_t *packed_size);
-extern LIBMPQ_API int32_t libmpq__archive_unpacked_size(mpq_archive_s *mpq_archive, libmpq__off_t *unpacked_size);
+extern LIBMPQ_API int32_t libmpq__archive_size_packed(mpq_archive_s *mpq_archive, libmpq__off_t *packed_size);
+extern LIBMPQ_API int32_t libmpq__archive_size_unpacked(mpq_archive_s *mpq_archive, libmpq__off_t *unpacked_size);
 extern LIBMPQ_API int32_t libmpq__archive_offset(mpq_archive_s *mpq_archive, libmpq__off_t *offset);
 extern LIBMPQ_API int32_t libmpq__archive_version(mpq_archive_s *mpq_archive, uint32_t *version);
 extern LIBMPQ_API int32_t libmpq__archive_files(mpq_archive_s *mpq_archive, uint32_t *files);
 
 /* generic file processing functions. */
-extern LIBMPQ_API int32_t libmpq__file_packed_size(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *packed_size);
-extern LIBMPQ_API int32_t libmpq__file_unpacked_size(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *unpacked_size);
+extern LIBMPQ_API int32_t libmpq__file_size_packed(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *packed_size);
+extern LIBMPQ_API int32_t libmpq__file_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *unpacked_size);
 extern LIBMPQ_API int32_t libmpq__file_offset(mpq_archive_s *mpq_archive, uint32_t file_number, libmpq__off_t *offset);
 extern LIBMPQ_API int32_t libmpq__file_blocks(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *blocks);
 extern LIBMPQ_API int32_t libmpq__file_encrypted(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *encrypted);
@@ -88,7 +91,7 @@ extern LIBMPQ_API int32_t libmpq__file_read(mpq_archive_s *mpq_archive, uint32_t
 /* generic block processing functions. */
 extern LIBMPQ_API int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
 extern LIBMPQ_API int32_t libmpq__block_close_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
-extern LIBMPQ_API int32_t libmpq__block_unpacked_size(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size);
+extern LIBMPQ_API int32_t libmpq__block_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size);
 extern LIBMPQ_API int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
 
 #ifdef __cplusplus

--- a/dep/libmpq/libmpq/pack_begin.h
+++ b/dep/libmpq/libmpq/pack_begin.h
@@ -1,7 +1,7 @@
 /*
  *  pack_begin.h -- header file for struct packing used by libmpq.
  *
- *  Copyright (c) 2010 Georg Lukas <georg@op-co.de>
+ *  Copyright (c) 2010-2011 Georg Lukas <georg@op-co.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 #endif
 
 #ifdef _MSC_VER
-  #pragma warning(disable:4103)
   #pragma pack(push,1)
   #define PACK_STRUCT
 #else

--- a/dep/libmpq/libmpq/pack_end.h
+++ b/dep/libmpq/libmpq/pack_end.h
@@ -1,7 +1,7 @@
 /*
  *  pack_end.h -- header file for struct packing used by libmpq.
  *
- *  Copyright (c) 2010 Georg Lukas <georg@op-co.de>
+ *  Copyright (c) 2010-2011 Georg Lukas <georg@op-co.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 #endif
 
 #ifdef _MSC_VER
-    #pragma warning(disable:4103)
   #pragma pack(pop)
 #endif
 

--- a/dep/libmpq/libmpq/platform.h
+++ b/dep/libmpq/libmpq/platform.h
@@ -1,7 +1,7 @@
 /*
  *  platform.h -- header file for platform specific parts.
  *
- *  Copyright (c) 2010 Georg Lukas <georg@op-co.de>
+ *  Copyright (c) 2010-2011 Georg Lukas <georg@op-co.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 #ifndef _PLATFORM_H
 #define _PLATFORM_H
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   #define fseeko _fseeki64
 #endif
 

--- a/dep/libmpq/libmpq/wave.c
+++ b/dep/libmpq/libmpq/wave.c
@@ -2,7 +2,7 @@
  *  wave.c -- this file contains decompression methods used by mpq-tools
  *            to decompress wave files.
  *
- *  Copyright (c) 2003-2007 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This source was adepted from the C++ version of wave.cpp included
  *  in stormlib. The C++ version belongs to the following authors:
@@ -64,7 +64,7 @@ int32_t libmpq__do_decompress_wave(uint8_t *out_buf, int32_t out_length, uint8_t
 	uint32_t index;
 	int32_t nr_array1[2];
 	int32_t nr_array2[2];
-    int32_t count = 0;
+	int32_t count = 0;
 
 	/* end on input buffer. */
 	uint8_t *in_end = in_buf + in_length;

--- a/dep/libmpq/libmpq/wave.h
+++ b/dep/libmpq/libmpq/wave.h
@@ -1,7 +1,7 @@
 /*
  *  wave.h -- header file for wav unplode functions used by mpq-tools.
  *
- *  Copyright (c) 2003-2007 Maik Broemme <mbroemme@plusserver.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
  *
  *  This source was adepted from the C++ version of wave.h included
  *  in stormlib. The C++ version belongs to the following authors:

--- a/dep/libmpq/tools/crypt_buf_gen.c
+++ b/dep/libmpq/tools/crypt_buf_gen.c
@@ -1,8 +1,8 @@
 /*
  *  crypt_buf_gen.c -- tool to re-create the static decryption buffer.
  *
- *  Copyright (c) 2003-2008 Maik Broemme <mbroemme@plusserver.de>
- *  Copyright (c)      2008 Georg Lukas <georg@op-co.de>
+ *  Copyright (c) 2003-2011 Maik Broemme <mbroemme@libmpq.org>
+ *  Copyright (c) 2008-2011 Georg Lukas <georg@op-co.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## 🍰 Pullrequest
Updates libmpq.

This library is used in the mapextractor and vmap_extractor for extracting files stored in MPQs.

Previous version had a bug, that would prevent it from retrieving some files. This could result in extractors extracting an older version of the files.

Credits to Maik Broemme - https://github.com/mbroemme/libmpq

### Proof
Andorhal before and after the update.
![image](https://user-images.githubusercontent.com/2223066/109361570-76910400-7889-11eb-93d1-010f4f4a0ffd.png)

### Issues
- None

### How2Test
- See proof

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- None
