### PR TITLE
STV - improvements for Riggle Bassbait annoucements

### DIFF
--- a/src/game/ObjectMgr.h
+++ b/src/game/ObjectMgr.h
@@ -490,10 +490,10 @@ enum PermVariables
     EVENT_IND_WATER = 3,
 
     // Stranglethorn Fishing Extravaganza support
-    VAR_TOURNAMENT  = 30021,    // last quest completion time
-    VAR_TOURN_GOES  = 30022,    // tournament was started already
-    VAR_TOURN_OVER  = 30023,    // tournament is over
-    VAR_TOURN_WINNER = 30056,   // for gosssip menu condition
+    VAR_STV_FISHING_PREV_WIN_TIME         = 30021, // last master angler quest completion time
+    VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN  = 30022, // announce tournament start
+    VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN = 30023, // announce tournament over
+    VAR_STV_FISHING_HAS_WINNER            = 30056, // used for gosssip menu condition
 
     // War Effort shared contributions
     VAR_WE_ALLIANCE_COPPER          = 30024,

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1513,6 +1513,9 @@ struct npc_riggle_bassbaitAI : ScriptedAI
                 m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
             }
 
+            // only progress to announce over when pools have been despawned
+            if (sGameEventMgr.IsActiveEvent(EVENT_TOURNAMENT)) return;
+
             auto announceOver = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN);
 
             if (!announceOver) return;

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1468,10 +1468,13 @@ struct npc_riggle_bassbaitAI : ScriptedAI
     {
         m_uiTimer = 0;
 
-        auto prevWinTime = sObjectMgr.GetSavedVariable(VAR_TOURNAMENT);
+        auto prevWinTime = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_PREV_WIN_TIME);
         if (time(nullptr) - prevWinTime > DAY)
         {
-            sObjectMgr.SetSavedVariable(VAR_TOURN_WINNER, 0, true);
+            // reset all after 1 day
+            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN, 1, true);
+            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 0, true);
+            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_HAS_WINNER, 0, true);
         }
         npc_riggle_bassbaitAI::Reset();
     }
@@ -1491,19 +1494,21 @@ struct npc_riggle_bassbaitAI : ScriptedAI
         {
             if (!m_creature->IsQuestGiver())
             {
-                auto prevWinTime = sObjectMgr.GetSavedVariable(VAR_TOURNAMENT);
+                auto prevWinTime = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_PREV_WIN_TIME);
 
                 if (time(nullptr) - prevWinTime > DAY)
                 {
                     m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
 
-                    auto startedAlready = sObjectMgr.GetSavedVariable(VAR_TOURN_GOES);
+                    auto announceBegin = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN);
 
-                    if (startedAlready) return;
+                    if (!announceBegin) return;
 
                     m_creature->MonsterYellToZone(YELL_BEGIN);
-                    sObjectMgr.SetSavedVariable(VAR_TOURN_GOES, 1, true);
-                    sObjectMgr.SetSavedVariable(VAR_TOURN_OVER, 0, true);
+                    // store announce begin done
+                    sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN, 0, true);
+                    // store enable over annoucement
+                    sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 1, true);
                 }
             }
         }
@@ -1512,15 +1517,15 @@ struct npc_riggle_bassbaitAI : ScriptedAI
             if (m_creature->IsQuestGiver())
             {
                 m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-                sObjectMgr.SetSavedVariable(VAR_TOURN_GOES, 0, true);
             }
 
-            auto isOver = sObjectMgr.GetSavedVariable(VAR_TOURN_OVER);
+            auto announceOver = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN);
 
-            if (isOver) return;
+            if (!announceOver) return;
 
             m_creature->MonsterYellToZone(YELL_OVER);
-            sObjectMgr.SetSavedVariable(VAR_TOURN_OVER, 1, true);
+            // store announce over done
+            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 0, true);
         }
     }
 
@@ -1547,9 +1552,8 @@ bool QuestRewarded_npc_riggle_bassbait(Player* pPlayer, Creature* pCreature, Que
 {
     if (pQuest->GetQuestId() == QUEST_MASTER_ANGLER)
     {
-        sObjectMgr.SetSavedVariable(VAR_TOURNAMENT, time(nullptr), true);
-        sObjectMgr.SetSavedVariable(VAR_TOURN_GOES, 0, true);
-        sObjectMgr.SetSavedVariable(VAR_TOURN_WINNER, 1, true);
+        sObjectMgr.SetSavedVariable(VAR_STV_FISHING_PREV_WIN_TIME, time(nullptr), true);
+        sObjectMgr.SetSavedVariable(VAR_STV_FISHING_HAS_WINNER, 1, true);
         pCreature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
         pCreature->MonsterYellToZone(YELL_WINNER, 0, pPlayer);
     }

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1467,7 +1467,6 @@ struct npc_riggle_bassbaitAI : ScriptedAI
     explicit npc_riggle_bassbaitAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         m_uiTimer = 0;
-
         auto prevWinTime = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_PREV_WIN_TIME);
         if (time(nullptr) - prevWinTime > DAY)
         {
@@ -1496,15 +1495,14 @@ struct npc_riggle_bassbaitAI : ScriptedAI
             {
                 m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
             }
-            auto announceBegin = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN);
-
-            if (!announceBegin) return;
-
-            m_creature->MonsterYellToZone(YELL_BEGIN);
-            // store announce begin done
-            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN, 0, true);
-            // store enable over annoucement
-            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 1, true);
+            if (sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN))
+            {
+                m_creature->MonsterYellToZone(YELL_BEGIN);
+                // store announce begin done
+                sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN, 0, true);
+                // store enable over annoucement
+                sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 1, true);
+            }
         }
         else
         {
@@ -1512,17 +1510,13 @@ struct npc_riggle_bassbaitAI : ScriptedAI
             {
                 m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
             }
-
-            // only progress to announce over when pools have been despawned
-            if (sGameEventMgr.IsActiveEvent(EVENT_TOURNAMENT)) return;
-
-            auto announceOver = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN);
-
-            if (!announceOver) return;
-
-            m_creature->MonsterYellToZone(YELL_OVER);
-            // store announce over done
-            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 0, true);
+            // only progress to announce over when pools have been despawned (EVENT_TOURNAMENT is over)
+            if (!sGameEventMgr.IsActiveEvent(EVENT_TOURNAMENT) && sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN))
+            {
+                m_creature->MonsterYellToZone(YELL_OVER);
+                // store announce over done
+                sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 0, true);
+            }
         }
     }
 

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -1490,27 +1490,21 @@ struct npc_riggle_bassbaitAI : ScriptedAI
     {
         // complex system to keep things safe in case of crashes/restarts during the event
         // yells should not be repeatable, quest credit should go to a single person per week
-        if (sGameEventMgr.IsActiveEvent(EVENT_TOURNAMENT))
+        if (sGameEventMgr.IsActiveEvent(EVENT_TOURNAMENT) && !sObjectMgr.GetSavedVariable(VAR_STV_FISHING_HAS_WINNER))
         {
             if (!m_creature->IsQuestGiver())
             {
-                auto prevWinTime = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_PREV_WIN_TIME);
-
-                if (time(nullptr) - prevWinTime > DAY)
-                {
-                    m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-
-                    auto announceBegin = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN);
-
-                    if (!announceBegin) return;
-
-                    m_creature->MonsterYellToZone(YELL_BEGIN);
-                    // store announce begin done
-                    sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN, 0, true);
-                    // store enable over annoucement
-                    sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 1, true);
-                }
+                m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
             }
+            auto announceBegin = sObjectMgr.GetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN);
+
+            if (!announceBegin) return;
+
+            m_creature->MonsterYellToZone(YELL_BEGIN);
+            // store announce begin done
+            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_EVENT_BEGIN, 0, true);
+            // store enable over annoucement
+            sObjectMgr.SetSavedVariable(VAR_STV_FISHING_ANNOUNCE_POOLS_DESPAN, 1, true);
         }
         else
         {


### PR DESCRIPTION
## 🍰 Pullrequest
Fix Riggle Bassbait announcing _"And the Tastyfish have gone for the week! I will remain for another hour to allow you to turn in your fish!"_ when event 40 starts at 13:00 and event 15 was not active
Some improvements based on https://github.com/azerothcore/azerothcore-wotlk/pull/12506

### Proof
- None

### Issues
- None

### How2Test
- .event start 40 (the crew, spawns npc's)
- .event start 15 (quests and pools) -> Riggle should announce _"Let the Fishing Tournament BEGIN!"_
- .event stop 15 -> Riggle should announce _"...Tastyfish have gone for the week..."_

### Todo / Checklist
- [X] tested
