### PR TITLE
Corrections for spell Haunting Spirits and Haunting Phantoms

### DIFF
--- a/sql/migrations/20220617125040_world.sql
+++ b/sql/migrations/20220617125040_world.sql
@@ -12,7 +12,7 @@ INSERT INTO `migrations` VALUES ('20220617125040');
 DELETE FROM `spell_effect_mod` WHERE `Id`=7057;
 
 -- Remove loot from Haunting Spirits
-UPDATE `creature_template` SET `gold_min`=0 AND `gold_max`=0 WHERE `entry`=4958;
+UPDATE `creature_template` SET `gold_min`=0,`gold_max`=0 WHERE `entry`=4958;
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20220617125040_world.sql
+++ b/sql/migrations/20220617125040_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220617125040');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220617125040');
+-- Add your query below.
+
+-- Remove effect mod of Haunting Spirits which caused to many ticks
+DELETE FROM `spell_effect_mod` WHERE `Id`=7057;
+
+-- Remove loot from Haunting Spirits
+UPDATE `creature_template` SET `gold_min`=0 AND `gold_max`=0 WHERE `entry`=4958;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20220617125040_world.sql
+++ b/sql/migrations/20220617125040_world.sql
@@ -11,8 +11,8 @@ INSERT INTO `migrations` VALUES ('20220617125040');
 -- Remove effect mod of Haunting Spirits which caused to many ticks
 DELETE FROM `spell_effect_mod` WHERE `Id`=7057;
 
--- Remove loot from Haunting Spirits
-UPDATE `creature_template` SET `gold_min`=0,`gold_max`=0 WHERE `entry`=4958;
+-- Remove (money) loot from Haunting Spirits, Wrath Phantom, Spiteful Phantom
+UPDATE `creature_template` SET `gold_min`=0,`gold_max`=0 WHERE `entry` IN(4958,10388,10389);
 
 -- End of migration.
 END IF;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1733,6 +1733,13 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                         }
                         return;
                     }
+                    case 7057: // Haunting Spirits
+                    {
+                        m_isPeriodic = true;
+                        m_modifier.periodictime = 5 * IN_MILLISECONDS; // expected to tick with 5 sec period
+                        m_periodicTimer = m_modifier.periodictime;
+                        return;
+                    }
                     case 16336: // Haunting Phantoms
                     {
                         m_isPeriodic = true;
@@ -6400,9 +6407,13 @@ void Aura::PeriodicDummyTick()
                     return;
                 }
                 case 7057:                                  // Haunting Spirits
-                    if (roll_chance_i(33))
-                        target->CastSpell(target, m_modifier.m_amount, true, nullptr, this);
+                {
+                    if (roll_chance_i(5)) // 4 spawns over 5 minutes
+                    {
+                        target->CastSpell(target, 7067, true, nullptr, this); // Summon Haunting Spirit
+                    }
                     return;
+                }
                 case 16336:                                 // Haunting Phantoms
                 {
                     if (urand(0,1))

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1733,17 +1733,11 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                         }
                         return;
                     }
-                    case 7057: // Haunting Spirits
-                    {
-                        m_isPeriodic = true;
-                        m_modifier.periodictime = 5 * IN_MILLISECONDS; // expected to tick with 5 sec period
-                        m_periodicTimer = m_modifier.periodictime;
-                        return;
-                    }
+                    case 7057:  // Haunting Spirits
                     case 16336: // Haunting Phantoms
                     {
                         m_isPeriodic = true;
-                        m_modifier.periodictime = urand(30, 90) * IN_MILLISECONDS;
+                        m_modifier.periodictime = 5 * IN_MILLISECONDS; // expected to tick with 5 sec period
                         return;
                     }
                     case 26234:                             // Ragnaros Submerge Visual
@@ -6408,7 +6402,7 @@ void Aura::PeriodicDummyTick()
                 }
                 case 7057:                                  // Haunting Spirits
                 {
-                    if (roll_chance_i(5)) // 4 spawns over 5 minutes
+                    if (roll_chance_i(5))
                     {
                         target->CastSpell(target, 7067, true, nullptr, this); // Summon Haunting Spirit
                     }
@@ -6416,10 +6410,13 @@ void Aura::PeriodicDummyTick()
                 }
                 case 16336:                                 // Haunting Phantoms
                 {
-                    if (urand(0,1))
-                        target->CastSpell(target, 16334, true); // Summon Spiteful Phantom
-                    else
-                        target->CastSpell(target, 16335, true); // Summon Wrath Phantom
+                    if (roll_chance_i(5))
+                    {
+                        if (urand(0, 1))
+                            target->CastSpell(target, 16334, true); // Summon Spiteful Phantom
+                        else
+                            target->CastSpell(target, 16335, true); // Summon Wrath Phantom
+                    }
                     return;
                 }
                 case 24596:                                 // Intoxicating Venom


### PR DESCRIPTION
## 🍰 Pullrequest
Fix tick amount of spell Haunting Spirits and Haunting Phantoms.
Remove money loot from summoned spirits and phantoms.

### Proof
Haunting Spirits: _I saw 4 spawns over 5 minutes_
every 5 seconds over 5 minutes results in total of 60 ticks
4/60 = 0,06 -> about 5%
Haunting Phantoms: use same chance like for Haunting Spirits

### Issues
- fixes https://github.com/vmangos/core/issues/866
- fixes https://github.com/vmangos/core/issues/865 except health of phantoms might still be wrong

### How2Test
- .learn 7057
- .learn 16336
- cast spell on enemy and check spawn rate & loot