### PR TITLE
Correct ghost zones to Patch 1.6  sub-areas, remove invalid graveyards

### DIFF
--- a/sql/migrations/20220922195507_world.sql
+++ b/sql/migrations/20220922195507_world.sql
@@ -36,7 +36,7 @@ INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) V
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES (634, 2258, 0, 0);
 
 -- Caer Darrow Graveyard can be accessed while in Caer Darrow
-INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('869', '2298', '0', '0');
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES (869, 2298, 0, 0);
 
 -- Delete invalid neutral Darkshore Graveyard for Stonetalon Mountains
 DELETE FROM `game_graveyard_zone` WHERE  `id`=469 AND `ghost_zone`=406;

--- a/sql/migrations/20220922195507_world.sql
+++ b/sql/migrations/20220922195507_world.sql
@@ -9,22 +9,34 @@ INSERT INTO `migrations` VALUES ('20220922195507');
 -- Add your query below.
 
 -- Red Cloud Mesa Graveyard can only be accessed while in Red Cloud Mesa
-UPDATE `game_graveyard_zone` SET `ghost_zone`=220 WHERE `id`=34;
+UPDATE `game_graveyard_zone` SET `ghost_zone`=220 WHERE `id`=34 AND `ghost_zone`=215;
 
 -- Coldridge Valley Graveyard can only be accessed while in Coldridge Valley
-UPDATE `game_graveyard_zone` SET `ghost_zone`=132 WHERE `id`=100;
+UPDATE `game_graveyard_zone` SET `ghost_zone`=132 WHERE `id`=100 AND `ghost_zone`=1;
 
 -- Shadowglen Graveyard can only be accessed while in Shadowglen
-UPDATE `game_graveyard_zone` SET `ghost_zone`=188 WHERE `id`=93;
+UPDATE `game_graveyard_zone` SET `ghost_zone`=188 WHERE `id`=93 AND `ghost_zone`=141;
 
 -- Northshire Valley Graveyard can only be accessed while in Northshire Valley
-UPDATE `game_graveyard_zone` SET `ghost_zone`=9 WHERE `id`=105;
+UPDATE `game_graveyard_zone` SET `ghost_zone`=9 WHERE `id`=105 AND `ghost_zone`=12;
 
 -- Valley of Trials Graveyard can only be accessed while in Valley of Trials
-UPDATE `game_graveyard_zone` SET `ghost_zone`=363 WHERE `id`=709;
+UPDATE `game_graveyard_zone` SET `ghost_zone`=363 WHERE `id`=709 AND `ghost_zone`=14;
 
 -- Deathknell Graveyard can only be accessed while in Deathknell
-UPDATE `game_graveyard_zone` SET `ghost_zone`=154 WHERE `id`=94;
+UPDATE `game_graveyard_zone` SET `ghost_zone`=154 WHERE `id`=94 AND `ghost_zone`=85;
+
+-- Gates of Ironforge Graveyard can only be accessed while in Gates of Ironforge
+UPDATE `game_graveyard_zone` SET `ghost_zone`=809 WHERE `id`=852 AND `ghost_zone`=1;
+
+-- Caer Darrow Graveyard can be accessed while in Caer Darrow
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('911', '2298', '0', '4544');
+
+-- Delete invalid neutral Darnassus Graveyard for Darkshore
+DELETE FROM `game_graveyard_zone` WHERE  `id`=469 AND `ghost_zone`=148;
+
+-- Delete invalid Ratchet Graveyard for Mulgore 
+DELETE FROM `game_graveyard_zone` WHERE  `id`=249 AND `ghost_zone`=215;
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20220922195507_world.sql
+++ b/sql/migrations/20220922195507_world.sql
@@ -29,11 +29,17 @@ UPDATE `game_graveyard_zone` SET `ghost_zone`=154 WHERE `id`=94 AND `ghost_zone`
 -- Gates of Ironforge Graveyard can only be accessed while in Gates of Ironforge
 UPDATE `game_graveyard_zone` SET `ghost_zone`=809 WHERE `id`=852 AND `ghost_zone`=1;
 
--- Caer Darrow Graveyard can be accessed while in Caer Darrow
-INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('911', '2298', '0', '0');
+-- Set Dun Morogh, Anvilmar GY for Coldridge Pass
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES (100, 800, 469, 0);
 
--- Delete invalid neutral Darnassus Graveyard for Darkshore
-DELETE FROM `game_graveyard_zone` WHERE  `id`=469 AND `ghost_zone`=148;
+-- Set Eastern Plaguelands, Darrowshire GY for The Fungal Vale
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES (634, 2258, 0, 0);
+
+-- Caer Darrow Graveyard can be accessed while in Caer Darrow
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('869', '2298', '0', '0');
+
+-- Delete invalid neutral Darkshore Graveyard for Stonetalon Mountains
+DELETE FROM `game_graveyard_zone` WHERE  `id`=469 AND `ghost_zone`=406;
 
 -- Delete invalid Ratchet Graveyard for Mulgore 
 DELETE FROM `game_graveyard_zone` WHERE  `id`=249 AND `ghost_zone`=215;

--- a/sql/migrations/20220922195507_world.sql
+++ b/sql/migrations/20220922195507_world.sql
@@ -30,7 +30,7 @@ UPDATE `game_graveyard_zone` SET `ghost_zone`=154 WHERE `id`=94 AND `ghost_zone`
 UPDATE `game_graveyard_zone` SET `ghost_zone`=809 WHERE `id`=852 AND `ghost_zone`=1;
 
 -- Caer Darrow Graveyard can be accessed while in Caer Darrow
-INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('911', '2298', '0', '4544');
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES ('911', '2298', '0', '0');
 
 -- Delete invalid neutral Darnassus Graveyard for Darkshore
 DELETE FROM `game_graveyard_zone` WHERE  `id`=469 AND `ghost_zone`=148;

--- a/sql/migrations/20220922195507_world.sql
+++ b/sql/migrations/20220922195507_world.sql
@@ -1,0 +1,34 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220922195507');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220922195507');
+-- Add your query below.
+
+-- Red Cloud Mesa Graveyard can only be accessed while in Red Cloud Mesa
+UPDATE `game_graveyard_zone` SET `ghost_zone`=220 WHERE `id`=34;
+
+-- Coldridge Valley Graveyard can only be accessed while in Coldridge Valley
+UPDATE `game_graveyard_zone` SET `ghost_zone`=132 WHERE `id`=100;
+
+-- Shadowglen Graveyard can only be accessed while in Shadowglen
+UPDATE `game_graveyard_zone` SET `ghost_zone`=188 WHERE `id`=93;
+
+-- Northshire Valley Graveyard can only be accessed while in Northshire Valley
+UPDATE `game_graveyard_zone` SET `ghost_zone`=9 WHERE `id`=105;
+
+-- Valley of Trials Graveyard can only be accessed while in Valley of Trials
+UPDATE `game_graveyard_zone` SET `ghost_zone`=363 WHERE `id`=709;
+
+-- Deathknell Graveyard can only be accessed while in Deathknell
+UPDATE `game_graveyard_zone` SET `ghost_zone`=154 WHERE `id`=94;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Currently, when you die outside of a starting area, your ghost can still be sent to the graveyard in the starting area should it be the closest graveyard to the player character on death. This pull request corrects the ghost zones of graveyards in starting areas to use the ghost zones of the starting areas, instead of using the ghost zone for the entire zone.

### Proof
"Starting area graveyards are still reserved exclusively for characters of similar faction that die **within their confines**. For example, the spirit of a Horde character dying right outside of [Deathknell](https://wowpedia.fandom.com/wiki/Deathknell) will not use Deathknell graveyard, but will instead go to the next closest Tirisfal Glades graveyard." (Patch 1.6 change notes: https://web.archive.org/web/20060104092012/http://www.worldofwarcraft.com/patchnotes/patch-05-08-02.html)

TBC Classic behaviour recorded by @heyitsbench : https://www.youtube.com/watch?v=wyaBOODuwqs&t=53s

### Issues
- Fixes https://github.com/vmangos/core/issues/1417

### How2Test
- Make a horde/alliance character
- Die in a location such that the closest graveyard is the graveyard in the starting area, but the character is not in the starting area zone.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
