### PR TITLE
Add sql migration to fix Moira Bronzebeards portal

### DIFF
--- a/sql/migrations/20220105011323_world.sql
+++ b/sql/migrations/20220105011323_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220105011323');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220105011323');
+-- Add your query below.
+
+
+-- Fix: Have Princess Moira Bronzebeard summon visible portal to Ironforge
+UPDATE `spell_template` SET `effect1`='50', `effectMiscValue1`='176497' WHERE  `entry`=13912 AND `build`=4222;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
Add sql migration to fix Moira Bronzebeards portal by changing the spell effect from SPELL_EFFECT_PORTAL to SPELL_EFFECT_TRANS_DOOR and adding Ironforge portal object as effect misc value

## 🍰 Pullrequest
A database migration to fix a portal spell for Princess Moira Bronzebeard.

### Proof


### Issues
- fixes #1391 

### How2Test
- As GM run 
- .go 1380.58 -819.48 -92.72 230
- Kill Emperor Dagran Thaurissan
- Observe Princess Moira Bronzebeard cast a spell and a portal will open
### Todo / Checklist
- [X] None
