### PR TITLE
Send proper exit code on honor maintenance restart

### DIFF
--- a/src/game/HonorMgr.cpp
+++ b/src/game/HonorMgr.cpp
@@ -582,7 +582,7 @@ void HonorMaintenancer::CheckMaintenanceDay()
     {
         // Restart 15 minutes after honor weekend by server time
         if (sWorld.getConfig(CONFIG_BOOL_AUTO_HONOR_RESTART))
-            sWorld.ShutdownServ(900, SHUTDOWN_MASK_RESTART, SHUTDOWN_EXIT_CODE);
+            sWorld.ShutdownServ(900, SHUTDOWN_MASK_RESTART, RESTART_EXIT_CODE);
         else
             sLog.outString("HonorMaintenancer: Server needs to be restarted to perform honor rank calculations.");
 


### PR DESCRIPTION
## 🍰 Pullrequest
Right now the weekly honor maintenance restart schedules a restart (not a shutdown), but sends the shutdown exit code. If you have a shell restarter script listening on the specific exit codes, this may cause behavior of not restarting the server. Instead, if we're scheduling a restart, we should send the restart exit code so that scripts expecting that code know what to do.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
