### PR TITLE
Correct graveyard factions and and invalid graveyards.

### DIFF
--- a/sql/migrations/20220907004536_world.sql
+++ b/sql/migrations/20220907004536_world.sql
@@ -1,0 +1,62 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220907004536');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220907004536');
+-- Add your query below.
+
+
+-- Duskwood, Darkshire GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=3 AND `ghost_zone`=10;
+-- Loch Modan, Thelsamar GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=6 AND `ghost_zone`=38;
+-- Delete Horde Badlands, Graveyard NE GY for Loch Modan
+DELETE FROM `game_graveyard_zone` WHERE  `id`=8 AND `ghost_zone`=38;
+-- The Barrens, The Crossroads GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=10 AND `ghost_zone`=17;
+-- Darkshore, Auberdine GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=35 AND `ghost_zone`=148;
+-- Badlands, Kargath GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=103 AND `ghost_zone`=3;
+-- Delete invalid Horde Redridge Mountains, Lakeshire GY for Duskwood
+DELETE FROM `game_graveyard_zone` WHERE  `id`=104 AND `ghost_zone`=10;
+-- Elwynn Forest, Goldshire GY for The Stockades is Alliance only
+UPDATE `game_graveyard_zone` SET `faction`='469' WHERE  `id`=106 AND `ghost_zone`=717;
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('854', '717', '67', '0');
+-- Delete invalid GY for Champions' Hall, use Elwynn Forest, Goldshire GY instead
+DELETE FROM `game_graveyard_zone` WHERE  `id`=107 AND `ghost_zone`=2918;
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('106', '2918', '469', '0');
+-- Swamp of Sorrows, Stonard GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=108 AND `ghost_zone`=8;
+-- Hillsbrad Foothills, Southshore GY is Alliance only, even for SFK
+UPDATE `game_graveyard_zone` SET `faction`='469' WHERE  `id`=149 AND `ghost_zone`=209;
+-- The Barrens, Camp Taurajo GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=229 AND `ghost_zone`=17;
+-- Feralas, Camp Mojache GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=310 AND `ghost_zone`=357;
+-- Delete Feralas, Feathermoon Stronghold GY for The Temple of Atal'Hakkar
+DELETE FROM `game_graveyard_zone` WHERE  `id`=309 AND `ghost_zone`=1477;
+-- Feralas, Feathermoon Stronghold GY is neutral
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=309 AND `ghost_zone`=357;
+-- Thousand Needles, Shimmering Flats GY is Horde only
+UPDATE `game_graveyard_zone` SET `faction`='67' WHERE  `id`=329 AND `ghost_zone`=400;
+-- Delete Alliance Blasted Lands, Dreadmaul Hold GY for Swamp of Sorrows
+DELETE FROM `game_graveyard_zone` WHERE  `id`=370 AND `ghost_zone`=8;
+-- Delete invalid Horde Darkshore, Twilight Vale GY for Teldrassil and Darnassus
+DELETE FROM `game_graveyard_zone` WHERE  `id`=469 AND `ghost_zone`=141;
+DELETE FROM `game_graveyard_zone` WHERE  `id`=469 AND `ghost_zone`=1657;
+-- Wetlands, Baradin Bay GY is Alliance only
+UPDATE `game_graveyard_zone` SET `faction`='469' WHERE  `id`=489 AND `ghost_zone`=11;
+-- Delete invalid Alliance Ashenvale, Kargathia GY for The Barrens
+DELETE FROM `game_graveyard_zone` WHERE  `id`=512 AND `ghost_zone`=17;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Corrects all graveyard factions in the game that didn't have correct faction set.
Last remaining invalid graveyards were deleted and correct graveyard added for zones affected.
### Proof
<!-- Link resources as proof -->

I checked every single graveyard on classic by suicide a ton of times on both factions.
My tests resulted in the information below, which this commit is based on:

|ID |AreaName_lang                             |Loc[0]    |Loc[1]    |Loc[2]    |Continent|Facing  |faction |
|---|------------------------------------------|----------|----------|----------|---------|--------|--------|
|3  |Duskwood, Darkshire                       |-10774.263|-1189.6719|33.149426 |0        |220.378 |neutral |
|4  |Westfall, Sentinel Hill                   |-10546.9  |1197.24   |31.7263   |0        |143.1   |neutral |
|6  |Loch Modan, Thelsamar                     |-5351.229 |-2881.5823|340.94235 |0        |273.825 |neutral |
|7  |Wetlands, Crossroads                      |-3289.1238|-2435.9912|18.59659  |0        |144.778 |neutral |
|8  |Badlands, Graveyard NE                    |-6289.911 |-3493.108 |251.48277 |0        |160     |neutral |
|10 |The Barrens, The Crossroads               |-592.60144|-2523.4924|91.78803  |1        |70.3032 |neutral |
|31 |Desolace, Ghost Walker Post               |-1443.488 |1973.3696 |85.490715 |1        |0       |neutral |
|32 |Durotar, Razor Hill                       |233.458   |-4793.73  |10.1881   |1        |12.1862 |neutral |
|34 |Mulgore, Red Cloud Mesa                   |-2944.5564|-153.21503|65.786026 |1        |108.225 |horde   |
|35 |Darkshore, Auberdine                      |6739.19   |209.9926  |23.284561 |1        |279.001 |neutral |
|36 |Deadwind Pass, Morgan's Plot              |-11110.377|-1833.2407|71.8642   |0        |180.712 |neutral |
|39 |Thousand Needles, The Great Lift          |-4656     |-1765     |-41       |1        |272.025 |neutral |
|70 |Silithus, Valor's Rest                    |-6432.2563|-278.2921 |3.794105  |1        |12.1501 |neutral |
|89 |Mulgore, Bloodhoof Village                |-2175.1897|-342.02692|-5.512325 |1        |106.65  |alliance|
|90 |Teldrassil, Darnassus                     |10054.3   |2117.12   |1329.63   |1        |138.322 |alliance|
|91 |Teldrassil, Dolanaar                      |9701.255  |945.6204  |1291.3551 |1        |155.7   |neutral |
|92 |Ashenvale, Astranaar                      |2633.4111 |-629.73517|107.58125 |1        |105.202 |neutral |
|93 |Teldrassil, Aldrassil                     |10384.81  |811.5312  |1317.5382 |1        |63.9    |alliance|
|94 |Tirisfal Glades, Deathknell               |1882.94   |1629.11   |94.4175   |0        |265.77  |horde   |
|97 |Silverpine Forest, The Sepulcher          |516.19434 |1589.8066 |127.54494 |0        |180.225 |horde   |
|98 |Hillsbrad Foothills, Tarren Mill          |-18.677681|-981.17145|55.83767  |0        |96.3    |horde   |
|99 |Arathi Highlands                          |-1472.2894|-2617.9587|49.27652  |0        |319.402 |neutral |
|100|Dun Morogh, Anvilmar                      |-6164.226 |336.32114 |399.79337 |0        |117.9   |alliance|
|101|Dun Morogh, Kharanos                      |-5680.0444|-518.9205 |396.27432 |0        |146.025 |neutral |
|103|Badlands, Kargath                         |-6805     |-2287.19  |280.752   |0        |161.361 |neutral |
|104|Redridge Mountains, Lakeshire             |-9403.245 |-2037.692 |58.36874  |0        |53.3616 |neutral |
|105|Elwynn Forest, Northshire                 |-8935.325 |-188.64627|80.416466 |0        |156.375 |alliance|
|106|Elwynn Forest, Goldshire                  |-9339.456 |171.40845 |61.56181  |0        |262.35  |alliance|
|108|Swamp of Sorrows, Stonard                 |-10567.813|-3377.2031|22.25322  |0        |179.1   |neutral |
|109|Stranglethorn Vale, Booty Bay             |-14284.962|288.44717 |32.33204  |0        |53.3251 |neutral |
|149|Hillsbrad Foothills, Southshore           |-732.7994 |-592.50195|22.663046 |0        |12.15   |alliance|
|189|Dustwallow Marsh, Theramore Isle          |-3525.706 |-4315.455 |6.995607  |1        |172.35  |alliance|
|209|Tanaris, Gadgetzan                        |-7190.949 |-3944.6523|9.227391  |1        |155.377 |neutral |
|229|The Barrens, Camp Taurajo                 |-2517.75  |-1972.64  |91.7838   |1        |76.8281 |neutral |
|249|The Barrens, Ratchet                      |-1081.4   |-3478.68  |63.6066   |1        |5.27823 |neutral |
|289|Tirisfal Glades, Brill                    |2348.67   |492.027   |33.3665   |0        |280.125 |horde   |
|309|Feralas, Feathermoon Stronghold           |-4596.4043|3229.4343 |8.993764  |1        |72      |neutral |
|310|Feralas, Camp Mojache                     |-4439.967 |370.15344 |51.356552 |1        |177.75  |neutral |
|329|Thousand Needles, Shimmering Flats        |-5530.2827|-3459.28  |-45.74437 |1        |262.575 |neutral |
|349|The Hinterlands, Aerie Peak               |323.51263 |-2227.1958|137.61746 |0        |148.32  |neutral |
|369|Azshara, Talrendis Point                  |2681.0579 |-4009.754 |107.84863 |1        |263.7   |neutral |
|370|Blasted Lands, Dreadmaul Hold             |-10846.574|-2949.4878|13.227232 |0        |343.386 |neutral |
|389|Stranglethorn Vale, Northern Stranglethorn|-11542.56 |-228.6365 |27.842743 |0        |176.175 |neutral |
|409|Stonetalon Mountains, Webwinder Path      |898.261   |434.53    |65.7279   |1        |88.6499 |neutral |
|429|Tirisfal Glades, Faol's Rest              |2604.52   |-543.39   |88.9996   |0        |52.2001 |neutral |
|449|Felwood, Morlos'Aran                      |3806.5396 |-1600.2914|218.83124 |1        |42.7865 |neutral |
|450|Un'Goro Crater, The Marshlands            |-7205.565 |-2436.6743|-218.16096|1        |28.1248 |neutral |
|469|Darkshore, Twilight Vale                  |4291.2827 |96.95573  |43.075256 |1        |332.326 |neutral |
|489|Wetlands, Baradin Bay                     |-3347.72  |-856.713  |1.05955   |0        |282.478 |alliance|
|509|Western Plaguelands, Chillwind Camp       |908.3233  |-1520.2861|55.037178 |0        |285.525 |alliance|
|510|Eastern Plaguelands, Light's Hope Chapel  |2116.7898 |-5287.337 |81.13204  |0        |0       |neutral |
|511|Winterspring, Everlook                    |6875.76   |-4661.54  |701.094   |1        |2.0248  |neutral |
|512|Ashenvale, Kargathia                      |2421.7236 |-2953.619 |123.47346 |1        |2.60178 |neutral |
|569|Western Plaguelands, Bulwark              |1750.3435 |-669.78986|44.569843 |0        |193.725 |horde   |
|609|Azshara, Southridge Beach                 |2942.76   |-6037.13  |5.16996   |1        |163.8   |neutral |
|630|Azshara, Legash Encampment                |4788.78   |-6845     |89.7901   |1        |351.9   |neutral |
|631|Dustwallow Marsh, Brackenwall Village     |-3127.69  |-3046.94  |33.8313   |1        |324.9   |horde   |
|632|Burning Steppes, Flame Crest              |-7490.45  |-2132.62  |142.186   |0        |101.128 |neutral |
|633|Moonglade                                 |7426      |-2809     |464       |1        |218.062 |neutral |
|634|Eastern Plaguelands, Darrowshire          |1392      |-3701     |77        |0        |0.577984|neutral |
|635|Felwood, Irontree Woods                   |5935.47   |-1217.75  |383.202   |1        |20.9615 |neutral |
|636|Searing Gorge, Thorium Point              |-6450.61  |-1113.51  |308.022   |0        |356.4   |neutral |
|649|Durotar, Sen'jin Village                  |-778      |-4985     |19        |1        |281.7   |horde   |
|709|Durotar, Valley of Trials                 |-634.6349 |-4296.0337|40.52543  |1        |236.25  |horde   |
|789|The Hinterlands, The Overlook Cliffs      |-291      |-4374     |107       |0        |0       |neutral |
|849|Feralas, Dire Maul                        |-4590.4087|1632.0807 |93.97383  |1        |0       |neutral |
|850|Durotar, Northern Durotar                 |1177.78   |-4464.24  |21.3539   |1        |52.4774 |horde   |
|851|Mulgore, Thunder Bluff                    |-981.917  |-74.6465  |20.1265   |1        |359.992 |horde   |
|852|Dun Morogh, Gates of Ironforge            |-5165.52  |-874.664  |507.177   |0        |45.1267 |alliance|
|853|Tirisfal Glades, Ruins of Lordaeron       |1780.11   |221.761   |59.6169   |0        |0       |horde   |
|854|Elwynn Forest, Eastvale Logging Camp      |-9552.46  |-1374.05  |51.2332   |0        |101.241 |neutral |
|869|Western Plaguelands, Caer Darrow          |1236.89   |-2411.99  |60.68     |0        |139.725 |neutral |
|909|Eastern Plaguelands, Blackwood Lake       |2647.55   |-4014.39  |105.938   |0        |346.951 |neutral |
|910|Silithus, Cenarion Hold                   |-6831.3174|891.4373  |33.86627  |1        |166     |neutral |
|911|Duskwood, Ravenhill                       |-10606.8  |294.048   |31.8007   |0        |0       |neutral |
|913|Silithus, Scarab Wall (AQ Only)           |-7991.5737|1557.804  |4.974186  |1        |0       |neutral |
|927|Eastern Plaguelands, Graveyard CG Tower   |1978.4685 |-3655.885 |119.79466 |0        |0       |neutral |

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
-
- 
-->
- Die at any of the graveyards fixed in this PR and check if you get sent to the correct graveyard.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
