### PR TITLE
Fix Plagued Warrior Cleave spell and make Crypt Guards susceptible to stuns

### DIFF
--- a/sql/migrations/20210504223527_world.sql
+++ b/sql/migrations/20210504223527_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210504223527');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210504223527');
+-- Add your query below.
+
+-- Make sure Plagued Warrior creatures use the proper Cleave spell.
+UPDATE `creature_spells` SET `spellId_1` = 15623 WHERE `entry` = 169840;
+-- Crypt Guards shouldn't be immune to Stuns.
+UPDATE `creature_template` SET `mechanic_immune_mask` = 1023391482 WHERE `entry` = 16573;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
- Make sure Plagued Warrior creatures use the proper Cleave spell.
- Crypt Guards shouldn't be immune to Stuns.

### Proof
Cleave spell from sniff:
```
(1608231426938, @CGUID+1783, 16984, 'Creature', @CGUID+1783, 16984, 'Creature', 15623, 245272, 0, 2, 1048576, 0, 0, @PGUID+33, 0, 'Player'),
(1608231426906, @CGUID+1782, 16984, 'Creature', @CGUID+1782, 16984, 'Creature', 15623, 245272, 0, 2, 1048576, 0, 0, @PGUID+23, 0, 'Player'),
```

Crypt Guard stunned:
https://www.youtube.com/watch?v=O8FBFRXqnMg&t=21s
