### PR TITLE
Correct Seal of Righteousness coefficient according to Classic testing

### DIFF
--- a/src/game/Spells/SpellEntry.cpp
+++ b/src/game/Spells/SpellEntry.cpp
@@ -744,21 +744,21 @@ float SpellEntry::CalculateCustomCoefficient(WorldObject const* caster, DamageEf
             // Seal of Righteousness
             if (IsFitToFamilyMask(UI64LIT(0x0000000008000000)) && SpellIconID == 25)
             {
-                coeff = 0.092f;
+                coeff = 0.10f;
                 float speed = BASE_ATTACK_TIME;
 
                 if (caster->IsPlayer())
                 {
                     if (Item *item = ((Player*)caster)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND))
                     {
-                        coeff = item->isOneHandedWeapon() ? 0.092f : 0.108f;
-                        speed = item->GetProto()->Delay;
+                        coeff = item->isOneHandedWeapon() ? 0.10f : 0.125f;
+                        
                     }
                 }
 
-                speed /= 1000.0f;
+                
 
-                return speed * coeff;
+                return coeff;
             }
             // Seal of Command
             if (Id == 20424)


### PR DESCRIPTION
-Added 0.1/0.125 coefficient based on one handed/two handed
-Removed speed factor for coefficient

Sources:

Details vanilla era SoR scaling:

http://web.archive.org/web/20060328085844/http://forums.worldofwarcraft.com/thread.aspx?fn=wow-paladin&t=647087&p=1

Details TBC era SoR scaling which is what we have currently:

https://docs.google.com/spreadsheets/d/1CKci73D_GJV7Z7WUJmYWcN1k8i5oYlxfbRzRqSwvgXw/edit#gid=0

Classic testing with SoR at 96 Spellpower:

![image](https://user-images.githubusercontent.com/45871932/148503811-b58a88e3-5f78-421c-932f-1000ce7b66b8.png)

![image](https://user-images.githubusercontent.com/45871932/148503824-07697c1e-2dce-4c55-9fa2-203239c545d1.png)


![image](https://user-images.githubusercontent.com/45871932/148503844-e8cbc1a0-b39e-4184-ae66-ffa54d5e30e9.png)

![image](https://user-images.githubusercontent.com/45871932/148504073-da231875-3f14-4728-ac6d-c8ebd9283ad7.png)
![image](https://user-images.githubusercontent.com/45871932/148504082-28a06b50-a5d4-40d2-8e44-2148889140ed.png)



Current behavior in Vmangos with 96 Spellpower:

![image](https://user-images.githubusercontent.com/45871932/148503923-c7230830-519e-4cf5-9ccb-36b30648d1e9.png)

