### PR TITLE
Update Windows Choco package install with version information

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -33,7 +33,7 @@ jobs:
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers
         export TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb
         #wget
-        choco install -y wget
+        choco install -y wget --version 1.20
         #ACE package download
         wget http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-$ACE_VERSION2/ACE-$ACE_VERSION.zip
         unzip ACE-$ACE_VERSION.zip
@@ -44,12 +44,8 @@ jobs:
         wget https://github.com/oneapi-src/oneTBB/releases/download/v$TBB_VERSION/tbb-$TBB_VERSION-win.zip
         unzip tbb-$TBB_VERSION-win.zip
         rm tbb-$TBB_VERSION-win.zip
-        #make
-        choco install -y make
-        #cmake
-        choco install -y cmake
         #openssl
-        choco install -y openssl
+        choco install -y openssl --version=1.1.1.500
       #git bash shell
       shell: bash
 

--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -1,4 +1,4 @@
-#3 build types 
+#3 build types
 # - gcc under Ubuntu
 # - clang under Ubuntu
 # - visual studio under Windows
@@ -62,13 +62,13 @@ jobs:
         ACE_VERSION: 6.5.11
         ACE_VERSION2: 6_5_11
         TBB_VERSION: 2020.3
-      
+
       run: |
         #directory variables
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers
         export TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb
         #wget
-        choco install -y wget
+        choco install -y wget --version 1.20
         #ACE package download
         wget http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-$ACE_VERSION2/ACE-$ACE_VERSION.zip
         unzip ACE-$ACE_VERSION.zip
@@ -79,12 +79,8 @@ jobs:
         wget https://github.com/oneapi-src/oneTBB/releases/download/v$TBB_VERSION/tbb-$TBB_VERSION-win.zip
         unzip tbb-$TBB_VERSION-win.zip
         rm tbb-$TBB_VERSION-win.zip
-        #make
-        choco install -y make
-        #cmake
-        choco install -y cmake
         #openssl
-        choco install -y openssl
+        choco install -y openssl --version=1.1.1.500
       #git bash shell
       shell: bash
 
@@ -99,7 +95,7 @@ jobs:
         cmake ../ -DCMAKE_INSTALL_PREFIX=../_install -DWITH_WARNINGS=0 -DUSE_EXTRACTORS=1
         make -j2
         make install
-    #windows 
+    #windows
     - name: windows build & install
       if: matrix.os == 'windows-latest'
       run: |


### PR DESCRIPTION
## 🍰 Pull request
Choco package installer(pre-installed package manager for Github virtual environment) API is currently having issues with windows, (starting from yesterday), and slowly recovering, not sure when it fully recovered.
right now,
![image](https://user-images.githubusercontent.com/10232727/148729640-0eabfedd-6070-4d19-bf8e-b3104a685aed.png)


```
choco install wget
choco install openssl
```
won't work or end up with server 500 very often.

Temp solution is to add version information and use a slightly older package.
if this issue has been fixed and choco fully recovered after one or two days, can ignore this PR.

```
choco install -y wget --version 1.20
choco install -y openssl --version=1.1.1.500
```