### PR TITLE
Jer'kai Moonweaver should only be a quest giver.

### DIFF
--- a/sql/migrations/20210505024627_world.sql
+++ b/sql/migrations/20210505024627_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20210505024627');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20210505024627');
+-- Add your query below.
+
+-- Jer'kai Moonweaver is only a quest giver.
+UPDATE `creature_template` SET `npc_flags` = 2 WHERE `entry` = 7957;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Jer'kai Moonweaver should only be a quest giver, not a quest giver + gossip.

### Proof
Confirmed by Classic sniff:
```
             entry: 7957
    gossip_menu_id: 0
         level_min: 36
         level_max: 36
           faction: 124
         npc_flags: 2
        speed_walk: 1
         speed_run: 1.14286
             scale: 1
  base_attack_time: 2000
ranged_attack_time: 0
        unit_flags: 512
       unit_flags2: 2048
        vehicle_id: 0
      hover_height: 1
             auras:
```
And video evidence: https://youtu.be/GV64q-i420o?t=207
