### PR TITLE
Fix Mage's Wand quest chain.

### DIFF
--- a/sql/migrations/20210501140709_world.sql
+++ b/sql/migrations/20210501140709_world.sql
@@ -1,0 +1,26 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210501140709');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210501140709');
+-- Add your query below.
+
+
+-- Fix Mage's Wand quest chain.
+UPDATE `quest_template` SET `NextQuestId`=1949 where `entry`=1947;
+UPDATE `quest_template` SET `NextQuestId`=1948 where `entry`=1951;
+UPDATE `quest_template` SET `PrevQuestId`=1951 where `entry`=1948;
+UPDATE `quest_template` SET `PrevQuestId`=1948 where `entry`=1952;
+UPDATE `quest_template` SET `ExclusiveGroup`=0 where `entry`=1948;
+UPDATE `quest_template` SET `ExclusiveGroup`=0 where `entry`=1951;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Migration to fix Mage's Wand quest chain.

### Proof
- None

### Issues
- Quest chain is messed
- Last quest never unlock

### How2Test
- Do quest chain as mage lvl30+ (starting quest: Journey to the Marsh - entry 1947)

### Todo / Checklist
- [X] None
