### PR TITLE
fix stat modifier issue

### DIFF
--- a/src/game/Objects/Object.h
+++ b/src/game/Objects/Object.h
@@ -368,8 +368,9 @@ class Object
 
         void ApplyPercentModFloatValue(uint16 index, float val, bool apply)
         {
-            val = val != -100.0f ? val : -99.9f ;
-            SetFloatValue(index, GetFloatValue(index) * (apply?(100.0f+val)/100.0f : 100.0f / (100.0f+val)));
+            float value = GetFloatValue(index);
+            ApplyPercentModFloatVar(value, val, apply);
+            SetFloatValue(index, value);
         }
 
         void SetFlag(uint16 index, uint32 newFlag);

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -5293,7 +5293,7 @@ void Aura::HandleModDamagePercentDone(bool apply, bool Real)
             // For show in client
             if (target->GetTypeId() == TYPEID_PLAYER)
             {
-                // TODO: fix positive aura gets removed -> damage is displayed at 100%
+                // TODO: fix positive aura gets removed -> damage is displayed red at 100%
                 target->ApplyPercentModFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT, m_modifier.m_amount, apply);
             }         
         }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -5292,7 +5292,10 @@ void Aura::HandleModDamagePercentDone(bool apply, bool Real)
 
             // For show in client
             if (target->GetTypeId() == TYPEID_PLAYER)
-                target->ApplyPercentModFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT, /*TODO: m_isAuraEnabled ? m_amount : 0 */ m_modifier.m_amount, apply);
+            {
+                // TODO: fix positive aura gets removed -> damage is displayed at 100%
+                target->ApplyPercentModFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT, m_modifier.m_amount, apply);
+            }         
         }
         else
         {
@@ -5317,7 +5320,7 @@ void Aura::HandleModDamagePercentDone(bool apply, bool Real)
     // Send info to client
     if (target->GetTypeId() == TYPEID_PLAYER)
         for (int i = SPELL_SCHOOL_HOLY; i < MAX_SPELL_SCHOOL; ++i)
-            target->ApplyModSignedFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i, m_modifier.m_amount / 100.0f, apply);
+            target->ApplyPercentModFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i, m_modifier.m_amount, apply);
 }
 
 void Aura::HandleModOffhandDamagePercent(bool apply, bool Real)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -5281,7 +5281,7 @@ void Aura::HandleModDamagePercentDone(bool apply, bool Real)
     // with spell->EquippedItemClass and  EquippedItemSubClassMask and EquippedItemInventoryTypeMask
     // m_modifier.m_miscvalue comparison with item generated damage types
 
-    if ((m_modifier.m_miscvalue & SPELL_SCHOOL_MASK_NORMAL) != 0)
+    if (GetMiscValue() & SPELL_SCHOOL_MASK_NORMAL)
     {
         // apply generic physical damage bonuses including wand case
         if (GetSpellProto()->EquippedItemClass == -1 || target->GetTypeId() != TYPEID_PLAYER)
@@ -5289,12 +5289,19 @@ void Aura::HandleModDamagePercentDone(bool apply, bool Real)
             target->HandleStatModifier(UNIT_MOD_DAMAGE_MAINHAND, TOTAL_PCT, m_modifier.m_amount, apply);
             target->HandleStatModifier(UNIT_MOD_DAMAGE_OFFHAND, TOTAL_PCT, m_modifier.m_amount, apply);
             target->HandleStatModifier(UNIT_MOD_DAMAGE_RANGED, TOTAL_PCT, m_modifier.m_amount, apply);
-
+            
             // For show in client
             if (target->GetTypeId() == TYPEID_PLAYER)
             {
-                // TODO: fix positive aura gets removed -> damage is displayed red at 100%
-                target->ApplyPercentModFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT, m_modifier.m_amount, apply);
+                for (uint8 i = 0; i < MAX_SPELL_SCHOOL; ++i)
+                {
+                    if (GetMiscValue() & (1 << i))
+                    {
+                        // only aura type modifying PLAYER_FIELD_MOD_DAMAGE_DONE_PCT
+                        float amount = target->GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, 1 << i);
+                        target->SetFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i, amount);
+                    }
+                }
             }         
         }
         else

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -5289,7 +5289,7 @@ void Aura::HandleModDamagePercentDone(bool apply, bool Real)
             target->HandleStatModifier(UNIT_MOD_DAMAGE_MAINHAND, TOTAL_PCT, m_modifier.m_amount, apply);
             target->HandleStatModifier(UNIT_MOD_DAMAGE_OFFHAND, TOTAL_PCT, m_modifier.m_amount, apply);
             target->HandleStatModifier(UNIT_MOD_DAMAGE_RANGED, TOTAL_PCT, m_modifier.m_amount, apply);
-            
+
             // For show in client
             if (target->GetTypeId() == TYPEID_PLAYER)
             {

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -5292,7 +5292,7 @@ void Aura::HandleModDamagePercentDone(bool apply, bool Real)
 
             // For show in client
             if (target->GetTypeId() == TYPEID_PLAYER)
-                target->ApplyModSignedFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT, m_modifier.m_amount / 100.0f, apply);
+                target->ApplyPercentModFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT, /*TODO: m_isAuraEnabled ? m_amount : 0 */ m_modifier.m_amount, apply);
         }
         else
         {

--- a/src/shared/Util.h
+++ b/src/shared/Util.h
@@ -168,7 +168,7 @@ inline void ApplyPercentModFloatVar(float& var, float val, bool apply)
 {
     if (val == -100.0f)     // prevent set var to zero
         val = -99.99f;
-    var *= (apply?(100.0f+val)/100.0f : 100.0f / (100.0f+val));
+    var *= (apply ? (100.0f + val) / 100.0f : 100.0f / (100.0f + val));
 }
 
 bool Utf8toWStr(std::string const& utf8str, std::wstring& wstr, size_t max_len = 0);


### PR DESCRIPTION
## 🍰 Pullrequest
Fix stat modifier calculation and the damage modifier shown in client.

Inspired by azerothcore and trinitycore:
<del>
https://github.com/azerothcore/azerothcore-wotlk/blob/36a6d04156214b207d7b1f286ff8f365c733a557/src/server/game/Entities/Unit/Unit.cpp#L14462
</del> (does work, but not related to the issue)

https://github.com/azerothcore/azerothcore-wotlk/blob/ea5b1b384658fc071ae509f6e26bb680bdb3c8ef/src/server/game/Spells/Auras/SpellAuraEffects.cpp#L4860

https://github.com/TrinityCore/TrinityCore/blob/c08f086a02729f3b7e4c99f4741063e45301ebf8/src/server/game/Spells/Auras/SpellAuraEffects.cpp#L4187

### Issues
- fix https://github.com/vmangos/core/issues/1236

### Todo / Checklist
- [x] None 
