### PR TITLE
Scepter of Celebras stone should remain ACTIVE.

### DIFF
--- a/src/scripts/kalimdor/desolace/maraudon/boss_celebras_the_cursed.cpp
+++ b/src/scripts/kalimdor/desolace/maraudon/boss_celebras_the_cursed.cpp
@@ -185,7 +185,7 @@ struct celebrasSpiritAI : public npc_escortAI
 
                 GetGameObjectListWithEntryInGrid(scepterList, m_creature, GO_CREATOR, 40.0f);
                 for (const auto& it : scepterList)
-                    it->UseDoorOrButton(0, false);
+                    it->SetGoState(GO_STATE_ACTIVE);
                 scepterList.clear();
 
                 break;


### PR DESCRIPTION
## 🍰 Pullrequest
Before this change the GameObject was just being used and it was resetting back to the READY state instantly. With this change, it remains ACTIVE until the instance is reset.

### Proof
https://youtu.be/buMUOX_pZhA?t=424
