### PR TITLE
SFK: Improve Arugal intro event

### DIFF
--- a/sql/migrations/20220721212432_world.sql
+++ b/sql/migrations/20220721212432_world.sql
@@ -1,0 +1,35 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220721212432');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220721212432');
+-- Add your query below.
+
+-- SFK: Arugal intro script
+DELETE FROM `generic_scripts` WHERE `id`=10000;
+INSERT INTO `generic_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(10000, 0, 0, 4, 46, 134217728, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Invisible'),
+(10000, 0, 0, 37, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Set Instance Data'),
+(10000, 5, 0, 4, 46, 134217728, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Visible'),
+(10000, 5, 0, 15, 10418, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Cast Teleport'),
+(10000, 9, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Emote Talk'),
+(10000, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1456, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Say Text 0'),
+(10000, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5680, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Say Text 1'),
+(10000, 12, 0, 1, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Emote Point'),
+(10000, 16, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Emote Talk'),
+(10000, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5681, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Say Text 2'),
+(10000, 18, 0, 28, 7, 0, 0, 0, 4444, 20, 8, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Deathstalker Vincent Set Stand State to Dead'),
+(10000, 18, 0, 1, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Emote Laugh'),
+(10000, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5682, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Say Text 3'),
+(10000, 24, 0, 15, 7741, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Cast Teleport'),
+(10000, 25, 0, 18, 22, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Despawn');
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20220721212432_world.sql
+++ b/sql/migrations/20220721212432_world.sql
@@ -12,7 +12,6 @@ INSERT INTO `migrations` VALUES ('20220721212432');
 DELETE FROM `generic_scripts` WHERE `id`=10000;
 INSERT INTO `generic_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
 (10000, 0, 0, 4, 46, 134217728, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Invisible'),
-(10000, 0, 0, 37, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Set Instance Data'),
 (10000, 5, 0, 4, 46, 134217728, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Visible'),
 (10000, 5, 0, 15, 10418, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Cast Teleport'),
 (10000, 9, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Emote Talk'),
@@ -25,7 +24,8 @@ INSERT INTO `generic_scripts` (`id`, `delay`, `priority`, `command`, `datalong`,
 (10000, 18, 0, 1, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Emote Laugh'),
 (10000, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5682, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Say Text 3'),
 (10000, 24, 0, 15, 7741, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Cast Teleport'),
-(10000, 25, 0, 18, 22, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Despawn');
+(10000, 25, 0, 18, 22, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Arugal Despawn'),
+(10000, 26, 0, 37, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SFK Intro - Set Instance Data');
 
 -- End of migration.
 END IF;

--- a/src/scripts/eastern_kingdoms/silverpine_forest/shadowfang_keep/instance_shadowfang_keep.cpp
+++ b/src/scripts/eastern_kingdoms/silverpine_forest/shadowfang_keep/instance_shadowfang_keep.cpp
@@ -37,7 +37,6 @@ enum
     NPC_CMD_SPRINGVALE      = 4278,
     NPC_ASH                 = 3850,
     NPC_ADA                 = 3849,
-    NPC_ARUGAL              = 10000,                        //"Arugal" says intro text
     NPC_ARCHMAGE_ARUGAL     = 4275,                         //"Archmage Arugal" does Fenrus event
     NPC_FENRUS              = 4274,                         //used to summon Arugal in Fenrus event
     NPC_VINCENT             = 4444,                         //Vincent should be "dead" is Arugal is done the intro already
@@ -120,11 +119,6 @@ struct instance_shadowfang_keep : public ScriptedInstance
                 break;
             case NPC_FENRUS:
                 m_uiFenrusGUID = pCreature->GetGUID();
-                break;
-            case NPC_ARUGAL:
-                //if Arugal has done the intro, make him invisible!
-                if (m_auiEncounter[4] == DONE)
-                    pCreature->SetVisibility(VISIBILITY_OFF);
                 break;
             case NPC_VINCENT:
                 m_uiVincentGUID = pCreature->GetGUID();


### PR DESCRIPTION
## 🍰 Pullrequest
- ~~fix Arugal not being invisible before script starts~~
- adapt timers for his script actions
- use correct spell for visual teleporting https://classic.wowhead.com/npc=10000/arugal#abilities
- despawn Arugal in script instead of making him invisible in cpp 

Note: making Vincent "die" during the script is different from the video, but was part of the script before - so I kept it in.

### Proof
- https://youtu.be/6P2ZrJzuBdY?t=633

### Issues
- None

### How2Test
- enter Shadowfang Keep and watch intro event  at the entrance
- to ensure that the event only happens once and Arugal is despawned: re-enter or relog in dungeon

### Todo / Checklist
- [X] None