### PR TITLE
Fix some quest issues in Duskwood.

### DIFF
--- a/sql/migrations/20210327011645_world.sql
+++ b/sql/migrations/20210327011645_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210327011645');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210327011645');
+-- Add your query below.
+
+-- Sirra Von'Indi shouldn't say anything on "Translation To Ello" start.
+-- https://www.youtube.com/watch?v=L5KffZOUbCQ
+DELETE FROM `quest_start_scripts` WHERE `id` = 252;
+UPDATE `quest_template` SET `StartScript` = 0 WHERE `entry` = 252;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/eastern_kingdoms/duskwood/duskwood.cpp
+++ b/src/scripts/eastern_kingdoms/duskwood/duskwood.cpp
@@ -720,14 +720,6 @@ CreatureAI* GetAI_ElloEbonlocke(Creature* pCreature)
     return new elloEbonlockeAI(pCreature);
 }
 
-bool GossipHello_npc_lord_ello_ebonlocke(Player* pPlayer, Creature* pCreature)
-{
-    /** Show quest menu */
-    pPlayer->PrepareQuestMenu(pCreature->GetGUID());
-    pPlayer->SEND_GOSSIP_MENU(pPlayer->GetGossipTextId(pCreature), pCreature->GetObjectGuid());
-    return true;
-}
-
 bool QuestRewarded_npc_lord_ello_ebonlocke(Player* pPlayer, Creature* pCreature, Quest const* pQuest)
 {
     if (pQuest->GetQuestId() == QUEST_TRANSLATION_TO_ELO)
@@ -767,7 +759,6 @@ void AddSC_duskwood()
     newscript->Name = "npc_lord_ello_ebonlocke";
     newscript->GetAI = &GetAI_ElloEbonlocke;
     newscript->pQuestRewardedNPC = &QuestRewarded_npc_lord_ello_ebonlocke;
-    newscript->pGossipHello = &GossipHello_npc_lord_ello_ebonlocke;
     newscript->RegisterSelf();
 
     newscript = new Script;


### PR DESCRIPTION
## 🍰 Pullrequest

- Sirra Von'Indi shouldn't say anything on "Translation To Ello" quest start. He was saying the same twice as the text is already said in "Wait for Sirra to Finish".
- Removed not needed `GossipHello` from Lord Ello Ebonlocke.
