### PR TITLE
Add field names for SMSG_PETITION_QUERY_RESPONSE.

### DIFF
--- a/src/game/Handlers/PetitionsHandler.cpp
+++ b/src/game/Handlers/PetitionsHandler.cpp
@@ -215,24 +215,24 @@ void WorldSession::HandlePetitionQueryOpcode(WorldPacket& recv_data)
         return;
 
     WorldPacket data(SMSG_PETITION_QUERY_RESPONSE, (4 + 8 + petition->GetName().size() + 1 + 2 + 4 * 11));
-    data << uint32(petitionguid);                           // petition guid
-    data << ObjectGuid(petition->GetOwnerGuid());           // charter owner guid
-    data << petition->GetName();                            // name (guild/arena team)
-    data << uint8(0);                                       // CString
-    data << uint32(1);
-    data << uint32(9);
-    data << uint32(9);                                      // bypass client - side limitation, a different value is needed here for each petition
-    data << uint32(0);                                      // 5
-    data << uint32(0);                                      // 6
-    data << uint32(0);                                      // 7
-    data << uint32(0);                                      // 8
-    data << uint32(0);                                      // 9
-    data << uint16(0);                                      // 10 2 bytes field
-    data << uint32(0);                                      // 11
-    data << uint32(0);                                      // 12
-    data << uint32(0);                                      // 13 count of next strings; if 0, no data for strings, only 1 uint32 below
+    data << uint32(petitionguid);                           // int m_petitionID;
+    data << ObjectGuid(petition->GetOwnerGuid());           // unsigned __int64 m_petitioner;
+    data << petition->GetName();                            // char m_title[256];
+    data << uint8(0);                                       // char m_bodyText[4096];
+    data << uint32(1);                                      // int m_flags;
+    data << uint32(9);                                      // int m_minSignatures;
+    data << uint32(9);                                      // int m_maxSignatures;
+    data << uint32(0);                                      // int m_deadLine;
+    data << uint32(0);                                      // int m_issueDate;
+    data << uint32(0);                                      // int m_allowedGuildID;
+    data << uint32(0);                                      // int m_allowedClasses;
+    data << uint32(0);                                      // int m_allowedRaces;
+    data << uint16(0);                                      // __int16 m_allowedGender;
+    data << uint32(0);                                      // int m_allowedMinLevel;
+    data << uint32(0);                                      // int m_allowedMaxLevel;
+    data << uint32(0);                                      // char m_choicetext[10][64];
     // for (int i=0; i<field13; ++i) data << chartSignersName[i];   Probably, names of the petition signers
-    data << uint32(0);
+    data << uint32(0);                                      // int m_numChoices;
     SendPacket(&data);
 }
 


### PR DESCRIPTION
From 0.5.3 client:

```c
struct __cppobj __declspec(align(8)) CGPetition
{
  int m_petitionID;
  unsigned __int64 m_petitioner;
  char m_title[256];
  char m_bodyText[4096];
  int m_flags;
  int m_minSignatures;
  int m_maxSignatures;
  int m_deadLine;
  int m_issueDate;
  int m_allowedGuildID;
  int m_allowedClasses;
  int m_allowedRaces;
  __int16 m_allowedGender;
  int m_allowedMinLevel;
  int m_allowedMaxLevel;
  char m_choicetext[10][64];
  int m_numChoices;
  unsigned int m_muid;
};
```

```c
LABEL_9:
  obja->m_record.m_petitionID = item->m_petitionID;
  obja->m_record.m_petitioner = item->m_petitioner;
  SStrCopy(obja->m_record.m_title, item->m_title, 0x100u);
  SStrCopy(obja->m_record.m_bodyText, item->m_bodyText, 0x1000u);
  obja->m_record.m_flags = item->m_flags;
  obja->m_record.m_minSignatures = item->m_minSignatures;
  obja->m_record.m_maxSignatures = item->m_maxSignatures;
  obja->m_record.m_deadLine = item->m_deadLine;
  obja->m_record.m_issueDate = item->m_issueDate;
  obja->m_record.m_allowedGuildID = item->m_allowedGuildID;
  obja->m_record.m_allowedClasses = item->m_allowedClasses;
  obja->m_record.m_allowedRaces = item->m_allowedRaces;
  obja->m_record.m_allowedGender = item->m_allowedGender;
  obja->m_record.m_allowedMaxLevel = item->m_allowedMaxLevel;
  obja->m_record.m_allowedMinLevel = item->m_allowedMinLevel;
  v12 = (char *)((char *)item - (char *)&obja->m_record);
  obja->m_record.m_muid = item->m_muid;
  v13 = obja->m_record.m_choicetext[0];
  v16 = v12;
  itema = 10;
  while ( 1 )
  {
    SStrCopy(v13, &v12[(_DWORD)v13], 0x40u);
    v13 += 64;
    if ( !--itema )
      break;
    v12 = v16;
  }
  obja->m_record.m_numChoices = item->m_numChoices;
```