### PR TITLE
Remove bots if the original leader changed and it's not in party anymore.

### DIFF
--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -139,13 +139,37 @@ void PartyBotAI::LearnPremadeSpecForClass()
     }
 }
 
-Player* PartyBotAI::GetPartyLeader() const
+Player* PartyBotAI::GetPartyLeader()
 {
     Group* pGroup = me->GetGroup();
     if (!pGroup)
         return nullptr;
 
     ObjectGuid leaderGuid = pGroup->GetLeaderGuid();
+    // In case the current leader is not the same as the last leader.
+    if (leaderGuid != m_leaderGuid)
+    {
+        // Check if the last leader is still in the party.
+        bool lastLeaderFound = false;
+        for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            if (Player* pMember = itr->getSource())
+            {
+                // Last leader found in the party, update leader to the current one.
+                if (pMember->GetObjectGuid() == m_leaderGuid)
+                {
+                    m_leaderGuid = leaderGuid;
+                    lastLeaderFound = true;
+                }
+            }
+        }
+
+        // If the last leader is not in the party anymore, return null.
+        if (!lastLeaderFound)
+            return nullptr;
+    }
+
+    // In case the current leader is the bot itself and it's not inside a Battleground.
     if (leaderGuid == me->GetObjectGuid() && !me->InBattleGround())
         return nullptr;
 

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -150,7 +150,7 @@ Player* PartyBotAI::GetPartyLeader() const
     if (leaderGuid != m_leaderGuid)
     {
         // Check if the original leader is still in the party.
-        bool lastLeaderFound = false;
+        bool originalLeaderFound = false;
         for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
         {
             if (Player* pMember = itr->getSource())
@@ -158,14 +158,14 @@ Player* PartyBotAI::GetPartyLeader() const
                 // Original leader found in the party, bots can stay.
                 if (pMember->GetObjectGuid() == m_leaderGuid)
                 {
-                    lastLeaderFound = true;
+                    originalLeaderFound = true;
                     break;
                 }
             }
         }
 
         // If the original leader is not in the party anymore, return null.
-        if (!lastLeaderFound)
+        if (!originalLeaderFound)
             return nullptr;
     }
 

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -139,7 +139,7 @@ void PartyBotAI::LearnPremadeSpecForClass()
     }
 }
 
-Player* PartyBotAI::GetPartyLeader()
+Player* PartyBotAI::GetPartyLeader() const
 {
     Group* pGroup = me->GetGroup();
     if (!pGroup)

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -147,14 +147,17 @@ Player* PartyBotAI::GetPartyLeader() const
 
     if (Player* originalLeader = ObjectAccessor::FindPlayerNotInWorld(m_leaderGuid))
     {
-        // In case the original spawner is not in the same group as the bots anymore.
-        if (pGroup != originalLeader->GetGroup())
-            return nullptr;
+        if (me->InBattleGround() == originalLeader->InBattleGround())
+        {
+            // In case the original spawner is not in the same group as the bots anymore.
+            if (pGroup != originalLeader->GetGroup())
+                return nullptr;
 
-        // In case the current leader is the bot itself and it's not inside a Battleground.
-        ObjectGuid currentLeaderGuid = pGroup->GetLeaderGuid();
-        if (currentLeaderGuid == me->GetObjectGuid() && !me->InBattleGround())
-            return nullptr;
+            // In case the current leader is the bot itself and it's not inside a Battleground.
+            ObjectGuid currentLeaderGuid = pGroup->GetLeaderGuid();
+            if (currentLeaderGuid == me->GetObjectGuid() && !me->InBattleGround())
+                return nullptr;
+        }
 
         return originalLeader;
     }

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -146,7 +146,7 @@ Player* PartyBotAI::GetPartyLeader() const
         return nullptr;
 
     ObjectGuid leaderGuid = pGroup->GetLeaderGuid();
-    // In case the original leader is not the same as the last leader.
+    // In case the original leader is not the same as the current leader.
     if (leaderGuid != m_leaderGuid)
     {
         // Check if the original leader is still in the party.
@@ -155,7 +155,7 @@ Player* PartyBotAI::GetPartyLeader() const
         {
             if (Player* pMember = itr->getSource())
             {
-                // Original leader found in the party, update leader to the current one.
+                // Original leader found in the party, bots can stay.
                 if (pMember->GetObjectGuid() == m_leaderGuid)
                 {
                     lastLeaderFound = true;

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -146,26 +146,25 @@ Player* PartyBotAI::GetPartyLeader()
         return nullptr;
 
     ObjectGuid leaderGuid = pGroup->GetLeaderGuid();
-    // In case the current leader is not the same as the last leader.
+    // In case the original leader is not the same as the last leader.
     if (leaderGuid != m_leaderGuid)
     {
-        // Check if the last leader is still in the party.
+        // Check if the original leader is still in the party.
         bool lastLeaderFound = false;
         for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
         {
             if (Player* pMember = itr->getSource())
             {
-                // Last leader found in the party, update leader to the current one.
+                // Original leader found in the party, update leader to the current one.
                 if (pMember->GetObjectGuid() == m_leaderGuid)
                 {
-                    m_leaderGuid = leaderGuid;
                     lastLeaderFound = true;
                     break;
                 }
             }
         }
 
-        // If the last leader is not in the party anymore, return null.
+        // If the original leader is not in the party anymore, return null.
         if (!lastLeaderFound)
             return nullptr;
     }

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -160,6 +160,7 @@ Player* PartyBotAI::GetPartyLeader()
                 {
                     m_leaderGuid = leaderGuid;
                     lastLeaderFound = true;
+                    break;
                 }
             }
         }

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -54,7 +54,7 @@ public:
     void AddToPlayerGroup();
     void LearnPremadeSpecForClass();
 
-    Player* GetPartyLeader();
+    Player* GetPartyLeader() const;
     bool AttackStart(Unit* pVictim);
     Unit* SelectAttackTarget(Player* pLeader) const;
     Unit* SelectPartyAttackTarget() const;

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -54,7 +54,7 @@ public:
     void AddToPlayerGroup();
     void LearnPremadeSpecForClass();
 
-    Player* GetPartyLeader() const;
+    Player* GetPartyLeader();
     bool AttackStart(Unit* pVictim);
     Unit* SelectAttackTarget(Player* pLeader) const;
     Unit* SelectPartyAttackTarget() const;


### PR DESCRIPTION
Before this change, you could still control bots that you spawned even if they weren't in party with you as long as they were inside a party with someone else.