### PR TITLE
Naxxramas/Patchwerk - rewrite target selection for spell Hateful Strike

### DIFF
--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
@@ -139,22 +139,21 @@ struct boss_patchwerkAI : public ScriptedAI
             if (threatListPosition > 0)
             {
                 // Only target players
-                if (!iter->getUnitGuid().IsPlayer())
-                    continue;
-
-                Player* pTempTarget = m_creature->GetMap()->GetPlayer(iter->getUnitGuid());
-                if (!pTempTarget)
-                    continue;
-
-                // Player must be within map and within melee range
-                if(!m_creature->IsInMap(pTempTarget) || !m_creature->CanReachWithMeleeSpellAttack(pTempTarget))
-                    continue;
-
-                // Check if target has higher hp than anyone checked so far
-                if (pTempTarget->GetHealth() > uiHighestHP)
+                if (iter->getUnitGuid().IsPlayer())
                 {
-                    pTarget = pTempTarget;
-                    uiHighestHP = pTarget->GetHealth();
+                    if (Player* pTempTarget = m_creature->GetMap()->GetPlayer(iter->getUnitGuid()))
+                    {
+                        // Check if selected player is within melee range
+                        if (m_creature->IsInMap(pTempTarget) && m_creature->CanReachWithMeleeSpellAttack(pTempTarget))
+                        {
+                            // Check if target has higher hp than anyone checked so far
+                            if (pTempTarget->GetHealth() > uiHighestHP)
+                            {
+                                pTarget = pTempTarget;
+                                uiHighestHP = pTarget->GetHealth();
+                            }
+                        }
+                    }
                 }
             }
             threatListPosition++;

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
@@ -40,8 +40,6 @@ enum PatchwerkData
     SPELL_SLIMEBOLT       = 32309  // Added in patch 1.12
 };
 
-constexpr float MELEE_DISTANCE = 5.0; 
-
 enum ePatchwerkEvents
 {
     EVENT_BERSERK       = 1,

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
@@ -128,7 +128,7 @@ struct boss_patchwerkAI : public ScriptedAI
         for (const auto iter : tList)
         {
             // Do not check further than fourth form threat list
-            if (threatListPosition > 4)
+            if (threatListPosition > 3)
                 break;
 
             // Skip current main tank for inital target search

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
@@ -139,21 +139,22 @@ struct boss_patchwerkAI : public ScriptedAI
             if (threatListPosition > 0)
             {
                 // Only target players
-                if (iter->getUnitGuid().IsPlayer())
+                if (!iter->getUnitGuid().IsPlayer())
+                    continue;
+
+                Player* pTempTarget = m_creature->GetMap()->GetPlayer(iter->getUnitGuid());
+                if (!pTempTarget)
+                    continue;
+
+                // Player must be within map and within melee range
+                if(!m_creature->IsInMap(pTempTarget) || !m_creature->CanReachWithMeleeSpellAttack(pTempTarget))
+                    continue;
+
+                // Check if target has higher hp than anyone checked so far
+                if (pTempTarget->GetHealth() > uiHighestHP)
                 {
-                    if (Player* pTempTarget = m_creature->GetMap()->GetPlayer(iter->getUnitGuid()))
-                    {
-                        // Check if selected player is within melee range
-                        if (m_creature->IsInMap(pTempTarget) && m_creature->CanReachWithMeleeSpellAttack(pTempTarget))
-                        {
-                            // Check if target has higher hp than anyone checked so far
-                            if (pTempTarget->GetHealth() > uiHighestHP)
-                            {
-                                pTarget = pTempTarget;
-                                uiHighestHP = pTarget->GetHealth();
-                            }
-                        }
-                    }
+                    pTarget = pTempTarget;
+                    uiHighestHP = pTarget->GetHealth();
                 }
             }
             threatListPosition++;

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
@@ -144,7 +144,7 @@ struct boss_patchwerkAI : public ScriptedAI
                     if (Player* pTempTarget = m_creature->GetMap()->GetPlayer(iter->getUnitGuid()))
                     {
                         // Check if selected player is within melee range
-                        if (m_creature->IsInMap(pTarget) && m_creature->CanReachWithMeleeSpellAttack(pTarget))
+                        if (m_creature->IsInMap(pTempTarget) && m_creature->CanReachWithMeleeSpellAttack(pTempTarget))
                         {
                             // Check if target has higher hp than anyone checked so far
                             if (pTempTarget->GetHealth() > uiHighestHP)

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
@@ -168,10 +168,8 @@ struct boss_patchwerkAI : public ScriptedAI
             // Cast Hateful Strike
             DoCastSpellIfCan(pTarget, SPELL_HATEFULSTRIKE, CF_TRIGGERED);
         }
-        /*
         else
         {
-            // TODO: confirm that this is correct
             // Hateful Strike will target main tank if second, third, and fourth players form threat list are not within meele range.
             if (Unit* mainTank = m_creature->GetVictim())
             {
@@ -181,7 +179,6 @@ struct boss_patchwerkAI : public ScriptedAI
                 }
             }
         }
-        */
     }
 
     bool CustomGetTarget()

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
@@ -163,6 +163,9 @@ struct boss_patchwerkAI : public ScriptedAI
             m_creature->SetInFront(pTarget);
             m_creature->SetTargetGuid(pTarget->GetObjectGuid());
 
+            // Update previousTarget for CustomGetTarget() - not sure if needed at all?
+            previousTarget = pTarget->GetObjectGuid();
+
             // Cast Hateful Strike
             DoCastSpellIfCan(pTarget, SPELL_HATEFULSTRIKE, CF_TRIGGERED);
         }


### PR DESCRIPTION
## 🍰 Pullrequest
Rewrite target selection for spell Hateful Strike [https://classic.wowhead.com/spell=28308/hateful-strike] used by Patchwerk according to linked sources.
Remove old constexpr for meele distance check
Set Hateful Strike timer to 1,5 - 2 seconds, instead of 1,2 second

### Proof
- https://classic.wowhead.com/guides/patchwerk-naxxramas-raid-strategy
- https://youtu.be/fn9I8afey7w?t=822
- https://youtu.be/bmpVXEQYIcg?t=53

### Issues
- None

### How2Test
- Encounter Patchwerk in Naxxramas with a group
- Patchwerk should use Hateful Strike on a target if it matches the following conditions:
 1) checks for players between second, third, and fourth on threat list
 2) only players within melee range
 3) player with the most health (which has passed two contitions above) OR Hateful Strike will target main tank if second, third, and fourth players form threat list are not within meele range.

### Todo / Checklist
- [x] tested ingame
- [ ] confirm that new Hateful Strike timer is correct
- [ ] Hateful Strike meele range correct? (See no longer used constexpr which is removed with this PR)
- [x] What happes when second, third, and fourth players form threat list are not within meele range. Will main tank be targeted from Hateful Strike? - Due to https://old.reddit.com/r/classicwow/comments/jw3vlt/patchwerk_hateful_strike_clarification/ and the damge values https://youtu.be/pjUv7HfOPbE?t=563 main tank will be targeted.
- [ ] can Hateful Strike target anything other than players?