### PR TITLE
Fixed trade logs table

### DIFF
--- a/sql/migrations/20220913193700_logs.sql
+++ b/sql/migrations/20220913193700_logs.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220913193700');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220913193700');
+
+ALTER TABLE `logs_trade` CHANGE `type` `type` ENUM('AuctionBid','AuctionBuyout','BuyItem','SellItem','GM','Mail','QuestMaxLevel','Quest','Loot','Trade','') CHARSET utf8 COLLATE utf8_general_ci DEFAULT '' NOT NULL, CHARSET=utf8mb3;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest

This fixes cases such as https://github.com/vmangos/core/blob/development/src/game/Objects/Player.cpp#L18526 which uses `BuyItem` in a trade log, which is not an acceptable enum member in the schema.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
