### PR TITLE
Make Ouro follow content patch progression.

### DIFF
--- a/sql/migrations/20210404181907_world.sql
+++ b/sql/migrations/20210404181907_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210404181907');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210404181907');
+-- Add your query below.
+
+-- This hackfix was making Ouro's quake hit 2 times more than it should.
+DELETE FROM `spell_effect_mod` WHERE `Id` = 26093;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_cthun.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_cthun.cpp
@@ -44,6 +44,7 @@ enum eCreatures {
     PUNT_CREATURE                   = 15922, //invisible viscidus trigger, used in stomach
 };
 
+// C'Thun hotfixes: http://blue.cardplace.com/cache/wow-general/7950998.htm
 enum eSpells {
     // Phase 1 spells
     SPELL_FREEZE_ANIMATION          = 16245, // Dummy spell to avoid the eye gazing around during dark glare

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
@@ -73,11 +73,6 @@ enum
  */
 const uint32_t SANDBLAST_TIMER_INITIAL_MIN = 30000;
 const uint32_t SANDBLAST_TIMER_INITIAL_MAX = 45000;
-// Take nerfs into account http://blue.cardplace.com/cache/wow-dungeons/481724.htm for content patch progression
-// Note: Investigate if these timers are 100% accurate.
-const uint32_t SANDBLAST_TIMER_MIN         = sWorld.GetWowPatch() >= WOW_PATCH_110 ? 17000 : 12000;
-const uint32_t SANDBLAST_TIMER_MAX         = sWorld.GetWowPatch() >= WOW_PATCH_110 ? 22000 : 17000;
-const uint32_t SUBMERGE_TIMER              = sWorld.GetWowPatch() >= WOW_PATCH_110 ? 90000 : 60000;
 const uint32_t SUBMERGE_ANIMATION_INVIS    = 2000;
 const uint32_t SWEEP_TIMER                 = 15000;
 
@@ -107,11 +102,18 @@ struct boss_ouroAI : public Scripted_NoMovementAI
 
     WorldLocation m_StartingLoc;
 
+    // Take nerfs into account http://blue.cardplace.com/cache/wow-dungeons/481724.htm for content patch progression
+    // Note: Investigate if these timers are 100% accurate.
+    uint32_t SandBlastTimerMin() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 17000 : 12000; }
+    uint32_t SandBlastTimerMax() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 22000 : 17000; }
+    uint32_t SubmergeTimer() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 90000 : 60000; }
+
     void Reset() override
     {
+
         m_uiSweepTimer        = urand(30000, 40000);
         m_uiSandBlastTimer    = urand(SANDBLAST_TIMER_INITIAL_MIN, SANDBLAST_TIMER_INITIAL_MAX);
-        m_uiSubmergeTimer     = SUBMERGE_TIMER;
+        m_uiSubmergeTimer     = SubmergeTimer();
         m_SummonBase = true;
         m_uiSubmergeInvisTimer = SUBMERGE_ANIMATION_INVIS;
         
@@ -193,7 +195,7 @@ struct boss_ouroAI : public Scripted_NoMovementAI
         // "Ouro has a chance to submerge every 1.5minutes.
         // He will not submerge if he is busy casting a Sand Blast or Sweep, else he will submerge
         // (ie. the chance of submerging is totally random)"
-        m_uiSubmergeTimer = SUBMERGE_TIMER;
+        m_uiSubmergeTimer = SubmergeTimer();
 
         if (DoCastSpellIfCan(m_creature, SPELL_SUBMERGE_VISUAL, false) == CAST_OK)
         {
@@ -303,7 +305,7 @@ struct boss_ouroAI : public Scripted_NoMovementAI
 
                 if (target && DoCastSpellIfCan(target, SPELL_SANDBLAST) == CAST_OK)
                 {
-                    m_uiSandBlastTimer = urand(SANDBLAST_TIMER_MIN, SANDBLAST_TIMER_MAX);
+                    m_uiSandBlastTimer = urand(SandBlastTimerMin(), SandBlastTimerMax());
                 }
             }
             else
@@ -403,10 +405,10 @@ struct boss_ouroAI : public Scripted_NoMovementAI
 
                     m_bSubmerged        = false;
                     m_SummonBase = true;
-                    m_uiSubmergeTimer   = SUBMERGE_TIMER;
+                    m_uiSubmergeTimer   = SubmergeTimer();
                     m_uiSubmergeInvisTimer = SUBMERGE_ANIMATION_INVIS;
                     m_uiSweepTimer = SWEEP_TIMER;
-                    m_uiSandBlastTimer = urand(SANDBLAST_TIMER_MIN, SANDBLAST_TIMER_MAX);
+                    m_uiSandBlastTimer = urand(SandBlastTimerMin(), SandBlastTimerMax());
 
                     DespawnCreatures(false);
 

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
@@ -104,9 +104,9 @@ struct boss_ouroAI : public Scripted_NoMovementAI
 
     // Take nerfs into account http://blue.cardplace.com/cache/wow-dungeons/481724.htm for content patch progression
     // Note: Investigate if these timers are 100% accurate.
-    uint32_t SandBlastTimerMin() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 17000 : 12000; }
-    uint32_t SandBlastTimerMax() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 22000 : 17000; }
-    uint32_t SubmergeTimer() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 90000 : 60000; }
+    inline uint32_t SandBlastTimerMin() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 17000 : 12000; }
+    inline uint32_t SandBlastTimerMax() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 22000 : 17000; }
+    inline uint32_t SubmergeTimer() { return sWorld.GetWowPatch() >= WOW_PATCH_110 ? 90000 : 60000; }
 
     void Reset() override
     {

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
@@ -67,17 +67,17 @@ enum
 };
 
 /*
- * Sand Blast timers are based on June 2006 values (15-20s) as shown in
- * https://www.youtube.com/watch?v=REmX3uRTFkQ and further reduced to account
- * for April 2006 nerfs (http://blue.cardplace.com/cache/wow-dungeons/481724.htm &
- * http://blue.cardplace.com/cache/wow-general/7950998.htm
- * Sweep timers based on the same video. No known nerfs.
+ * Sand Blast timers are based on June 2006 values (17-22s) as shown in
+ * https://www.youtube.com/watch?v=REmX3uRTFkQ Sweep timers based on the
+ * same video. No known nerfs.
  */
 const uint32_t SANDBLAST_TIMER_INITIAL_MIN = 30000;
 const uint32_t SANDBLAST_TIMER_INITIAL_MAX = 45000;
-const uint32_t SANDBLAST_TIMER_MIN         = 12000;
-const uint32_t SANDBLAST_TIMER_MAX         = 17000;
-const uint32_t SUBMERGE_TIMER              = 90000;
+// Take nerfs into account http://blue.cardplace.com/cache/wow-dungeons/481724.htm for content patch progression
+// Note: Investigate if these timers are 100% accurate.
+const uint32_t SANDBLAST_TIMER_MIN         = sWorld.GetWowPatch() >= WOW_PATCH_110 ? 17000 : 12000;
+const uint32_t SANDBLAST_TIMER_MAX         = sWorld.GetWowPatch() >= WOW_PATCH_110 ? 22000 : 17000;
+const uint32_t SUBMERGE_TIMER              = sWorld.GetWowPatch() >= WOW_PATCH_110 ? 90000 : 60000;
 const uint32_t SUBMERGE_ANIMATION_INVIS    = 2000;
 const uint32_t SWEEP_TIMER                 = 15000;
 


### PR DESCRIPTION
## 🍰 Pullrequest
Take nerfs into account for Ouro fight. 

### Proof
http://blue.cardplace.com/cache/wow-dungeons/481724.htm
https://www.youtube.com/watch?v=O6eoVLFNWsk

### Issues
- Ouro was using a mix of pre-nerf and post-nerf timer values.
- Ouro's Sand Blast was hitting 2 times more than it should. (Quake spell changes are handled already on client progression, no need to have any hackfix).

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- Investigate if these values are 100% accurate, I think there is a bit of room for improvement. 
