### PR TITLE
Fix(Core/Creature): Disable shredder should not attack creatures nearby

### DIFF
--- a/src/scripts/kalimdor/the_barrens/the_barrens.cpp
+++ b/src/scripts/kalimdor/the_barrens/the_barrens.cpp
@@ -523,7 +523,10 @@ struct npc_wizzlecranks_shredderAI : public npc_escortAI
     void JustSummoned(Creature* pSummoned) override
     {
         if (pSummoned->GetEntry() == NPC_PILOT_WIZZ)
+        {
             m_creature->SetStandState(UNIT_STAND_STATE_DEAD);
+            m_creature->RestoreFaction();
+        }
 
         if (pSummoned->GetEntry() == NPC_MERCENARY)
             pSummoned->AI()->AttackStart(m_creature);


### PR DESCRIPTION
## 🍰 Pullrequest
Fix for barrens quest [The Escape]:
Wizzlecrank's Shredder should not remain aggressive towards enemy NPCs, after escort quest is completed.

Credit goes to AzerothCore:
https://github.com/azerothcore/azerothcore-wotlk/pull/9920

### Todo / Checklist
- [X] tested ingame
