### PR TITLE
fix defence skill can increase by two points

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -8233,13 +8233,9 @@ void Unit::ProcSkillsAndReactives(bool isVictim, Unit* pTarget, uint32 procFlag,
         // Update skills here for players
         if (IsPlayer())
         {
-            // On melee based hit/miss/resist need update skill (for victim and attacker)
+            // On melee based hit/miss/resist/parry/dodge/block need update skill
             if (procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT | PROC_EX_MISS | PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK | PROC_EX_RESIST))
-                ((Player*)this)->UpdateCombatSkills(pTarget, attType, isVictim);
-
-            // Update defence if player is victim and parry/dodge/block
-            if (isVictim && procExtra & (PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK))
-                ((Player*)this)->UpdateCombatSkills(pTarget, attType, isVictim);
+                ((Player*)this)->UpdateCombatSkills(pTarget, attType, isVictim); // (isVictim -> defence, !isVictim -> weapon)
         }
         // If exist crit/parry/dodge/block need update aura state (for victim and attacker)
         if (procExtra & (PROC_EX_CRITICAL_HIT | PROC_EX_PARRY | PROC_EX_DODGE | PROC_EX_BLOCK))


### PR DESCRIPTION
## 🍰 Pullrequest
Since the first if statement for skill increase does not check for `isVictim`, the condition of the second if statement is already covered. This can lead to `UpdateCombatSkills ` getting called twice from one enemy attack.

### Proof
- None

### Issues
- None

### How2Test
- create new character
- .level 59
- get attacked by an enemy
- defence skill sometimes gets updated by two points if player parrys/dodges/blocks an attack

### Todo / Checklist
- [X] None
