### PR TITLE
Restrict accepting party quests to players which are in the same map

### DIFF
--- a/src/game/Handlers/QuestHandler.cpp
+++ b/src/game/Handlers/QuestHandler.cpp
@@ -170,7 +170,7 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPacket& recv_data)
                     {
                         Player* pPlayer = itr->getSource();
 
-                        if (!pPlayer || pPlayer == _player)     // not self
+                        if (!pPlayer || pPlayer == _player || !pPlayer->IsInMap(_player))     // not self and in same map
                             continue;
 
                         if (pPlayer->CanTakeQuest(qInfo, true))


### PR DESCRIPTION
## 🍰 Pullrequest
Credit goes to TrinityCore https://github.com/TrinityCore/TrinityCore/pull/26880

### Proof
- None

### Issues
- relates https://github.com/vmangos/core/issues/521

### How2Test
1. join a party
2. one party member is not in the same map
3. accept any quest which can be completed as group (f.e. quest=898)
4. player which is not in the same map should not get asked to accept the quest

### Todo / Checklist
- [X] None
