### PR TITLE
Vaelastraz shouldn't despawn after 1 hour in Patch 1.8 or greater.

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
@@ -206,8 +206,12 @@ struct boss_vaelAI : public ScriptedAI
         if (!m_bEngaged)
         {
             m_bEngaged = true;
-            m_creature->SetRespawnDelay(43200); // 12h 43200
-            m_creature->ForcedDespawn(3600000); // 1h 3600000
+            // From 1.8: There is no longer a one-hour time restriction on the Vaelastraz the Corrupt encounter in Blackwing Lair.
+            if (sWorld.GetWowPatch() < WOW_PATCH_110)
+            {
+                m_creature->SetRespawnDelay(43200); // 12h 43200
+                m_creature->ForcedDespawn(3600000); // 1h 3600000
+            }
         }
     }
 

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
@@ -207,7 +207,7 @@ struct boss_vaelAI : public ScriptedAI
         {
             m_bEngaged = true;
             // From 1.8: There is no longer a one-hour time restriction on the Vaelastraz the Corrupt encounter in Blackwing Lair.
-            if (sWorld.GetWowPatch() < WOW_PATCH_110)
+            if (sWorld.GetWowPatch() < WOW_PATCH_108)
             {
                 m_creature->SetRespawnDelay(43200); // 12h 43200
                 m_creature->ForcedDespawn(3600000); // 1h 3600000


### PR DESCRIPTION
## 🍰 Pullrequest
Vaelastraz shouldn't despawn after 1 hour in Patch 1.8 or greater.

### Proof
https://wow.gamepedia.com/Patch_1.8.0