### PR TITLE
Send invalidate player packet on race change

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -20951,7 +20951,7 @@ bool Player::ChangeRace(uint8 newRace)
     m_DbSaveDisabled = true;
     if (!ChangeSpellsForRace(oldRace, newRace))
     {
-        CHANGERACE_ERR("Impossible de changer les spells.");
+        CHANGERACE_ERR("Cannot change spells.");
         return false;
     }
 
@@ -20963,17 +20963,17 @@ bool Player::ChangeRace(uint8 newRace)
 
     if (!ChangeReputationsForRace(oldRace, newRace))
     {
-        CHANGERACE_ERR("Impossible de changer les reputations.");
+        CHANGERACE_ERR("Cannot change reputations.");
         return false;
     }
     if (!ChangeQuestsForRace(oldRace, newRace))
     {
-        CHANGERACE_ERR("Impossible de changer les quetes.");
+        CHANGERACE_ERR("Cannot change quests.");
         return false;
     }
     if (!ChangeItemsForRace(oldRace, newRace))
     {
-        CHANGERACE_ERR("Impossible de changer les items.");
+        CHANGERACE_ERR("Cannot change items.");
         return false;
     }
     /*
@@ -20998,11 +20998,12 @@ bool Player::ChangeRace(uint8 newRace)
             SetHomebindToLocation(WorldLocation(1, 1633.33f, -4439.11f, 15.7588f, 0.0f), 1637);
         }
     }
-    // Sauvegarde dans ObjectMgr aussi (sinon mauvaise faction prise en compte dans la distrib PvP)
-    if (PlayerCacheData* data = sObjectMgr.GetPlayerDataByGUID(GetGUIDLow()))
-        data->uiRace = newRace;
+
+    ObjectGuid guid = GetObjectGuid();
 
     m_session->LogoutPlayer(false);
+    sWorld.InvalidatePlayerDataToAllClient(guid);
+
     return true;
 }
 


### PR DESCRIPTION
Also remove redundant call to updating player cache (is called again in LogoutPlayer()), and change some French log lines to English.

## 🍰 Pullrequest
Sends the SMSG_INVALIDATE_PLAYER packet when race changing. Mostly is a GM command, but can be utilized as a custom NPC feature. This is only really needed to support 1.14 clients where the race is cached.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Using two clients, you can use an addon like WowLua (on 1.14 client) to call `print(GetPlayerInfoByGUID(UnitGUID("target")))` to get API info for targeted player. Conduct a race change on the targeted player and log back in, recall this Lua print line and you'll see the race stays the same before this change, but afterwards sends the new updated race.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
