### PR TITLE
Transport uses 1.9 update flags conditionally

### DIFF
--- a/src/game/Transports/Transport.cpp
+++ b/src/game/Transports/Transport.cpp
@@ -35,7 +35,12 @@
 
 Transport::Transport(TransportTemplate const& transportTemplate) : GenericTransport(), m_transportTemplate(transportTemplate), m_isMoving(true), m_pendingStop(false)
 {
-    m_updateFlag = (UPDATEFLAG_TRANSPORT | UPDATEFLAG_ALL | UPDATEFLAG_HAS_POSITION);
+    m_updateFlag = UPDATEFLAG_TRANSPORT;
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
+    m_updateFlag |= UPDATEFLAG_ALL | UPDATEFLAG_HAS_POSITION;
+#endif
+
     SetPeriod(transportTemplate.pathTime);
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes the build currently failing for client version 1.8.4 and below.

### Proof
<!-- Link resources as proof -->
These flags were made conditional based on client version in [8ed340b](https://github.com/vmangos/core/commit/8ed340bb98f1d0fdd59509046f56e28a3626a6a0#diff-a903ec7d7e06646d004b874b376f013064614e5b2dbcf86d97ad3b19e52377cb).

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Build using both `CLIENT_BUILD_1_8_4` and `CLIENT_BUILD_1_12_1`.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
