### PR TITLE
Add The Fungal Vale to CG Tower GY.

### DIFF
--- a/sql/migrations/20220924032106_world.sql
+++ b/sql/migrations/20220924032106_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220924032106');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220924032106');
+-- Add your query below.
+
+-- Add The Fungal Vale to Eastern Plaguelands, Graveyard CG Tower GY
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES (927, 2258, 0, 5875);
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/OutdoorPvP/OutdoorPvPEP.cpp
+++ b/src/game/OutdoorPvP/OutdoorPvPEP.cpp
@@ -599,6 +599,8 @@ void OPvPCapturePointEP_CGT::LinkGraveYard(Team team)
         m_GraveyardSide = team;
         sObjectMgr.RemoveGraveYardLink(EP_GraveYardId, EP_Zone, team, false);
         sObjectMgr.AddGraveYardLink(EP_GraveYardId, EP_Zone, team, false);
+        sObjectMgr.RemoveGraveYardLink(EP_GraveYardId, TFV_area, team, false);
+        sObjectMgr.AddGraveYardLink(EP_GraveYardId, TFV_area, team, false);
     }
 }
 
@@ -606,6 +608,8 @@ void OPvPCapturePointEP_CGT::UnLinkGraveYard()
 {
     sObjectMgr.RemoveGraveYardLink(EP_GraveYardId, EP_Zone, ALLIANCE, false);
     sObjectMgr.RemoveGraveYardLink(EP_GraveYardId, EP_Zone, HORDE, false);
+    sObjectMgr.RemoveGraveYardLink(EP_GraveYardId, TFV_area, ALLIANCE, false);
+    sObjectMgr.RemoveGraveYardLink(EP_GraveYardId, TFV_area, HORDE, false);
 }
 
 void OPvPCapturePointEP_CGT::SummonBannerAura(uint32 team)

--- a/src/game/OutdoorPvP/OutdoorPvPEP.h
+++ b/src/game/OutdoorPvP/OutdoorPvPEP.h
@@ -214,6 +214,7 @@ uint32 const EP_AllianceBuffs[4] = { SPELL_ALLIANCE_ECHOES_OF_LORDAERON_RANK_1, 
 uint32 const EP_HordeBuffs[4] = { SPELL_HORDE_ECHOES_OF_LORDAERON_RANK_1, SPELL_HORDE_ECHOES_OF_LORDAERON_RANK_2, SPELL_HORDE_ECHOES_OF_LORDAERON_RANK_3, SPELL_HORDE_ECHOES_OF_LORDAERON_RANK_4 };
 
 uint32 const EP_Zone = 139; // Eastern Plaguelands.
+uint32 const TFV_area = 2258; // The Fungal Vale.
 
 uint32 const EP_GraveYardId = 927;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Added the area The Fungal Vale to Crown Guard Tower Graveyard.
If you die in the The Fungal Vale and your faction controls Crown Guard Tower you will now be sent to the tower graveyard.

### Proof
<!-- Link resources as proof -->
- [Patch 1.12.1 (2006-09-26)](https://wowpedia.fandom.com/wiki/Patch_1.12.1): Players will now port to the [Crown Guard Tower](https://wowpedia.fandom.com/wiki/Crown_Guard_Tower) graveyard if they die in [Fungal Vale](https://wowpedia.fandom.com/wiki/Fungal_Vale) while their faction controls the tower.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1. Die in The Fungal Vale without your faction controlling Crown Guard Tower.
2. You will be sent to Darrowshire graveyard.
3. Die in The Fungal Vale with your faction controlling Crown Guard Tower.
4. You will be sent to Crown Guard Tower graveyard.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
