### PR TITLE
Correct graveyard faction for Dolanaar

### DIFF
--- a/sql/migrations/20220921023009_world.sql
+++ b/sql/migrations/20220921023009_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220921023009');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220921023009');
+-- Add your query below.
+
+-- Dolanaar, Teldrassil GY is neutral.
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=91 AND `ghost_zone`=141;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
An intended change from https://github.com/vmangos/core/pull/1608 that accidentally wasn't included.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
As per above description.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Currently, the horde has no graveyard to be sent to when dying in Teldrassil. This is because the Dolanaar graveyard, intended to be a neutral graveyard, is currently alliance only.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Make a horde character
- Teleport to Teldrassil
- Die

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
