### PR TITLE
STV: Fix assignment of Riggle Bassbait texts

### DIFF
--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1457,9 +1457,9 @@ enum
 
     EVENT_TOURNAMENT        = 15,
 
-    YELL_BEGIN              = 10608, // Let the Fishing Tournament BEGIN!
-    YELL_WINNER             = 10609, // We have a winner! $n has won FIRST PLACE in the tournament!
-    YELL_OVER               = 10610, // And the Tastyfish have gone for the week! I will remain for another hour to allow you to turn in your fish!
+    YELL_BEGIN              = 10608,
+    YELL_WINNER             = 10610,
+    YELL_OVER               = 10609
 };
 
 struct npc_riggle_bassbaitAI : ScriptedAI


### PR DESCRIPTION
## 🍰 Pullrequest
Wrong broadcast text was used when master angler quest was turned in:
_And the Tastyfish have gone for the week! I will remain for another hour to allow you to turn in your fish!_

### Todo / Checklist
- [X] tested changes
