### PR TITLE
STV Fishing Extravaganza: fix Apprentice Angler condition, add some m…

### DIFF
--- a/sql/migrations/20220322181309_world.sql
+++ b/sql/migrations/20220322181309_world.sql
@@ -8,8 +8,21 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20220322181309');
 -- Add your query below.
 
--- Assign script to Jang
-UPDATE `creature_template` SET `script_name`='npc_jang' WHERE `entry`=15078;
+-- New condition: fishing event has no winner
+INSERT INTO `conditions` VALUES (7716, 11, 30056, 0, 0, 0, 0);
+
+-- Events list for Jang
+DELETE FROM `creature_ai_events` WHERE `creature_id`=15078;
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES
+(1507801, 15078, 0, 1, 0, 100, 1, 1000, 1000, 1000, 1000, 1507801, 0, 0, 'Jang - Add Quest Flag'),
+(1507802, 15078, 0, 1, 0, 100, 1, 1000, 1000, 1000, 1000, 1507802, 0, 0, 'Jang - Remove Quest Flag');
+
+DELETE FROM `creature_ai_scripts` WHERE `id` IN (1507801, 1507802);
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1507801, 0, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7715, 'Jang - Add Quest Flag'),
+(1507802, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7716, 'Jang - Remove Quest Flag');
+
+UPDATE `creature_template` SET `ai_name`='EventAI' WHERE `entry`=15078;
 
 -- Master Angler
 UPDATE `locales_quest` SET `OfferRewardText_loc3`='Beeilt Euch und reicht die Fische ein, wenn Ihr den Titel des Meisteranglers erwerben wollt! Ich stehe hier schon seit STUNDEN ohne etwas zu essen! Gebt mir die Viecher schon her!' WHERE `entry`=8193;

--- a/sql/migrations/20220322181309_world.sql
+++ b/sql/migrations/20220322181309_world.sql
@@ -36,6 +36,9 @@ UPDATE `locales_quest` SET `RequestItemsText_loc3`='Aye, Landratte! Bringt mir 1
 
 -- Quest [Could I get a Fishing Flier?] requires fishing skill of 150
 UPDATE `quest_template` SET `RequiredSkillValue`=150 WHERE `entry` IN (8228, 8229);
+-- Quest [Could I get a Fishing Flier?] german locales
+UPDATE `locales_quest` SET `OfferRewardText_loc3`='Es wird diesen Sonntag einen Angelwettbewerb in Booty Bay geben! Hier sind die Regeln für den Wettbewerb, falls Ihr daran teilnehmen möchtet!' WHERE `entry`=8228;
+UPDATE `locales_quest` SET `OfferRewardText_loc3`='Es wird einen Angelwettbewerb in Booty Bay geben, diesen Sonntag! Hier sind die Regeln für Euch!' WHERE `entry`=8229;
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20220322181309_world.sql
+++ b/sql/migrations/20220322181309_world.sql
@@ -21,6 +21,9 @@ UPDATE `locales_quest` SET `RequestItemsText_loc3`='Wir haben zwar schon einen G
 -- Arena Grandmaster
 UPDATE `locales_quest` SET `RequestItemsText_loc3`='Aye, Landratte! Bringt mir 12 Schmuckstücke des hiesigen Meisters der Arena und Ihr seid der neue Großmeister der Arena der Gurabashi! Arrrr!' WHERE `entry`=7838;
 
+-- Quest [Could I get a Fishing Flier?] requires fishing skill of 150
+UPDATE `quest_template` SET `RequiredSkillValue`=150 WHERE `entry` IN (8228, 8229);
+
 -- End of migration.
 END IF;
 END??

--- a/sql/migrations/20220322181309_world.sql
+++ b/sql/migrations/20220322181309_world.sql
@@ -40,6 +40,9 @@ UPDATE `quest_template` SET `RequiredSkillValue`=150 WHERE `entry` IN (8228, 822
 UPDATE `locales_quest` SET `OfferRewardText_loc3`='Es wird diesen Sonntag einen Angelwettbewerb in Booty Bay geben! Hier sind die Regeln für den Wettbewerb, falls Ihr daran teilnehmen möchtet!' WHERE `entry`=8228;
 UPDATE `locales_quest` SET `OfferRewardText_loc3`='Es wird einen Angelwettbewerb in Booty Bay geben, diesen Sonntag! Hier sind die Regeln für Euch!' WHERE `entry`=8229;
 
+-- School of Tastyfish: rare fish drop rate https://classic.wowhead.com/item=19803/brownells-blue-striped-racer#comments
+UPDATE `gameobject_loot_template` SET `ChanceOrQuestChance`=0.2 WHERE `entry`=17280  AND `item` IN (19803, 19805, 19806, 19808);
+
 -- End of migration.
 END IF;
 END??

--- a/sql/migrations/20220322181309_world.sql
+++ b/sql/migrations/20220322181309_world.sql
@@ -1,0 +1,29 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220322181309');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220322181309');
+-- Add your query below.
+
+-- Assign script to Jang
+UPDATE `creature_template` SET `script_name`='npc_jang' WHERE `entry`=15078;
+
+-- Master Angler
+UPDATE `locales_quest` SET `OfferRewardText_loc3`='Beeilt Euch und reicht die Fische ein, wenn Ihr den Titel des Meisteranglers erwerben wollt! Ich stehe hier schon seit STUNDEN ohne etwas zu essen! Gebt mir die Viecher schon her!' WHERE `entry`=8193;
+UPDATE `locales_quest` SET `RequestItemsText_loc3`='Heute zwischen 14 Uhr und 16 Uhr findet der Wettbewerb statt, der den besten Angler unter uns ermitteln wird! Seid die ERSTE PERSON, die mir 40 Leckerfische aus den Fischschwärmen der Gewässer des Schlingendorntals bringt und Ihr werdet der neue Meisterangler sein!$b$bFalls Ihr nicht als Erster hier sein solltet, wird Euch mein Lehrling hier mit Geld für jeden Stapel von 5 Leckerfischen belohnen.$b$bOh und beeilt Euch, Leckerfische werden schnell schlecht!' WHERE `entry`=8193;
+
+-- Apprentice Angler
+UPDATE `locales_quest` SET `RequestItemsText_loc3`='Wir haben zwar schon einen Gewinner ermittelt, aber ich kaufe Euch dennoch Eure restlichen Leckerfische ab. Ich zahl\' Euch einen angemessenen Preis, na, was sagt Ihr!' WHERE `entry`=8194;
+
+-- Arena Grandmaster
+UPDATE `locales_quest` SET `RequestItemsText_loc3`='Aye, Landratte! Bringt mir 12 Schmuckstücke des hiesigen Meisters der Arena und Ihr seid der neue Großmeister der Arena der Gurabashi! Arrrr!' WHERE `entry`=7838;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1506,6 +1506,63 @@ bool QuestRewarded_npc_riggle_bassbait(Player* pPlayer, Creature* pCreature, Que
 }
 
 /*
+ * Jang (Stranglethorn Vale Fishing Extravaganza)
+ */
+
+struct npc_jangAI : ScriptedAI
+{
+    explicit npc_jangAI(Creature* pCreature) : ScriptedAI(pCreature)
+    {
+        m_uiTimer = 0;
+        npc_jangAI::Reset();
+    }
+
+    uint32 m_uiTimer;
+
+    void Reset() override
+    {
+
+    }
+
+    void CheckTournamentState() const
+    {
+
+        if (sObjectMgr.GetSavedVariable(VAR_TOURN_WINNER))
+        {
+            if (!m_creature->IsQuestGiver())
+            {
+                m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
+            }
+        }
+        else
+        {
+            if (m_creature->IsQuestGiver())
+            {
+                m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
+            }
+        }
+    }
+
+    void UpdateAI(uint32 const uiDiff) override
+    {
+        if (m_uiTimer < uiDiff)
+        {
+            CheckTournamentState();
+            m_uiTimer = 1000;
+        }
+        else
+            m_uiTimer -= uiDiff;
+
+        ScriptedAI::UpdateAI(uiDiff);
+    }
+};
+
+CreatureAI* GetAI_npc_jang(Creature* pCreature)
+{
+    return new npc_jangAI(pCreature);
+}
+
+/*
  * Target Dummy
  */
 
@@ -2494,6 +2551,11 @@ void AddSC_npcs_special()
     newscript->Name = "npc_riggle_bassbait";
     newscript->GetAI = &GetAI_npc_riggle_bassbait;
     newscript->pQuestRewardedNPC = &QuestRewarded_npc_riggle_bassbait;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "npc_jang";
+    newscript->GetAI = &GetAI_npc_jang;
     newscript->RegisterSelf();
 
     newscript = new Script;

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1506,63 +1506,6 @@ bool QuestRewarded_npc_riggle_bassbait(Player* pPlayer, Creature* pCreature, Que
 }
 
 /*
- * Jang (Stranglethorn Vale Fishing Extravaganza)
- */
-
-struct npc_jangAI : ScriptedAI
-{
-    explicit npc_jangAI(Creature* pCreature) : ScriptedAI(pCreature)
-    {
-        m_uiTimer = 0;
-        npc_jangAI::Reset();
-    }
-
-    uint32 m_uiTimer;
-
-    void Reset() override
-    {
-
-    }
-
-    void CheckTournamentState() const
-    {
-
-        if (sObjectMgr.GetSavedVariable(VAR_TOURN_WINNER))
-        {
-            if (!m_creature->IsQuestGiver())
-            {
-                m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-            }
-        }
-        else
-        {
-            if (m_creature->IsQuestGiver())
-            {
-                m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-            }
-        }
-    }
-
-    void UpdateAI(uint32 const uiDiff) override
-    {
-        if (m_uiTimer < uiDiff)
-        {
-            CheckTournamentState();
-            m_uiTimer = 1000;
-        }
-        else
-            m_uiTimer -= uiDiff;
-
-        ScriptedAI::UpdateAI(uiDiff);
-    }
-};
-
-CreatureAI* GetAI_npc_jang(Creature* pCreature)
-{
-    return new npc_jangAI(pCreature);
-}
-
-/*
  * Target Dummy
  */
 
@@ -2551,11 +2494,6 @@ void AddSC_npcs_special()
     newscript->Name = "npc_riggle_bassbait";
     newscript->GetAI = &GetAI_npc_riggle_bassbait;
     newscript->pQuestRewardedNPC = &QuestRewarded_npc_riggle_bassbait;
-    newscript->RegisterSelf();
-
-    newscript = new Script;
-    newscript->Name = "npc_jang";
-    newscript->GetAI = &GetAI_npc_jang;
     newscript->RegisterSelf();
 
     newscript = new Script;


### PR DESCRIPTION
…issing quest locales

## 🍰 Pullrequest
 - quest Apprentice Angler becomes available after someone has turned in Master Angler quest
 - add some missing german quest locales (source: wowhead)

https://classic.wowhead.com/npc=15078/jang
https://classic.wowhead.com/quest=8194/apprentice-angler

### Proof
- https://youtu.be/BKsft0yTM84?t=1465

### Issues
- relates https://github.com/vmangos/core/issues/1434

### How2Test
- event start 40
- event start 15
- Jang should have gossip
- turn in master angler quest
- Jang offers quest Apprentice Angler

### Todo / Checklist
- [X] tested
