### PR TITLE
Fix mmap_extract.py for python 3

### DIFF
--- a/contrib/mmap/mmap_extract.py
+++ b/contrib/mmap/mmap_extract.py
@@ -32,7 +32,7 @@ class workerThread(threading.Thread):
 
     def run(self):
         name = "Worker for map %u" % (self.mapID)
-        print "++ %s" % (name)
+        print("++ %s" % (name))
         if sys.platform == 'win32':
             stInfo = subprocess.STARTUPINFO()
             stInfo.dwFlags |= 0x00000001
@@ -44,13 +44,13 @@ class workerThread(threading.Thread):
             cFlags = 0
             binName = "./MoveMapGen"
         retcode = subprocess.call([binName, "%u" % (self.mapID),"--silent"], startupinfo=stInfo, creationflags=cFlags)
-        print "-- %s" % (name)
+        print("-- %s" % (name))
 
 if __name__ == "__main__":
     cpu = cpu_count() - 0 # You can reduce the load by putting 1 instead of 0 if you need to free 1 core/cpu
     if cpu < 1:
         cpu = 1
-    print "I will always maintain %u MoveMapGen tasks running in //\n" % (cpu)
+    print("I will always maintain %u MoveMapGen tasks running in //\n" % (cpu))
     while (len(mapList) > 0):
         if (threading.active_count() <= cpu):
             workerThread(mapList.popleft()).start()


### PR DESCRIPTION
## 🍰 Pullrequest
The mmap_extract.py script which helps extract pathfinding maps in a concurrent way was written for Python 2 and will fail on Python 3. Since P2 has been past end of life for over 2 years, it makes sense to update this.

### Proof
<!-- Link resources as proof -->
- [EoL notice](https://www.python.org/doc/sunset-python-2/)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- If you have maps and vmaps extracted, you can copy this script to where those folders are and execute this with `python3` command (assuming Python is installed and in your PATH). It should then work.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
