### PR TITLE
fix BattleGroundMgr::CreateClientVisibleInstanceId() bugs

### DIFF
--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -1140,22 +1140,21 @@ BattleGround * BattleGroundMgr::GetBattleGroundTemplate(BattleGroundTypeId bgTyp
 
 uint32 BattleGroundMgr::CreateClientVisibleInstanceId(BattleGroundTypeId bgTypeId, BattleGroundBracketId bracket_id)
 {
-    // we create here an instanceid, which is just for
-    // displaying this to the client and without any other use..
+    // here, we create an instanceid, which is just for
+    // displaying this to the client and without any other use.
     // the client-instanceIds are unique for each battleground-type
     // the instance-id just needs to be as low as possible, beginning with 1
     // the following works, because std::set is default ordered with "<"
-    // the optimalization would be to use as bitmask std::vector<uint32> - but that would only make code unreadable
-    uint32 lastId = 0;
+    // the optimization would be to use as bitmask std::vector<uint32> - but that would only make code unreadable
+    uint32 lastId = 1;
     ClientBattleGroundIdSet& ids = m_ClientBattleGroundIds[bgTypeId][bracket_id];
-    for (ClientBattleGroundIdSet::const_iterator itr = ids.begin(); itr != ids.end();)
-    {
-        if ((++lastId) != *itr)                             //if there is a gap between the ids, we will break..
-            break;
-        lastId = *itr;
+    for (auto id : ids) {
+        if (lastId == id)
+            lastId++;
+        break;
     }
-    ids.insert(lastId + 1);
-    return lastId + 1;
+    ids.insert(lastId);
+    return lastId;
 }
 
 // create a new battleground that will really be used to play


### PR DESCRIPTION
current implementation's for-loop never incremented its *itr, and also incremented lastId too much
this means that bgs created will have the numbers 1, 3, 3, 3... etcetera, and any bgs after the second will fail to be listed, since the "ids" set can only have unique entries.

**How2Test:**
Create at least 4 battlegrounds of the same type, in the same bracket using at least 4 different accounts.
Use partybots to fill each battleground to max players, or modify the max_players_per_team column in the battleground_templates database table to be = 1.
Alternatively, use the .debug bg ingame GM command, but this will only allow you to assert 1) in my experience, as battlegrounds don't seem to show up in the list that way.
1) Assert that each battleground instance is enumerated correctly in the "enter" popup
2) Assert that each battleground instance is enumerated correctly in the given battlemaster's list of active battlegrounds.