### PR TITLE
Vmapextractor Linux fix

### DIFF
--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -207,6 +207,8 @@ bool ExtractSingleWmoWithAllConfig(std::string& fname)
         //printf("Extracting wmo+doodadset %i\n", i);
         ExtractSingleWmo(fname, i);
     }
+
+    return true;
 }
 
 bool ExtractSingleWmo(std::string& fname, int DoodadConfig)


### PR DESCRIPTION
## 🍰 Pullrequest
I forgot a return value when i restructured the functions to handle doodads. Not returning a value is a undefined behaviour and is handled differently by compilers.

### Proof
- None

### Issues
- fixes https://github.com/vmangos/core/issues/1105

### How2Test

### Todo / Checklist

