### PR TITLE
Fix crash on stop server and compilation on OS X

### DIFF
--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -47,6 +47,7 @@ else( OPENSSL_INCLUDE_DIR AND OPENSSL_LIBRARIES )
       /usr/local/include
       /usr/local/include/openssl
       /usr/local/openssl/include
+      /usr/local/opt/openssl
       ${TMP_OPENSSL_INCLUDE_DIR}
     DOC
       "Specify the directory containing openssl.h."
@@ -62,6 +63,7 @@ else( OPENSSL_INCLUDE_DIR AND OPENSSL_LIBRARIES )
       /usr/local/lib
       /usr/local/lib/ssl
       /usr/local/ssl/lib
+      /usr/local/opt/openssl/lib
       ${TMP_OPENSSL_LIBRARIES}
     DOC "Specify the OpenSSL library here."
   )

--- a/src/shared/ProgressBar.cpp
+++ b/src/shared/ProgressBar.cpp
@@ -50,6 +50,12 @@ BarGoLink::BarGoLink(uint64 row_count)
     init((int)row_count);
 }
 
+BarGoLink::BarGoLink(size_t row_count)
+{
+    //MANGOS_ASSERT(row_count < (uint64)ACE_INT32_MAX);
+    init((int)row_count);
+}
+
 BarGoLink::~BarGoLink()
 {
     if (!m_showOutput)

--- a/src/shared/ProgressBar.h
+++ b/src/shared/ProgressBar.h
@@ -33,6 +33,7 @@ class BarGoLink
         explicit BarGoLink(int row_count);
         explicit BarGoLink(uint32 row_count);               // row_count < ACE_INT32_MAX
         explicit BarGoLink(uint64 row_count);               // row_count < ACE_INT32_MAX
+        explicit BarGoLink(size_t row_count);
         ~BarGoLink();
 
     public:                                                 // modifiers

--- a/src/shared/ThreadPool.h
+++ b/src/shared/ThreadPool.h
@@ -151,7 +151,7 @@ public:
 private:
     struct worker {
         worker(ThreadPool *pool, int id, ErrorHandling mode);
-        ~worker();
+        virtual ~worker();
 
         void loop_wrapper();
         void loop();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fix Crash mangosd  server during the stop : missing virtual constructor
Fix compilation on OS X with clang.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
