### PR TITLE
Tabards shouldn't have any design by default.

### DIFF
--- a/src/game/Guild/Guild.cpp
+++ b/src/game/Guild/Guild.cpp
@@ -83,11 +83,11 @@ void MemberSlot::ChangeRank(uint32 newRank)
 Guild::Guild() : m_Name(), MOTD(), GINFO()
 {
     m_Id = 0;
-    m_EmblemStyle = 0;
-    m_EmblemColor = 0;
-    m_BorderStyle = 0;
-    m_BorderColor = 0;
-    m_BackgroundColor = 0;
+    m_EmblemStyle = -1;
+    m_EmblemColor = -1;
+    m_BorderStyle = -1;
+    m_BorderColor = -1;
+    m_BackgroundColor = -1;
     m_accountsNumber = 0;
 
     m_CreatedYear = 0;
@@ -164,7 +164,7 @@ bool Guild::Create(Player* leader, std::string gname)
     // CharacterDatabase.PExecute("DELETE FROM guild WHERE guildid='%u'", Id); - MAX(guildid)+1 not exist
     CharacterDatabase.PExecute("DELETE FROM `guild_member` WHERE `guildid`='%u'", m_Id);
     CharacterDatabase.PExecute("INSERT INTO `guild` (`guildid`, `name`, `leaderguid`, `info`, `motd`, `createdate`, `EmblemStyle`, `EmblemColor`, `BorderStyle`, `BorderColor`, `BackgroundColor`) "
-                               "VALUES('%u','%s','%u', '%s', '%s','" UI64FMTD "','%u','%u','%u','%u','%u')",
+                               "VALUES('%u','%s','%u', '%s', '%s','" UI64FMTD "','%i','%i','%i','%i','%i')",
                                m_Id, gname.c_str(), m_LeaderGuid.GetCounter(), dbGINFO.c_str(), dbMOTD.c_str(), uint64(now), m_EmblemStyle, m_EmblemColor, m_BorderStyle, m_BorderColor, m_BackgroundColor);
     CharacterDatabase.CommitTransaction();
 
@@ -302,11 +302,11 @@ bool Guild::LoadGuildFromDB(QueryResult* guildDataResult)
     m_Id              = fields[0].GetUInt32();
     m_Name            = fields[1].GetCppString();
     m_LeaderGuid      = ObjectGuid(HIGHGUID_PLAYER, fields[2].GetUInt32());
-    m_EmblemStyle     = fields[3].GetUInt32();
-    m_EmblemColor     = fields[4].GetUInt32();
-    m_BorderStyle     = fields[5].GetUInt32();
-    m_BorderColor     = fields[6].GetUInt32();
-    m_BackgroundColor = fields[7].GetUInt32();
+    m_EmblemStyle     = fields[3].GetInt32();
+    m_EmblemColor     = fields[4].GetInt32();
+    m_BorderStyle     = fields[5].GetInt32();
+    m_BorderColor     = fields[6].GetInt32();
+    m_BackgroundColor = fields[7].GetInt32();
     GINFO             = fields[8].GetCppString();
     MOTD              = fields[9].GetCppString();
     time_t time       = fields[10].GetUInt64();
@@ -847,17 +847,17 @@ void Guild::Query(WorldSession* session)
             data << uint8(0);                               // null string
     }
 
-    data << uint32(m_EmblemStyle);
-    data << uint32(m_EmblemColor);
-    data << uint32(m_BorderStyle);
-    data << uint32(m_BorderColor);
-    data << uint32(m_BackgroundColor);
+    data << int32(m_EmblemStyle);
+    data << int32(m_EmblemColor);
+    data << int32(m_BorderStyle);
+    data << int32(m_BorderColor);
+    data << int32(m_BackgroundColor);
 
     session->SendPacket(&data);
     DEBUG_LOG("WORLD: Sent (SMSG_GUILD_QUERY_RESPONSE)");
 }
 
-void Guild::SetEmblem(uint32 emblemStyle, uint32 emblemColor, uint32 borderStyle, uint32 borderColor, uint32 backgroundColor)
+void Guild::SetEmblem(int32 emblemStyle, int32 emblemColor, int32 borderStyle, int32 borderColor, int32 backgroundColor)
 {
     m_EmblemStyle = emblemStyle;
     m_EmblemColor = emblemColor;
@@ -865,7 +865,7 @@ void Guild::SetEmblem(uint32 emblemStyle, uint32 emblemColor, uint32 borderStyle
     m_BorderColor = borderColor;
     m_BackgroundColor = backgroundColor;
 
-    CharacterDatabase.PExecute("UPDATE `guild` SET `EmblemStyle`=%u, `EmblemColor`=%u, `BorderStyle`=%u, `BorderColor`=%u, `BackgroundColor`=%u WHERE `guildid` = %u", m_EmblemStyle, m_EmblemColor, m_BorderStyle, m_BorderColor, m_BackgroundColor, m_Id);
+    CharacterDatabase.PExecute("UPDATE `guild` SET `EmblemStyle`=%i, `EmblemColor`=%i, `BorderStyle`=%i, `BorderColor`=%i, `BackgroundColor`=%i WHERE `guildid` = %u", m_EmblemStyle, m_EmblemColor, m_BorderStyle, m_BorderColor, m_BackgroundColor, m_Id);
 }
 
 /**

--- a/src/game/Guild/Guild.h
+++ b/src/game/Guild/Guild.h
@@ -245,7 +245,7 @@ class Guild
 
         void SetMOTD(std::string motd);
         void SetGINFO(std::string ginfo);
-        void SetEmblem(int emblemStyle, int emblemColor, int borderStyle, int borderColor, int backgroundColor);
+        void SetEmblem(int32 emblemStyle, int32 emblemColor, int32 borderStyle, int32 borderColor, int32 backgroundColor);
 
         uint32 GetMemberSize() const { return members.size(); }
         uint32 GetAccountsNumber();

--- a/src/game/Guild/Guild.h
+++ b/src/game/Guild/Guild.h
@@ -231,11 +231,11 @@ class Guild
         uint32 GetCreatedMonth() const { return m_CreatedMonth; }
         uint32 GetCreatedDay() const { return m_CreatedDay; }
 
-        uint32 GetEmblemStyle() const { return m_EmblemStyle; }
-        uint32 GetEmblemColor() const { return m_EmblemColor; }
-        uint32 GetBorderStyle() const { return m_BorderStyle; }
-        uint32 GetBorderColor() const { return m_BorderColor; }
-        uint32 GetBackgroundColor() const { return m_BackgroundColor; }
+        int32 GetEmblemStyle() const { return m_EmblemStyle; }
+        int32 GetEmblemColor() const { return m_EmblemColor; }
+        int32 GetBorderStyle() const { return m_BorderStyle; }
+        int32 GetBorderColor() const { return m_BorderColor; }
+        int32 GetBackgroundColor() const { return m_BackgroundColor; }
 
         void SetLeader(ObjectGuid guid);
         GuildAddStatus AddMember(ObjectGuid plGuid, uint32 plRank);
@@ -245,7 +245,7 @@ class Guild
 
         void SetMOTD(std::string motd);
         void SetGINFO(std::string ginfo);
-        void SetEmblem(uint32 emblemStyle, uint32 emblemColor, uint32 borderStyle, uint32 borderColor, uint32 backgroundColor);
+        void SetEmblem(int emblemStyle, int emblemColor, int borderStyle, int borderColor, int backgroundColor);
 
         uint32 GetMemberSize() const { return members.size(); }
         uint32 GetAccountsNumber();
@@ -329,11 +329,11 @@ class Guild
         uint32 m_CreatedMonth;
         uint32 m_CreatedDay;
 
-        uint32 m_EmblemStyle;
-        uint32 m_EmblemColor;
-        uint32 m_BorderStyle;
-        uint32 m_BorderColor;
-        uint32 m_BackgroundColor;
+        int32 m_EmblemStyle;
+        int32 m_EmblemColor;
+        int32 m_BorderStyle;
+        int32 m_BorderColor;
+        int32 m_BackgroundColor;
         uint32 m_accountsNumber;                            // 0 used as marker for need lazy calculation at request
 
         RankList m_Ranks;

--- a/src/game/Handlers/GuildHandler.cpp
+++ b/src/game/Handlers/GuildHandler.cpp
@@ -722,7 +722,7 @@ void WorldSession::HandleSaveGuildEmblemOpcode(WorldPacket& recvPacket)
     DEBUG_LOG("WORLD: Received MSG_SAVE_GUILD_EMBLEM");
 
     ObjectGuid vendorGuid;
-    uint32 EmblemStyle, EmblemColor, BorderStyle, BorderColor, BackgroundColor;
+    int32 EmblemStyle, EmblemColor, BorderStyle, BorderColor, BackgroundColor;
 
     recvPacket >> vendorGuid;
     recvPacket >> EmblemStyle >> EmblemColor >> BorderStyle >> BorderColor >> BackgroundColor;


### PR DESCRIPTION
## 🍰 Pullrequest
At this moment tabard design values were being saved as 0 by default, but that matches a valid design. Saving them to -1 instead ensures that a newly formed guild doesn't have any tabard design by default.

### Proof
<!-- Link resources as proof -->
- None
![image](https://user-images.githubusercontent.com/8654362/114049771-03b57880-988c-11eb-9ed6-7bd84ef09f1c.png)
