### PR TITLE
Fix memory leaks

### DIFF
--- a/src/game/Commands/CreatureCommands.cpp
+++ b/src/game/Commands/CreatureCommands.cpp
@@ -731,6 +731,7 @@ bool ChatHandler::HandleNpcAddCommand(char* args)
     {
         SendSysMessage(LANG_NO_FREE_STATIC_GUID_FOR_SPAWN);
         SetSentErrorMessage(true);
+        delete pCreature;
         return false;
     }
 

--- a/src/game/Commands/ObjectCommands.cpp
+++ b/src/game/Commands/ObjectCommands.cpp
@@ -399,6 +399,7 @@ bool ChatHandler::HandleGameObjectAddCommand(char* args)
     {
         SendSysMessage(LANG_NO_FREE_STATIC_GUID_FOR_SPAWN);
         SetSentErrorMessage(true);
+        delete pGameObj;
         return false;
     }
 

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2234,6 +2234,7 @@ BattleGroundMap::BattleGroundMap(uint32 id, time_t expiry, uint32 InstanceId)
 
 BattleGroundMap::~BattleGroundMap()
 {
+    UnloadAll(true);
 }
 
 void BattleGroundMap::Update(uint32 diff)

--- a/src/game/PacketBroadcast/PlayerBroadcaster.cpp
+++ b/src/game/PacketBroadcast/PlayerBroadcaster.cpp
@@ -95,7 +95,7 @@ void PlayerBroadcaster::QueuePacket(WorldPacket packet, bool self, ObjectGuid ex
     if (m_queue.size() >= MAX_QUEUE_SIZE)
     {
         BroadcastData& last_in_queue = m_queue[m_queue.size() - 1];
-        if (CanSkipPacket(last_in_queue.packet.GetOpcode()) && CanSkipPacket(packet.GetOpcode()))
+        if (CanSkipPacket(last_in_queue.packet.GetOpcode()) && CanSkipPacket(data.packet.GetOpcode()))
         {
             m_queue[m_queue.size() - 1] = std::move(data);
             guard.unlock();

--- a/src/game/vmap/VMapManager2.cpp
+++ b/src/game/vmap/VMapManager2.cpp
@@ -293,9 +293,10 @@ std::shared_ptr<WorldModel> VMapManager2::acquireModelInstance(std::string const
         //DEBUG_FILTER_LOG(LOG_FILTER_MAP_LOADING, "VMapManager2: loading file '%s%s'.", basepath.c_str(), filename.c_str());
         ret = std::shared_ptr<WorldModel>(
                     worldmodel,
-                    [this, filename](WorldModel*){
+                    [this, filename](WorldModel* m){
                         std::unique_lock<std::shared_timed_mutex> lock(m_modelsLock);
                         iLoadedModelFiles.erase(filename);
+                        delete m;
                     });
         model = iLoadedModelFiles.insert(std::pair<std::string, ManagedModel>(
                                              filename,


### PR DESCRIPTION
Fix an important memory leak in VMapManager2 and other smaller fixes detected by clang-tidy/clazy. This should fix #1098 