### PR TITLE
Remove extra cooking table from razor hill

### DIFF
--- a/sql/migrations/20220405061736_world.sql
+++ b/sql/migrations/20220405061736_world.sql
@@ -1,0 +1,16 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220405061736');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220405061736');
+-- Add your query below.
+ DELETE FROM `gameobject` WHERE `guid`= 99805;
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20220405061736_world.sql
+++ b/sql/migrations/20220405061736_world.sql
@@ -7,7 +7,11 @@ SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220405061736');
 IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20220405061736');
 -- Add your query below.
+
+
  DELETE FROM `gameobject` WHERE `guid`= 99805;
+ 
+ 
 -- End of migration.
 END IF;
 END??


### PR DESCRIPTION
 
  
- Removed one of two cooking tables that were inside each other on razor hill at .go 316.052399 -4666.528320 17.332701 1

### Proof
-  Razor Hill used to contain 2 cooking tables on vmangos using .gobject near got the guid of both tables.
- Using ReplayCore  with  combined_sniffdb parses that there should only be one cooking table and what GUID it has and it matched one of the cooking tables on vmangos.
- Also checked on Season of mastery that only one cooking table is present.

### How2Test
.go 316.052399 -4666.528320 17.332701 1
.gobject near
Now contains only cooking table with guid of 18076. 
