### PR TITLE
Fix quest Extinguishing the Idol after it was failed once

### DIFF
--- a/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
+++ b/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
@@ -96,6 +96,14 @@ struct npc_belnistraszAI : public npc_escortAI
         m_uiFrostNovaTimer = 6000;
     }
 
+    void JustDied(Unit* unit) override
+    {
+        m_uiRitualPhase = 0;
+        m_uiRitualTimer = 1000;
+        m_bAggro = false;
+        npc_escortAI::JustDied(unit);
+    }
+
     void AttackedBy(Unit* pAttacker) override
     {
         if (HasEscortState(STATE_ESCORT_PAUSED))


### PR DESCRIPTION
## 🍰 Pullrequest
Reset all variables of quest https://classic.wowhead.com/quest=3525/extinguishing-the-idol when it was failed once.

### Proof
- None

### Issues
- None

### How2Test
- accept quest 3525
- follow Belnistrasz until he starts his ritual
- let Belnistrasz die and fail quest
- .respawn Belnistrasz 
- reaccept quest -> quest should work and progress like before

### Todo / Checklist
- [X] None
