### PR TITLE
Hourly bell: Dwarf horn sound should only play once

### DIFF
--- a/sql/migrations/20220820150248_world.sql
+++ b/sql/migrations/20220820150248_world.sql
@@ -1,0 +1,28 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220820150248');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220820150248');
+-- Add your query below.
+
+-- Missing alliance bell spawns
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES
+(18178,176573,1,-3667.09,-4754,1.80047,2.26893,0,0,0.906307,0.422619,900,900,100,1,0,0,0,10),    -- Theramore Lighthouse
+(18180,176573,0,-8463.69,592.138,94.8484,0.401425,0,0,0.199368,0.979925,900,900,100,1,0,0,0,10), -- Stormwind (Dwarven District)
+(18182,176573,0,-8998.99,852.309,105.596,0.872664,0,0,0.422618,0.906308,900,900,100,1,0,0,0,10); -- Stormwind (Mage Quarter)
+
+-- Link to hourly bell event
+INSERT INTO `game_event_gameobject` (`guid`, `event`) VALUES
+(18178,78),
+(18180,78),
+(18182,78);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20220820150248_world.sql
+++ b/sql/migrations/20220820150248_world.sql
@@ -8,17 +8,22 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20220820150248');
 -- Add your query below.
 
+-- New bell guids
+SET @BELL1 := 60000;
+SET @BELL2 := 60001;
+SET @BELL3 := 60002;
+
 -- Missing alliance bell spawns
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES
-(18178,176573,1,-3667.09,-4754,1.80047,2.26893,0,0,0.906307,0.422619,900,900,100,1,0,0,0,10),    -- Theramore Lighthouse
-(18180,176573,0,-8463.69,592.138,94.8484,0.401425,0,0,0.199368,0.979925,900,900,100,1,0,0,0,10), -- Stormwind (Dwarven District)
-(18182,176573,0,-8998.99,852.309,105.596,0.872664,0,0,0.422618,0.906308,900,900,100,1,0,0,0,10); -- Stormwind (Mage Quarter)
+(@BELL1,176573,1,-3667.09,-4754,1.80047,2.26893,0,0,0.906307,0.422619,900,900,100,1,0,0,0,10),    -- Theramore Lighthouse
+(@BELL2,176573,0,-8463.69,592.138,94.8484,0.401425,0,0,0.199368,0.979925,900,900,100,1,0,0,0,10), -- Stormwind (Dwarven District)
+(@BELL3,176573,0,-8998.99,852.309,105.596,0.872664,0,0,0.422618,0.906308,900,900,100,1,0,0,0,10); -- Stormwind (Mage Quarter)
 
 -- Link to hourly bell event
 INSERT INTO `game_event_gameobject` (`guid`, `event`) VALUES
-(18178,78),
-(18180,78),
-(18182,78);
+(@BELL1,78),
+(@BELL2,78),
+(@BELL3,78);
 
 -- End of migration.
 END IF;

--- a/src/scripts/world/go_scripts.cpp
+++ b/src/scripts/world/go_scripts.cpp
@@ -236,6 +236,7 @@ enum BellHourlySoundFX
     BELLTOLLALLIANCE   = 6594, // Stormwind
     BELLTOLLNIGHTELF   = 6674, // Darnassus
     BELLTOLLDWARFGNOME = 7234, // Ironforge
+    LIGHTHOUSEFOGHORN  = 7197  // Lighthouses (TODO: not implememted yet)
 };
 
 enum BellHourlySoundZones
@@ -262,8 +263,7 @@ enum BellHourlyMisc
 {
     GAME_EVENT_HOURLY_BELLS = 78,
     EVENT_RING_BELL = 1,
-    EVENT_RESET = 2,
-    EVENT_TIME = 3
+    EVENT_TIME = 2
 };
 
 struct go_bells : public GameObjectAI
@@ -336,10 +336,14 @@ struct go_bells : public GameObjectAI
                     time(&rawtime);
                     struct tm * timeinfo = localtime(&rawtime);
                     uint8 _rings = (timeinfo->tm_hour) % 12;
-                    if (_rings == 0) // 00:00 and 12:00
+                    _rings = (_rings == 0) ? 12 : _rings; // 00:00 and 12:00
+
+                    // Dwarf hourly horn should only play a single time, each time the next hour begins.
+                    if (_soundId == BELLTOLLDWARFGNOME)
                     {
-                        _rings = 12;
+                        _rings = 1;
                     }
+
                     // Schedule ring event
                     for (auto i = 0; i < _rings; ++i)
                         m_events.ScheduleEvent(EVENT_RING_BELL, Seconds(i * 4 + 1));


### PR DESCRIPTION
## 🍰 Pullrequest
Dwarf hourly horn should only play a single time, each time the next hour begins.
Small cleanup.

[update]
add some missing bell gameobject spawns (source sniff db)

### Proof
- https://github.com/azerothcore/azerothcore-wotlk/issues/11328
- https://github.com/azerothcore/azerothcore-wotlk/pull/12795

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
