### PR TITLE
Scarlet Monastery: improve Mograine and Withemane encounter

### DIFF
--- a/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -480,27 +480,28 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
         if (MovementType == POINT_MOTION_TYPE) 
         {
             switch (id) {
-            case 1: // enter combat after intro waypoints
-            {
-                m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
-                m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
-                m_creature->SetInCombatWithZone();
-                break;
-            }
-            case 2: // face Mograine before casting SPELL_SCARLETRESURRECTION
-            {
-                if (m_pInstance)
+                case 1: // enter combat after intro waypoints
                 {
-                    if (Creature* pMograine = m_pInstance->instance->GetCreature(m_pInstance->GetData64(DATA_MOGRAINE)))
-                    {
-                        m_creature->SetFacingToObject(pMograine);
-                    }
+                    m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+                    m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                    m_creature->SetInCombatWithZone();
+                    break;
                 }
-                break;
-            }
-            default:
-            {
-                break; // nothing
+                case 2: // face Mograine before casting SPELL_SCARLETRESURRECTION
+                {
+                    if (m_pInstance)
+                    {
+                        if (Creature* pMograine = m_pInstance->instance->GetCreature(m_pInstance->GetData64(DATA_MOGRAINE)))
+                        {
+                            m_creature->SetFacingToObject(pMograine);
+                        }
+                    }
+                    break;
+                }
+                default:
+                {
+                    break; // nothing
+                }
             }
         }
     }

--- a/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -57,7 +57,9 @@ enum
     ENTRY_SCARLET_CENTURION      = 4301,
     ENTRY_SCARLET_CHAMPION       = 4302,
     ENTRY_SCARLET_ABBOT          = 4303,
-    ENTRY_SCARLET_MONK           = 4540
+    ENTRY_SCARLET_MONK           = 4540,
+
+    SOUND_MOGRAINE_FAKE_DEATH    = 1326
 };
 
 struct boss_scarlet_commander_mograineAI : public ScriptedAI
@@ -152,6 +154,8 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
         m_creature->ClearComboPointHolders();
         m_creature->RemoveAllAuras();
         m_creature->ClearAllReactives();
+
+        m_creature->PlayDistanceSound(SOUND_MOGRAINE_FAKE_DEATH);
 
         m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
         m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);

--- a/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -390,8 +390,8 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
             {
                 if (pMograine->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER) || pMograine->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC))
                 {
-                    m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
-                    m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                    pMograine->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+                    pMograine->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
                     pKiller->DealDamage(pMograine, 1, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
                 }
             }

--- a/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -510,7 +510,8 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
     {
         if (MovementType == POINT_MOTION_TYPE) 
         {
-            switch (id) {
+            switch (id)
+            {
                 case 1: // enter combat after intro waypoints
                 {
                     m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);

--- a/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/scripts/eastern_kingdoms/tirisfal_glades/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -86,7 +86,6 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
         //Incase wipe during phase that mograine fake death
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
-        m_creature->ClearUnitState(UNIT_STAT_FEIGN_DEATH);
         m_creature->SetStandState(UNIT_STAND_STATE_STAND);
 
         m_bDivineShield = false;


### PR DESCRIPTION
## 🍰 Pullrequest
Some improvements for Mograine and Withemane encounter at Scarlet Monastery.
- prevent Mograine from moving while being in fake death state (his corpse was sliding on the ground)
- no longer use `UNIT_FLAG_SPAWNING `in the script
- properly prevent Withemane from getting aggro, before she gets triggered by Mograine
- add sound when Mograine fakes death (source: CMangos https://github.com/cmangos/mangos-classic/blob/dc45231c0b3d852ade709094e3d14f4c9848987a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp#L187)

### Proof
- https://youtu.be/nPfBZ9lBDzo?t=603

### Issues
- None

### How2Test
- Enter Scarlet Monastery Cathedral
- encounter Mograine and Withemane

### Todo / Checklist
- [X] tested ingame
