### PR TITLE
Fix quest reward text for The Balance of Light and Shadow

### DIFF
--- a/sql/migrations/20220624171555_world.sql
+++ b/sql/migrations/20220624171555_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220624171555');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220624171555');
+-- Add your query below.
+
+UPDATE `quest_template` SET `OfferRewardText` = 'Your tenacity and courage are astounding, $G priest:priestess;. You have earned the right to hold the Splinter of Nordrassil. Only one task remains: The Eye of Shadow must be recovered. Scour the world.' WHERE `entry` = 7622;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
The quest reward text for this quest is missing a gender check and always refer to player as female priestess. This adds the missing gender check.

### Proof
<!-- Link resources as proof -->
- [WoW Classic](https://user-images.githubusercontent.com/14080595/175431537-a4da60e1-16fa-4923-afa0-c56b64935663.png)
- https://www.youtube.com/watch?v=fSwVpfdqToY
- [WoW Classic](https://user-images.githubusercontent.com/14080595/175431658-168ea9e3-805b-43e2-9ee4-8f821f0d93f8.png)
- https://www.youtube.com/watch?v=uOxnz-avHqI

### Issues
- fixes unreported issue

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Add quest, complete quest, check reward text. Change gender, check reward text again.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
