### PR TITLE
Fix Blue Pearl drops

### DIFF
--- a/sql/migrations/20210415162937_world.sql
+++ b/sql/migrations/20210415162937_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210415162937');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210415162937');
+-- Add your query below.
+
+-- Shadowforge Commander shouldn't drop Blue Pearls
+DELETE FROM `creature_loot_template` WHERE `item` = 4611 AND `entry` = 2744;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20210415162937_world.sql
+++ b/sql/migrations/20210415162937_world.sql
@@ -9,7 +9,7 @@ INSERT INTO `migrations` VALUES ('20210415162937');
 -- Add your query below.
 
 -- Shadowforge Commander shouldn't drop Blue Pearls (it was obviously an error since the Giant Clam gameobject has the
--- same entry as this NPC.
+-- same entry as this NPC).
 DELETE FROM `creature_loot_template` WHERE `item` = 4611 AND `entry` = 2744;
 
 -- Fix loot template of Giant Clam gameobject

--- a/sql/migrations/20210415162937_world.sql
+++ b/sql/migrations/20210415162937_world.sql
@@ -8,8 +8,15 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20210415162937');
 -- Add your query below.
 
--- Shadowforge Commander shouldn't drop Blue Pearls
+-- Shadowforge Commander shouldn't drop Blue Pearls (it was obviously an error since the Giant Clam gameobject has the
+-- same entry as this NPC.
 DELETE FROM `creature_loot_template` WHERE `item` = 4611 AND `entry` = 2744;
+
+-- Fix loot template of Giant Clam gameobject
+-- https://www.youtube.com/watch?v=iujWLpMG2s4
+-- https://classic.wowhead.com/object=2744/giant-clam#contains
+UPDATE `gameobject_loot_template` SET `ChanceOrQuestChance` = 100, `groupid` = 1 WHERE `entry` = 2264 AND `item` = 4611;
+UPDATE `gameobject_loot_template` SET `ChanceOrQuestChance` = 35 WHERE `entry` = 2264 AND `item` = 4655;
 
 -- End of migration.
 END IF;


### PR DESCRIPTION
## 🍰 Pullrequest

- Shadowforge Commander shouldn't drop Blue Pearls (it was obviously an error since the Giant Clam gameobject has the same entry as this NPC.
- Fix loot template of Giant Clam gameobject.

### Proof

- https://www.youtube.com/watch?v=iujWLpMG2s4
- https://classic.wowhead.com/object=2744/giant-clam#contains

### Todo / Checklist
It might be worth checking if the Giant Clam spawns in Vile Reef are accurate.
