### PR TITLE
On completion of the Arena event in BRD the mobs spectating the Arena will become neutral

### DIFF
--- a/sql/migrations/20220502012000_world.sql
+++ b/sql/migrations/20220502012000_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220502012000');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220502012000');
+-- Add your query below.
+
+-- set shadowforge senators and arena spectator faction to dark iron dwarves based on sniff data
+UPDATE creature_template SET faction = 54 WHERE entry = 8904 AND patch = 0;
+UPDATE creature_template SET faction = 54 WHERE entry = 8916 AND patch = 0;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;
+

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackrock_depths/blackrock_depths.h
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackrock_depths/blackrock_depths.h
@@ -63,6 +63,7 @@ enum
     EVENT_BAR_PATRONS          = 100,
 
     FACTION_DARK_IRON          = 54,
+    FACTION_ARENA_NEUTRAL      = 15,
 
     NPC_EMPEROR                = 9019,
     NPC_PRINCESS               = 8929,
@@ -128,8 +129,12 @@ enum
 
     NPC_FIREGUARD_DESTROYER    = 8911,
     NPC_ANVILRAGE_OFFICER      = 8895,
+    NPC_ANVILRAGE_SOLDIER      = 8893,
+    NPC_ANVILRAGE_MEDIC        = 8894,
 
     NPC_SHADOWFORGE_SENATOR    = 8904,
+    NPC_SHADOWFORGE_PEASANT    = 8896,
+    NPC_SHADOWFORGE_CITIZEN    = 8902,
     NPC_GRIMSTONE              = 10096,
     NPC_THELDREN               = 16059,
 
@@ -182,5 +187,16 @@ static float const aBarPatrolPositions[2][4] = {
 };
 
 static uint32 const aBarPatrolId[3] = {NPC_FIREGUARD_DESTROYER, NPC_ANVILRAGE_OFFICER, NPC_ANVILRAGE_OFFICER};
+
+struct ArenaCylinder
+{
+    float m_fCenterX;
+    float m_fCenterY;
+    float m_fCenterZ;
+    uint32 m_uiRadius;
+    uint32 m_uiHeight;
+};
+
+static const ArenaCylinder aArenaCrowdVolume = { 595.78f, -188.65f, -38.63f, 69, 10 };
 
 #endif

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackrock_depths/instance_blackrock_depths.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackrock_depths/instance_blackrock_depths.cpp
@@ -260,8 +260,20 @@ struct instance_blackrock_depths : ScriptedInstance
             case 9938:
                 m_uiGoMagnusGUID = pCreature->GetGUID();
                 break;
+			// Arena Crowd
             case NPC_ARENA_SPECTATOR:
+            case NPC_SHADOWFORGE_PEASANT:
+            case NPC_SHADOWFORGE_CITIZEN:
+            case NPC_SHADOWFORGE_SENATOR:
+            case NPC_ANVILRAGE_SOLDIER:
+            case NPC_ANVILRAGE_MEDIC:
+            case NPC_ANVILRAGE_OFFICER:
+                if (pCreature->GetPositionZ() < aArenaCrowdVolume.m_fCenterZ || pCreature->GetPositionZ() > aArenaCrowdVolume.m_fCenterZ + aArenaCrowdVolume.m_uiHeight ||
+                    !pCreature->IsWithinDist2d(aArenaCrowdVolume.m_fCenterX, aArenaCrowdVolume.m_fCenterY, aArenaCrowdVolume.m_uiRadius))
+                    break;
                 m_lArenaSpectatorMobGUIDList.push_back(pCreature->GetGUID());
+                if (m_auiEncounter[TYPE_RING_OF_LAW] == DONE)
+                    pCreature->SetFactionTemporary(FACTION_ARENA_NEUTRAL, TEMPFACTION_RESTORE_RESPAWN);
                 break;
             /*case NPC_PANZOR: m_uiPanzorGUID = pCreature->GetGUID();
                 switch (urand (0,1))
@@ -728,7 +740,7 @@ struct instance_blackrock_depths : ScriptedInstance
                         if (Creature* pCreature = instance->GetCreature(guid))
                         {
                             if (pCreature->IsAlive())
-                                pCreature->SetFactionTemplateId(674);
+                                pCreature->SetFactionTemporary(FACTION_ARENA_NEUTRAL, TEMPFACTION_RESTORE_RESPAWN);
                         }
                     }
                 }


### PR DESCRIPTION
On completion of the Arena event in BRD the mobs spectating the Arena will become neutral. This code is similar to the code from CMangos.

## 🍰 Pullrequest
On completion of the Arena event in BRD the mobs spectating the Arena will become neutral. If they are killed they will respawn with original faction settings. This code is similar to the code from CMangos. https://github.com/cmangos/mangos-classic/blob/master/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/blackrock_depths/instance_blackrock_depths.cpp
### Proof
<!-- Link resources as proof -->
- None

### Issues
- fixes #1495 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Complete ring of law event and see faction of mobs spectating. Also restart server to make sure they maintain their faction.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
