### PR TITLE
Automatic Data Extractor and Release

### DIFF
--- a/.github/workflows/datagen.yml
+++ b/.github/workflows/datagen.yml
@@ -1,0 +1,194 @@
+name: Client Data Extractor
+
+on:
+  push:
+    paths:
+      - '.github/workflows/datagen.yml'
+      - 'contrib/extractor/*.*'
+      - 'contrib/vmap_assembler/*.*'
+      - 'contrib/vmap_extractor/*.*'
+      - 'contrib/mmap/*.*'
+      - 'src/game/Maps/*.*'
+      - 'src/game/vmap/*.*'
+      - 'dep/include/g3dlite/G3D/*.*'
+      - 'dep/src/g3dlite/*.*'
+      - 'dep/recastnavigation/Detour/Include/*.*'
+      - 'dep/recastnavigation/Detour/Source/*.*'
+      - 'dep/recastnavigation/Recast/Include/*.*'
+      - 'dep/recastnavigation/Recast/Source/*.*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    #git checkout
+    - uses: actions/checkout@v2
+    
+    - name: build extractors
+      #Sets versions for ACE/TBB
+      env:
+        ACE_VERSION: 6.5.11
+        ACE_VERSION2: 6_5_11
+        TBB_VERSION: 2020.3
+      
+      run: |
+        #directory variables
+        export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers
+        export TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb
+        #wget
+        choco install -y wget
+        #ACE package download
+        wget http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-$ACE_VERSION2/ACE-$ACE_VERSION.zip
+        unzip ACE-$ACE_VERSION.zip
+        rm ACE-$ACE_VERSION.zip
+        #configuration of ACE header
+        echo "#include \"ace/config-win32.h\"" >> $ACE_ROOT/ace/config.h
+        #TBB package download
+        wget https://github.com/oneapi-src/oneTBB/releases/download/v$TBB_VERSION/tbb-$TBB_VERSION-win.zip
+        unzip tbb-$TBB_VERSION-win.zip
+        rm tbb-$TBB_VERSION-win.zip
+        #make
+        choco install -y make
+        #cmake
+        choco install -y cmake
+        #openssl
+        choco install -y openssl
+        #directory variables
+        export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers
+        cd $GITHUB_WORKSPACE/ACE_wrappers
+        /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe "ACE_wrappers_vs2019.sln" //p:Configuration=Release //p:Platform=x64 //t:ACE //m:2
+        cd $GITHUB_WORKSPACE
+        mkdir build
+        cd build
+        cmake -D TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb -DWITH_WARNINGS=0 -DUSE_EXTRACTORS=1 -G "Visual Studio 16 2019" -A x64 ..
+        /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe "MaNGOS.sln" //p:Platform=x64 //p:Configuration=Release //m:2
+      #git bash shell
+      shell: bash
+
+    - name: copy bin files
+      run: |
+          #data is in Release folder
+          cd ${{github.workspace}}/bin
+          copy ${{github.workspace}}/tbb/bin/intel64/vc14/tbbmalloc.dll ${{github.workspace}}/bin/Release/tbbmalloc.dll
+          copy ${{github.workspace}}/ACE_wrappers/lib/ACE.dll ${{github.workspace}}/bin/Release/ACE.dll
+ 
+    - name: make junk folder to remove later
+      run: |
+          cd ${{github.workspace}}
+          mkdir junk
+          move ${{github.workspace}}/ACE_wrappers ${{github.workspace}}/junk/ACE_wrappers
+          move ${{github.workspace}}/tbb ${{github.workspace}}/junk/tbb
+          move ${{github.workspace}}/build ${{github.workspace}}/junk/build
+          move ${{github.workspace}}/sql ${{github.workspace}}/junk/sql
+          move ${{github.workspace}}/src ${{github.workspace}}/junk/src
+          move ${{github.workspace}}/cmake ${{github.workspace}}/junk/cmake
+          move ${{github.workspace}}/dep ${{github.workspace}}/junk/dep
+          move ${{github.workspace}}/.github ${{github.workspace}}/junk/.github
+      
+      
+    - name: Remove junk dir
+      uses: JesseTG/rm@v1.0.2
+      with:
+        path: ${{github.workspace}}/junk
+
+  
+    #download small client, notice the extractor doesn't look dbc.mpq so copy it to patch2.mpq
+    - name: checkout
+      run: |
+          dir
+          cd ${{github.workspace}}
+          git clone https://github.com/coolzoom/smallvanilla
+
+    - name: Remove .git File
+      uses: JesseTG/rm@v1.0.2
+      with:
+        path: ${{github.workspace}}/smallvanilla/.git      
+
+ 
+    - name: copy tools
+      run: |   
+          cd ${{github.workspace}}
+          cd smallvanilla
+          cd 7z
+          7z x small_vanilla.7z.001
+          del small_vanilla.7z.*
+          dir
+          cd small_vanilla
+          copy Data/dbc.mpq Data/patch-2.mpq
+          cd ${{github.workspace}}
+          copy ${{github.workspace}}/bin/Release/ACE.dll ${{github.workspace}}/smallvanilla/7z/small_vanilla/ACE.dll
+          copy ${{github.workspace}}/bin/Release/tbbmalloc.dll ${{github.workspace}}/smallvanilla/7z/small_vanilla/tbbmalloc.dll
+          copy ${{github.workspace}}/bin/Release/mapextractor.exe ${{github.workspace}}/smallvanilla/7z/small_vanilla/mapextractor.exe
+          copy ${{github.workspace}}/bin/Release/vmapextractor.exe ${{github.workspace}}/smallvanilla/7z/small_vanilla/vmapextractor.exe
+          copy ${{github.workspace}}/bin/Release/vmap_assembler.exe ${{github.workspace}}/smallvanilla/7z/small_vanilla/vmap_assembler.exe
+          copy ${{github.workspace}}/bin/Release/MoveMapGen.exe ${{github.workspace}}/smallvanilla/7z/small_vanilla/MoveMapGen.exe
+          copy ${{github.workspace}}/contrib/mmap/MoveMapGen.sh ${{github.workspace}}/smallvanilla/7z/small_vanilla/MoveMapGen.sh
+          copy ${{github.workspace}}/contrib/mmap/offmesh.txt ${{github.workspace}}/smallvanilla/7z/small_vanilla/offmesh.txt
+      
+    - name: extract
+      run: |
+          cd ${{github.workspace}}/smallvanilla/7z/small_vanilla
+          ./mapextractor.exe
+          ./vmapextractor.exe
+          mkdir vmaps
+          ./vmap_assembler.exe Buildings vmaps
+          #./MoveMapGen.sh 8 MaNGOSExtractor.log MaNGOSExtractor_Detailed.log
+          dir
+          fsutil volume diskfree D:
+          #./MoveMapGen.sh 8
+    #build and install
+    - name: extract mmap
+      run: |
+        cd $GITHUB_WORKSPACE/smallvanilla/7z/small_vanilla
+        ./MoveMapGen.sh 8
+      #git bash shell
+      shell: bash          
+          
+    - name: move data file
+      run: |
+          cd ${{github.workspace}}
+          mkdir datapackage
+          cd datapackage
+          mkdir data
+          cd data
+          move ${{github.workspace}}/smallvanilla/7z/small_vanilla/dbc ${{github.workspace}}/datapackage/data/dbc
+          move ${{github.workspace}}/smallvanilla/7z/small_vanilla/maps ${{github.workspace}}/datapackage/data/maps
+          move ${{github.workspace}}/smallvanilla/7z/small_vanilla/vmaps ${{github.workspace}}/datapackage/data/vmaps
+          move ${{github.workspace}}/smallvanilla/7z/small_vanilla/mmaps ${{github.workspace}}/datapackage/data/mmaps
+          
+    - name: Remove client File
+      uses: JesseTG/rm@v1.0.2
+      with:
+        path: ${{github.workspace}}/smallvanilla
+        
+    - name: make data zip
+      run: |   
+          fsutil volume diskfree D:      
+          cd ${{github.workspace}}/datapackage
+          7z a -tzip data.zip data
+          
+    - name: Archive this artefact
+      uses: actions/upload-artifact@v2
+      with:
+          name: snapshot-datapackage
+          path: "${{github.workspace}}/datapackage/data.zip"
+
+    - name: Download artifact snapshot-datapackage
+      uses: actions/download-artifact@v1
+      with:
+        name: snapshot-datapackage
+        path: all_snapshots
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+    - name: Upload snapshot
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "data-latest"
+        prerelease: true
+        title: "Data Files (${{ steps.date.outputs.date }})"
+        files: all_snapshots

--- a/contrib/mmap/MoveMapGen.sh
+++ b/contrib/mmap/MoveMapGen.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information
+#
+# This file is free software; as a special exception the author gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+## Syntax of this helper
+## First param must be number of to be used CPUs (only 1, 2, 3, 4 supported) or "offmesh" to recreate the special tiles from the OFFMESH_FILE
+## Second param can be an additional filename for storing log
+## Third param can be an addition filename for storing detailed log
+
+## Additional Parameters to be forwarded to MoveMapGen, see mmaps/readme for instructions
+PARAMS="--silent --configInputPath config.json"
+
+## Already a few map extracted, and don't care anymore
+EXCLUDE_MAPS=""
+#EXCLUDE_MAPS="0 1 530 571" # example to exclude the continents
+
+## Offmesh file
+OFFMESH_FILE="offmesh.txt"
+
+## Normal log file (if not overwritten by second param
+LOG_FILE="MoveMapGen.log"
+## Detailed log file
+DETAIL_LOG_FILE="MoveMapGen_detailed.log"
+
+## ! Use below only for finetuning or if you know what you are doing !
+
+## All maps
+LIST_A="1"
+LIST_B="0"
+LIST_C="169"
+LIST_D="269 533 35 44 389 129 109 450 34 249 48"
+LIST_E="531 37 309 369"
+LIST_F="229 409 43 70 90 189"
+LIST_G="36 33 209 451 47"
+LIST_H="509 30 289 230"
+LIST_I="42 449 25 529 489 329 429 349 469 13"
+
+badParam()
+{
+ echo "ERROR! Bad arguments!"
+ echo "You can (re)extract mmaps with this helper script,"
+ echo "or recreate only the tiles from the offmash file"
+ echo
+ echo "Call with number of processes (1 - 4) to create mmaps"
+ echo "Call with 'offmesh' to reextract the tiles from offmash file"
+ echo
+ echo "For further fine-tuning edit this helper script"
+ echo
+}
+
+if [ "$#" = "3" ]
+then
+ LOG_FILE=$2
+ DETAIL_LOG_FILE=$3
+elif [ "$#" = "2" ]
+then
+ LOG_FILE=$2
+fi
+
+# Offmesh file provided?
+OFFMESH=""
+if [ "$OFFMESH_FILE" != "" ]
+then
+ if [ ! -f "$OFFMESH_FILE" ]
+ then
+   echo "ERROR! Offmesh file $OFFMESH_FILE could not be found."
+   echo "Provide valid file or none. You need to edit the script"
+   exit 1
+ else
+   OFFMESH="--offMeshInput $OFFMESH_FILE"
+ fi
+fi
+
+# Function to process a list
+createMMaps()
+{
+ for i in $@
+ do
+   for j in $EXCLUDE_MAPS
+   do
+     if [ "$i" = "$j" ]
+     then
+       continue 2
+     fi
+   done
+   ./MoveMapGen $PARAMS $OFFMESH $i | tee -a $DETAIL_LOG_FILE
+   echo "`date`: (Re)created map $i" | tee -a $LOG_FILE
+ done
+}
+
+createHeader()
+{
+ echo "`date`: Start creating MoveMaps" | tee -a $LOG_FILE
+ echo "Used params: $PARAMS $OFFMESH" | tee -a $LOG_FILE
+ echo "Detailed log can be found in $DETAIL_LOG_FILE" | tee -a $LOG_FILE
+ echo "Start creating MoveMaps" | tee -a $DETAIL_LOG_FILE
+ echo
+ echo "Be PATIENT - This will take a long time and might also have gaps between visible changes on the console."
+ echo "WAIT until you are informed that 'creating MoveMaps' is 'finished'!"
+}
+
+# Create mmaps directory if not exist
+if [ ! -d mmaps ]
+then
+ mkdir mmaps
+fi
+
+# Param control
+case "$1" in
+ "1" )
+   createHeader $1
+   createMMaps $LIST_A $LIST_B $LIST_C $LIST_D $LIST_F $LIST_G $LIST_H $LIST_I &
+   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
+   ;;
+ "2" )
+   createHeader $1
+   createMMaps $LIST_A $LIST_E $LIST_H $LIST_I &
+   createMMaps $LIST_B $LIST_C $LIST_D $LIST_F $LIST_G &
+   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
+   ;;
+ "4" )
+   createHeader $1
+   createMMaps $LIST_A &
+   createMMaps $LIST_B &
+   createMMaps $LIST_C $LIST_F $LIST_G &
+   createMMaps $LIST_D $LIST_E $LIST_H $LIST_I &
+   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
+   ;;
+ "8" )
+   createHeader $1
+   createMMaps $LIST_A &
+   createMMaps $LIST_B &
+   createMMaps $LIST_C &
+   createMMaps $LIST_D &
+   createMMaps $LIST_E &
+   createMMaps $LIST_F $LIST_H &
+   createMMaps $LIST_G &
+   createMMaps $LIST_I &
+   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
+   ;;
+ "offmesh" )
+   echo "`date`: Recreate offmeshs from file $OFFMESH_FILE" | tee -a $LOG_FILE
+   echo "Recreate offmeshs from file $OFFMESH_FILE" | tee -a $DETAIL_LOG_FILE
+   while read map tile line
+   do
+     ./MoveMapGen $PARAMS $OFFMESH $map --tile $tile | tee -a $DETAIL_LOG_FILE
+     echo "`date`: Recreated $map $tile from $OFFMESH_FILE" | tee -a $LOG_FILE
+   done < $OFFMESH_FILE &
+   ;;
+ * )
+   badParam
+   exit 1
+   ;;
+esac
+
+wait
+
+echo  | tee -a $LOG_FILE
+echo  | tee -a $DETAIL_LOG_FILE
+echo "`date`: Finished creating MoveMaps" | tee -a $LOG_FILE
+echo "`date`: Finished creating MoveMaps" >> $DETAIL_LOG_FILE


### PR DESCRIPTION
## 🍰 Pullrequest
here is just a 'works for me' action that may or may not help or fit the master vmangos repo, so i just made a pr see if you or some people have interests. it would trigger dbc/maps extract process after the extractor or map-related code changed. publish a new data package to the release section. not used often, but useful when it is needed

- client using small client from @Daribon  https://github.com/coolzoom/smallvanilla/  https://www.reddit.com/r/wowservers/comments/bunrcr/smallest_1121_client_ever_only_356_gb/
- trigger only when extractor or map-related file changes.
- use Github runner so no personal computer time is needed. 
- multithread extractor script using cmangos mangos-classic so credit to cmangos team.  https://github.com/cmangos/mangos-classic/blob/master/contrib/extractor_scripts/MoveMapGen.sh
- 4.5hours time consume, still better compare to my computer(~8hours)
- it does consume around 5 hours github free action time, but since we dont trigger it often, so should be fine

![image](https://user-images.githubusercontent.com/10232727/142257317-afea72a4-ae3e-4217-a440-ce8957f49dc4.png)



example release
![image](https://user-images.githubusercontent.com/10232727/142257097-d0df024e-ee4f-42ec-997d-243118fc738f.png)

example run history:
https://github.com/coolzoom/w1x-vmcore/runs/4238358797?check_suite_focus=true