### PR TITLE
Add cmake variable to change the configuration directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ if(WIN32)
   set(LIBS_DIR ${CMAKE_INSTALL_PREFIX})
 else()
   set(BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin)
-  set(CONF_DIR ${CMAKE_INSTALL_PREFIX}/etc)
+  set(CONF_DIR ${CMAKE_INSTALL_PREFIX}/etc CACHE PATH "Set custom configuration directory")
   set(LIBS_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 endif()
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Define a cache variable in cmake for setting the path for realmd.conf and mangosd.conf. If installing system wide on an unix system, e.g. via a package manager, the default location /usr/etc is nonstandard.
### Proof
<!-- Link resources as proof -->
- None
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None
### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->

1. Build with `-DCONF_DIR` unset and cache cleared, conf files will be in `$CMAKE_INSTALL_PREFIX/etc`.
2. Build with `-DCONF_DIR=/etc/vmangos`, conf files will be in system-wide /etc.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
