### PR TITLE
Stranglethorn Fishing Extravaganza - fix gossip condition for Riggle Bassbait

### DIFF
--- a/sql/migrations/20220316220003_world.sql
+++ b/sql/migrations/20220316220003_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220316220003');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220316220003');
+-- Add your query below.
+
+INSERT INTO `conditions` VALUES (7715, 11, 30023, 0, 0, 0, 0);
+INSERT INTO `conditions` VALUES (7716, -1, 7714, 7715, 0, 0, 0);
+UPDATE `gossip_menu` SET `condition_id`=7716 WHERE `entry`=6421 AND `text_id`=7714;
+UPDATE `gossip_menu` SET `condition_id`=0    WHERE `entry`=6421 AND `text_id`=7614;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20220316220003_world.sql
+++ b/sql/migrations/20220316220003_world.sql
@@ -8,9 +8,8 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20220316220003');
 -- Add your query below.
 
-INSERT INTO `conditions` VALUES (7715, 11, 30023, 0, 0, 0, 0);
-INSERT INTO `conditions` VALUES (7716, -1, 7714, 7715, 0, 0, 0);
-UPDATE `gossip_menu` SET `condition_id`=7716 WHERE `entry`=6421 AND `text_id`=7714;
+INSERT INTO `conditions` VALUES (7715, 11, 30056, 1, 0, 0, 0);
+UPDATE `gossip_menu` SET `condition_id`=7715 WHERE `entry`=6421 AND `text_id`=7714;
 UPDATE `gossip_menu` SET `condition_id`=0    WHERE `entry`=6421 AND `text_id`=7614;
 
 -- End of migration.

--- a/src/game/ObjectMgr.h
+++ b/src/game/ObjectMgr.h
@@ -492,6 +492,7 @@ enum PermVariables
     VAR_TOURNAMENT  = 30021,    // last quest completion time
     VAR_TOURN_GOES  = 30022,    // tournament was started already
     VAR_TOURN_OVER  = 30023,    // tournament is over
+    VAR_TOURN_WINNER = 30056,   // for gosssip menu condition
 
     // War Effort shared contributions
     VAR_WE_ALLIANCE_COPPER          = 30024,

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1415,7 +1415,7 @@ struct npc_riggle_bassbaitAI : ScriptedAI
     explicit npc_riggle_bassbaitAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         m_uiTimer = 0;
-
+        sObjectMgr.SetSavedVariable(VAR_TOURN_WINNER, 0, true); // reset on spawn
         npc_riggle_bassbaitAI::Reset();
     }
 
@@ -1492,6 +1492,7 @@ bool QuestRewarded_npc_riggle_bassbait(Player* pPlayer, Creature* pCreature, Que
     {
         sObjectMgr.SetSavedVariable(VAR_TOURNAMENT, time(nullptr), true);
         sObjectMgr.SetSavedVariable(VAR_TOURN_GOES, 0, true);
+        sObjectMgr.SetSavedVariable(VAR_TOURN_WINNER, 1, true);
         pCreature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
         pCreature->MonsterYellToZone(YELL_WINNER, 0, pPlayer);
     }

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1415,7 +1415,12 @@ struct npc_riggle_bassbaitAI : ScriptedAI
     explicit npc_riggle_bassbaitAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         m_uiTimer = 0;
-        sObjectMgr.SetSavedVariable(VAR_TOURN_WINNER, 0, true); // reset on spawn
+
+        auto prevWinTime = sObjectMgr.GetSavedVariable(VAR_TOURNAMENT);
+        if (time(nullptr) - prevWinTime > DAY)
+        {
+            sObjectMgr.SetSavedVariable(VAR_TOURN_WINNER, 0, true);
+        }
         npc_riggle_bassbaitAI::Reset();
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Riggle Bassbait now shows correct gossip due to state of the event.

### Proof
- None

### Issues
- fixes https://github.com/vmangos/core/issues/1434

### How2Test
- event start 40 -> gossip: welcome to booty bay....
- event start 15 -> gossip: welcome to booty bay....
- turn in master angler quest -> gossip: we have a winner for this week...
- restart event 40 (for example when server crashes) -> gossip: we have a winner for this week...
- restart event 40 on next day (or 7 days later) -> gossip: welcome to booty bay....

### Todo / Checklist
- [X] None
