### PR TITLE
Q3118 Encrypted Sigil - Use player's name in progress text

### DIFF
--- a/sql/migrations/20210403223408_world.sql
+++ b/sql/migrations/20210403223408_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210403223408');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210403223408');
+-- Add your query below.
+
+-- Replace static name "Ferlis" with player's name in progress text.
+UPDATE `quest_template`
+SET `RequestItemsText` = 'Hello, $N. I''m glad you found me. I was thinking that perhaps you got lost on the way here.$b$bNothing really new has happened in Shadowglen since I sent you my sigil, but I''ll leave all the information gathering to you. Speak to the rest of the people around Aldrassil if you''d like.'
+WHERE `entry` = 3118;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Uses the player's name in the quest's progress text instead of the hard-coded name "Ferlis".

### Proof
https://classic.wowhead.com/quest=3118/encrypted-sigil

### Issues
- None

### How2Test
1 Create a Night Elf Rogue
1 `.quest add 3118`
1 `.go creature frahun`
1 Talk to Frahun, click on quest.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
