### PR TITLE
Stay with Windows Server 2019 +  VS 2019

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -15,7 +15,7 @@ on:
    
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
     
     steps:
     #git checkout

--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest]
         compiler: [gcc, clang]
         include:
-          - os: windows-latest
+          - os: windows-2019
 
     steps:
 
@@ -56,7 +56,7 @@ jobs:
         sudo apt-get -qq install cmake build-essential cppcheck git make libiberty-dev openssl libssl-dev
       #windows dependencies
     - name: windows dependencies
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       #Sets versions for ACE/TBB
       env:
         ACE_VERSION: 6.5.11
@@ -97,7 +97,7 @@ jobs:
         make install
     #windows
     - name: windows build & install
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       run: |
         #directory variables
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers


### PR DESCRIPTION
windows-latest has been updated to Windows Server 2022 and VS 2022 today.
https://github.com/actions/virtual-environments/issues/4856
new commits check flow would fail for "vs2019 not found".

There is not a stable ACE for vs2022 yet so we should stay at Win2019+VS2019 right now.
