### PR TITLE
Spell immune misses and delayed spell misses from auras will now cause threat

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1239,15 +1239,15 @@ void Spell::DoAllEffectOnTarget(TargetInfo *target)
     }
     else                                                    // in 1.12.1 we need explicit miss info
     {
-        if (missInfo == SPELL_MISS_MISS || missInfo == SPELL_MISS_RESIST)
+        if (missInfo == SPELL_MISS_MISS || missInfo == SPELL_MISS_RESIST || missInfo == SPELL_MISS_IMMUNE)
         {
             if (pRealUnitCaster && pRealUnitCaster != unit)
             {
                 if (!m_spellInfo->IsPositiveSpell() && (m_caster->IsVisibleForOrDetect(unit, unit, false) || m_spellInfo->HasAttribute(SPELL_ATTR_EX_IS_PICKPOCKET)))
                 {
-                    bool combat = !IsTriggeredByAura() &&
-                                  !m_spellInfo->HasAttribute(SPELL_ATTR_EX_NO_THREAT) &&
-                                  !m_spellInfo->HasAttribute(SPELL_ATTR_EX2_NO_INITIAL_THREAT);
+                    bool combat = !m_spellInfo->HasAttribute(SPELL_ATTR_EX_NO_THREAT) &&
+                                  (m_immediateHandled || !IsTriggeredByAura() &&
+                                  !m_spellInfo->HasAttribute(SPELL_ATTR_EX2_NO_INITIAL_THREAT));
 
                     // Pickpocket can cause back attack if failed
                     if (m_spellInfo->HasAttribute(SPELL_ATTR_EX_IS_PICKPOCKET))


### PR DESCRIPTION


## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Spell immune misses and delayed spell misses from auras will now cause threat
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1443

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Testing on Teremus in blasted lands is helpful
- casting arcane missiles and see if aggros on first resist
- casting fireball and fireblast and check if it aggros on immune

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
