### PR TITLE
Allow the usage of race specific languages even if crossfaction chat is enabled

### DIFF
--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -175,8 +175,7 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
             lang = LANG_UNIVERSAL;
         else
         {
-            // Send message in universal language if crossfaction chat is enabled and player is using default faction
-            // languages.
+            // Send message in universal language if crossfaction chat is enabled and player is using default faction languages.
             if (sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT) && (lang == LANG_COMMON || lang == LANG_ORCISH))
                 lang = LANG_UNIVERSAL;
             else

--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -177,7 +177,7 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
         {
             // Send message in universal language if crossfaction chat is enabled and player is using default faction
             // languages.
-            if (sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT) && lang == LANG_COMMON || lang == LANG_ORCISH)
+            if (sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT) && (lang == LANG_COMMON || lang == LANG_ORCISH))
                 lang = LANG_UNIVERSAL;
             else
             {

--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -175,8 +175,9 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
             lang = LANG_UNIVERSAL;
         else
         {
-            // send in universal language in two side iteration allowed mode
-            if (sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT))
+            // Send message in universal language if crossfaction chat is enabled and player is using default faction
+            // languages.
+            if (sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT) && lang == LANG_COMMON || lang == LANG_ORCISH)
                 lang = LANG_UNIVERSAL;
             else
             {


### PR DESCRIPTION
## 🍰 Pullrequest
With this change players will be able to use race specific languages even if crossfaction chat is enabled. Crossfaction chat will only have effect if they are using default faction languages (Common or Orcish).

