### PR TITLE
Remove combo points on a creature when it evades

### DIFF
--- a/src/game/AI/CreatureAI.cpp
+++ b/src/game/AI/CreatureAI.cpp
@@ -472,6 +472,7 @@ void CreatureAI::EnterEvadeMode()
         m_creature->GetMotionMaster()->MoveTargetedHome();
     }
 
+    m_creature->ClearComboPointHolders();
     m_creature->DeleteThreatList();
     m_creature->CombatStop(true);
     m_creature->SetLootRecipient(nullptr);

--- a/src/game/AI/ScriptedAI.cpp
+++ b/src/game/AI/ScriptedAI.cpp
@@ -87,6 +87,7 @@ void ScriptedAI::UpdateAI(uint32 const uiDiff)
 
 void ScriptedAI::EnterEvadeMode()
 {
+    m_creature->ClearComboPointHolders();
     m_creature->RemoveAurasAtReset();
     m_creature->DeleteThreatList();
     m_creature->CombatStop(true);

--- a/src/game/AI/ScriptedEscortAI.cpp
+++ b/src/game/AI/ScriptedEscortAI.cpp
@@ -203,6 +203,7 @@ void npc_escortAI::JustRespawned()
 
 void npc_escortAI::EnterEvadeMode()
 {
+    m_creature->ClearComboPointHolders();
     m_creature->RemoveAurasAtReset();
     m_creature->DeleteThreatList();
     m_creature->CombatStop(true);

--- a/src/game/AI/ScriptedFollowerAI.cpp
+++ b/src/game/AI/ScriptedFollowerAI.cpp
@@ -166,6 +166,7 @@ void FollowerAI::JustRespawned()
 
 void FollowerAI::EnterEvadeMode()
 {
+    m_creature->ClearComboPointHolders();
     m_creature->RemoveAurasAtReset();
     m_creature->DeleteThreatList();
     m_creature->CombatStop(true);


### PR DESCRIPTION
## 🍰 Pullrequest
Credit goes to TrinityCore https://github.com/TrinityCore/TrinityCore/pull/26836

### Proof
- None

### Issues
- None

### How2Test
1. add combo point to a creature
2. let creature evade
3. combo points should be removed

### Todo / Checklist
- [X] None
