### PR TITLE
Fix patch for graveyards.

### DIFF
--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -145,6 +145,10 @@ INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `patch_max`) VALUES ('106
 -- Don't use Durotar, Razor Hill GY for Hall of Legends after patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_max`='3' WHERE  `id`=32 AND `ghost_zone`=2917 AND `patch_max`=10;
 
+-- Thousand Needles, Shimmering Flats GY should only be used for area Shimmering Flats
+-- Should be neutral
+UPDATE `game_graveyard_zone` SET `faction`=0, `ghost_zone`=439 WHERE `id`=329 AND `ghost_zone`=400 AND `patch_max`=10;
+
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -102,7 +102,7 @@ UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=40561;
 -- Use Feralas, Camp Mojache for Dire Maul GY pre patch 1.6
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`) VALUES ('310', '2557');
 
--- Set The Hinterlands, The Overlook Cliffs GY to patch 1.6
+-- Set The Hinterlands, The Overlook Cliffs GY to patch 1.5
 UPDATE `game_graveyard_zone` SET `patch_min`='3' WHERE  `id`=789 AND `ghost_zone`=47;
 
 -- Set Elwynn Forest, Eastvale Logging Camp GY to patch 1.6

--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -1,0 +1,104 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220925023354');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220925023354');
+-- Add your query below.
+
+
+-- Change build_min to patch_min
+ALTER TABLE `game_graveyard_zone` CHANGE COLUMN `build_min` `patch_min` SMALLINT(4) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Minimum content patch to load this entry' AFTER `faction`;
+
+-- Set Silithus, Cenarion Hold GY to patch 1.8
+UPDATE `game_graveyard_zone` SET `build_min`='6' WHERE  `id`=910 AND `ghost_zone`=1377;
+-- Delete incorrect zone Silithus for Silithus, Scarab Wall (AQ Only) GY
+DELETE FROM `game_graveyard_zone` WHERE  `id`=913 AND `ghost_zone`=1377;
+-- Delete incorrect zone Gates of Ahn'Qiraj for Silithus, Scarab Wall (AQ Only) GY
+DELETE FROM `game_graveyard_zone` WHERE  `id`=913 AND `ghost_zone`=3478;
+-- Add correct Silithus, Cenarion Hold for Gates of Ahn'Qiraj
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (910, 3478, 0, 6);
+-- Add Silithus, Valor's Rest for Gates of Ahn'Qiraj below 1.8
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (70, 3478, 0, 0);
+
+-- Set Duskwood, Ravenhill GY to patch patch 1.8
+UPDATE `game_graveyard_zone` SET `patch_min`='6' WHERE  `id`=911 AND `ghost_zone`=10;
+
+-- Set Silithus, Scarab Wall (AQ Only) to patch 1.9
+UPDATE `game_graveyard_zone` SET `patch_min`='7' WHERE  `id`=913;
+-- Set Silithus, Scarab Wall (AQ Only) Spirit healer to 1.9
+UPDATE `creature` SET `patch_min`='7' WHERE  `guid`=7716;
+
+-- Set Eastern Plaguelands, Graveyard CG Tower to patch 1.12
+UPDATE `game_graveyard_zone` SET `patch_min`='10' WHERE  `id`=927;
+
+-- Set Durotar, Northern Durotar to patch 1.6.0
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=850;
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=32 AND `ghost_zone`=1637;
+-- Don't use Durotar, Northern Durotar for Alliance Ragefire Chasm
+UPDATE `game_graveyard_zone` SET `faction`='67' WHERE  `id`=850 AND `ghost_zone`=2437;
+-- Add Ragefire Chasm to Durotar, Razor Hill
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (32, 2437, 0, 0);
+-- Add Hall of Legends to Durotar, Razor Hill
+-- For some reason it wont use grave 850 at 1.12
+-- even if looks exactly same as RFC and RFC works with 850 at 1.12
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (32, 2917, 0, 0);
+
+-- Set Mulgore, Thunder Bluff GY to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=851;
+-- Use Mulgore, Bloodhoof Village GY for Thunderbluff below 1.6
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=89 AND `ghost_zone`=1638;
+
+-- Set Teldrassil, Darnassus GY to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=90;
+-- Use Teldrassil, Dolanaar GY for Darnassus below 1.6
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=91 AND `ghost_zone`=1657;
+
+-- Set Dun Morogh, Gates of Ironforge GY to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=852;
+-- Use Dun Morogh, Kharanos GY for Ironforge below 1.6
+UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=101 AND `ghost_zone`=1537;
+
+-- Set Tirisfal Glades, Ruins of Lordaeron GY to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=853;
+-- Use Tirisfal Glades, Brill GY for Undercity below 1.6
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (289, 1497, 0, 0);
+
+-- Set Western Plaguelands, Caer Darrow GY to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=869;
+-- Delete invalid graveyards for Caer Darrow
+DELETE FROM `game_graveyard_zone` WHERE  `id`=429 AND `ghost_zone`=2057;
+DELETE FROM `game_graveyard_zone` WHERE  `id`=629 AND `ghost_zone`=2057;
+-- Set correct graveyards for Caer Darrow pre 1.6
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (569, 2057, 67, 0);
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (509, 2057, 469, 0);
+
+-- Set Eastern Plaguelands, Blackwood Lake GY to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=909;
+-- Use Eastern Plaguelands, Light's Hope Chapel for Stratholm pre 1.6
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`) VALUES ('510', '2017');
+
+-- Set Feralas, Dire Maul GY to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=849;
+-- Use Feralas, Camp Mojache for Dire Maul pre 1.6
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`) VALUES ('310', '2557');
+
+-- Set The Hinterlands, The Overlook Cliffs to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='3' WHERE  `id`=789 AND `ghost_zone`=47;
+
+-- Set Elwynn Forest, Eastvale Logging Camp to 1.6
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=854;
+
+-- Set Goldshire to neutral pre 1.6
+-- Horde should Goldshire for Stormwind, The Stockade and Deeprun Tram pre 1.6
+-- WIP
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -148,6 +148,12 @@ UPDATE `game_graveyard_zone` SET `patch_max`='3' WHERE  `id`=32 AND `ghost_zone`
 -- Thousand Needles, Shimmering Flats GY should only be used for area Shimmering Flats
 -- Should be neutral
 UPDATE `game_graveyard_zone` SET `faction`=0, `ghost_zone`=439 WHERE `id`=329 AND `ghost_zone`=400 AND `patch_max`=10;
+-- Add subareas in Shimmering Flats to Thousand Needles, Shimmering Flats GY 
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`, `patch_max`) VALUES
+(329, 479, 0, 0, 10),
+(329, 2240, 0, 0, 10),
+(329, 3038, 0, 0, 10),
+(329, 3039, 0, 0, 10);
 
 
 -- End of migration.

--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -13,7 +13,7 @@ INSERT INTO `migrations` VALUES ('20220925023354');
 ALTER TABLE `game_graveyard_zone` CHANGE COLUMN `build_min` `patch_min` SMALLINT(4) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Minimum content patch to load this entry' AFTER `faction`;
 
 -- Set Silithus, Cenarion Hold GY to patch 1.8
-UPDATE `game_graveyard_zone` SET `build_min`='6' WHERE  `id`=910 AND `ghost_zone`=1377;
+UPDATE `game_graveyard_zone` SET `patch_min`='6' WHERE  `id`=910 AND `ghost_zone`=1377;
 -- Delete incorrect zone Silithus for Silithus, Scarab Wall (AQ Only) GY
 DELETE FROM `game_graveyard_zone` WHERE  `id`=913 AND `ghost_zone`=1377;
 -- Delete incorrect zone Gates of Ahn'Qiraj for Silithus, Scarab Wall (AQ Only) GY

--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -10,90 +10,140 @@ INSERT INTO `migrations` VALUES ('20220925023354');
 
 
 -- Change build_min to patch_min
-ALTER TABLE `game_graveyard_zone` CHANGE COLUMN `build_min` `patch_min` SMALLINT(4) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Minimum content patch to load this entry' AFTER `faction`;
+ALTER TABLE `game_graveyard_zone`
+	CHANGE COLUMN `build_min` `patch_min` SMALLINT(4) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Minimum content patch to load this entry' AFTER `faction`;
 
 -- Set Silithus, Cenarion Hold GY to patch 1.8
 UPDATE `game_graveyard_zone` SET `patch_min`='6' WHERE  `id`=910 AND `ghost_zone`=1377;
+
 -- Delete incorrect zone Silithus for Silithus, Scarab Wall (AQ Only) GY
 DELETE FROM `game_graveyard_zone` WHERE  `id`=913 AND `ghost_zone`=1377;
 -- Delete incorrect zone Gates of Ahn'Qiraj for Silithus, Scarab Wall (AQ Only) GY
 DELETE FROM `game_graveyard_zone` WHERE  `id`=913 AND `ghost_zone`=3478;
--- Add correct Silithus, Cenarion Hold for Gates of Ahn'Qiraj
+-- Add correct Silithus, Cenarion Hold GY for Gates of Ahn'Qiraj
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (910, 3478, 0, 6);
--- Add Silithus, Valor's Rest for Gates of Ahn'Qiraj below 1.8
+-- Add Silithus, Valor's Rest GY for Gates of Ahn'Qiraj pre patch 1.8
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (70, 3478, 0, 0);
+-- Set Silithus, Scarab Wall (AQ Only) GY to patch 1.9
+UPDATE `game_graveyard_zone` SET `patch_min`='7' WHERE  `id`=913;
+-- Set Silithus, Scarab Wall (AQ Only) GY Spirit healer to patch 1.9
+UPDATE `creature` SET `patch_min`='7' WHERE  `guid`=7716;
 
 -- Set Duskwood, Ravenhill GY to patch patch 1.8
 UPDATE `game_graveyard_zone` SET `patch_min`='6' WHERE  `id`=911 AND `ghost_zone`=10;
 
--- Set Silithus, Scarab Wall (AQ Only) to patch 1.9
-UPDATE `game_graveyard_zone` SET `patch_min`='7' WHERE  `id`=913;
--- Set Silithus, Scarab Wall (AQ Only) Spirit healer to 1.9
-UPDATE `creature` SET `patch_min`='7' WHERE  `guid`=7716;
-
--- Set Eastern Plaguelands, Graveyard CG Tower to patch 1.12
+-- Set Eastern Plaguelands, Graveyard CG Tower GY to patch 1.12
 UPDATE `game_graveyard_zone` SET `patch_min`='10' WHERE  `id`=927;
+-- Set Eastern Plaguelands, Graveyard CG Tower GY Spirit Healer to patch 1.12
+UPDATE `creature` SET `patch_min`='10' WHERE  `guid`=9386;
 
--- Set Durotar, Northern Durotar to patch 1.6.0
+-- Set Durotar, Northern Durotar GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=850;
 UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=32 AND `ghost_zone`=1637;
--- Don't use Durotar, Northern Durotar for Alliance Ragefire Chasm
+-- Set Durotar, Northern Durotar GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=40576;
+-- Don't use Durotar, Northern Durotar GY for Alliance Ragefire Chasm
 UPDATE `game_graveyard_zone` SET `faction`='67' WHERE  `id`=850 AND `ghost_zone`=2437;
--- Add Ragefire Chasm to Durotar, Razor Hill
+-- Add Ragefire Chasm to Durotar, Razor Hill GY
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (32, 2437, 0, 0);
--- Add Hall of Legends to Durotar, Razor Hill
--- For some reason it wont use grave 850 at 1.12
--- even if looks exactly same as RFC and RFC works with 850 at 1.12
+-- Add Hall of Legends to Durotar, Razor Hill GY
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (32, 2917, 0, 0);
 
 -- Set Mulgore, Thunder Bluff GY to 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=851;
--- Use Mulgore, Bloodhoof Village GY for Thunderbluff below 1.6
+-- Set Mulgore, Thunder Bluff GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=40570;
+-- Use Mulgore, Bloodhoof Village GY for Thunderbluff pre patch 1.6
 UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=89 AND `ghost_zone`=1638;
 
--- Set Teldrassil, Darnassus GY to 1.6
+-- Set Teldrassil, Darnassus GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=90;
--- Use Teldrassil, Dolanaar GY for Darnassus below 1.6
+-- Set Teldrassil, Darnassus GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=87049;
+-- Use Teldrassil, Dolanaar GY for Darnassus pre patch 1.6
 UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=91 AND `ghost_zone`=1657;
 
--- Set Dun Morogh, Gates of Ironforge GY to 1.6
+-- Set Dun Morogh, Gates of Ironforge GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=852;
--- Use Dun Morogh, Kharanos GY for Ironforge below 1.6
+-- Set Dun Morogh, Gates of Ironforge GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=87044;
+-- Use Dun Morogh, Kharanos GY for Ironforge pre patch 1.6
 UPDATE `game_graveyard_zone` SET `faction`='0' WHERE  `id`=101 AND `ghost_zone`=1537;
 
--- Set Tirisfal Glades, Ruins of Lordaeron GY to 1.6
+-- Set Tirisfal Glades, Ruins of Lordaeron GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=853;
--- Use Tirisfal Glades, Brill GY for Undercity below 1.6
+-- Set Tirisfal Glades, Ruins of Lordaeron GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=2065;
+-- Use Tirisfal Glades, Brill GY for Undercity pre patch 1.6
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (289, 1497, 0, 0);
 
--- Set Western Plaguelands, Caer Darrow GY to 1.6
+-- Set Western Plaguelands, Caer Darrow GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=869;
+-- Set Western Plaguelands, Caer Darrow GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=40544;
 -- Delete invalid graveyards for Caer Darrow
 DELETE FROM `game_graveyard_zone` WHERE  `id`=429 AND `ghost_zone`=2057;
 DELETE FROM `game_graveyard_zone` WHERE  `id`=629 AND `ghost_zone`=2057;
--- Set correct graveyards for Caer Darrow pre 1.6
+-- Set correct graveyards for Caer Darrow pre patch 1.6
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (569, 2057, 67, 0);
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES (509, 2057, 469, 0);
 
--- Set Eastern Plaguelands, Blackwood Lake GY to 1.6
+-- Set Eastern Plaguelands, Blackwood Lake GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=909;
--- Use Eastern Plaguelands, Light's Hope Chapel for Stratholm pre 1.6
+-- Set Eastern Plaguelands, Blackwood Lake GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=40551;
+-- Use Eastern Plaguelands, Light's Hope Chapel GY for Stratholm pre patch 1.6
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`) VALUES ('510', '2017');
 
--- Set Feralas, Dire Maul GY to 1.6
+-- Set Feralas, Dire Maul GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=849;
--- Use Feralas, Camp Mojache for Dire Maul pre 1.6
+-- Set Feralas, Dire Maul GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=40561;
+-- Use Feralas, Camp Mojache for Dire Maul GY pre patch 1.6
 INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`) VALUES ('310', '2557');
 
--- Set The Hinterlands, The Overlook Cliffs to 1.6
+-- Set The Hinterlands, The Overlook Cliffs GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='3' WHERE  `id`=789 AND `ghost_zone`=47;
 
--- Set Elwynn Forest, Eastvale Logging Camp to 1.6
+-- Set Elwynn Forest, Eastvale Logging Camp GY to patch 1.6
 UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=854;
+-- Set Elwynn Forest, Eastvale Logging Camp GY Spirit Healer to patch 1.6
+UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=17650;
 
--- Set Goldshire to neutral pre 1.6
--- Horde should Goldshire for Stormwind, The Stockade and Deeprun Tram pre 1.6
--- WIP
+-- Set min patch for Badlands, Graveyard NE GY
+UPDATE `game_graveyard_zone` SET `patch_min`='10' WHERE  `id`=8;
+-- Add Badlands and Uldaman to Loch Modan, Thelsamar GY
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES ('6', '3', '0', '0');
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES ('6', '1337', '0', '0');
+-- Set Badlands, Graveyard NE GY Spirit Healer to patch 1.12
+UPDATE `creature` SET `patch_min`='10' WHERE  `guid`=40593;
+
+-- Add patch_max to game_graveyard_zone
+ALTER TABLE `game_graveyard_zone`
+	ADD COLUMN `patch_max` SMALLINT(4) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Maximum content patch to load this entry' AFTER `patch_min`;
+-- Add primary key to patch_max
+ALTER TABLE `game_graveyard_zone`
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`id`, `ghost_zone`, `patch_max`) USING BTREE;
+-- Set max 1.12 patch to all GYs
+UPDATE `game_graveyard_zone` SET `patch_max`='10' WHERE `patch_max`=0;
+
+-- Set patch 1.6 for Alliance Deeprun Tram to Elwynn Forest, Goldshire GY
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=106 AND `ghost_zone`=2257 AND `patch_max`=10;
+-- Set patch 1.6 for Alliance Stormwind City to Elwynn Forest, Goldshire GY
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=106 AND `ghost_zone`=1519 AND `patch_max`=10;
+-- Set patch 1.6 patch for Alliance The Stockade to Elwynn Forest, Goldshire GY
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=106 AND `ghost_zone`=717 AND `patch_max`=10;
+-- Set patch 1.6 patch for Alliance Elwynn Forest to Elwynn Forest, Goldshire GY
+UPDATE `game_graveyard_zone` SET `patch_min`='4' WHERE  `id`=106 AND `ghost_zone`=12 AND `patch_max`=10;
+-- Add neutral Elwynn Forest, Goldshire GY for pre patch 1.6
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `patch_max`) VALUES ('106', '2257', '3');
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `patch_max`) VALUES ('106', '1519', '3');
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `patch_max`) VALUES ('106', '717', '3');
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `patch_max`) VALUES ('106', '12', '3');
+
+-- Don't use Durotar, Razor Hill GY for Hall of Legends after patch 1.6
+UPDATE `game_graveyard_zone` SET `patch_max`='3' WHERE  `id`=32 AND `ghost_zone`=2917 AND `patch_max`=10;
 
 
 -- End of migration.

--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -11,7 +11,7 @@ INSERT INTO `migrations` VALUES ('20220925023354');
 
 -- Change build_min to patch_min
 ALTER TABLE `game_graveyard_zone`
-	CHANGE COLUMN `build_min` `patch_min` SMALLINT(4) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Minimum content patch to load this entry' AFTER `faction`;
+	CHANGE COLUMN `build_min` `patch_min` TINYINT(2) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Minimum content patch to load this entry' AFTER `faction`;
 
 -- Set Silithus, Cenarion Hold GY to patch 1.8
 UPDATE `game_graveyard_zone` SET `patch_min`='6' WHERE  `id`=910 AND `ghost_zone`=1377;
@@ -119,7 +119,7 @@ UPDATE `creature` SET `patch_min`='10' WHERE  `guid`=40593;
 
 -- Add patch_max to game_graveyard_zone
 ALTER TABLE `game_graveyard_zone`
-	ADD COLUMN `patch_max` SMALLINT(4) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Maximum content patch to load this entry' AFTER `patch_min`;
+	ADD COLUMN `patch_max` TINYINT(2) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Maximum content patch to load this entry' AFTER `patch_min`;
 -- Add primary key to patch_max
 ALTER TABLE `game_graveyard_zone`
 	DROP PRIMARY KEY,

--- a/sql/migrations/20220925023354_world.sql
+++ b/sql/migrations/20220925023354_world.sql
@@ -112,9 +112,8 @@ UPDATE `creature` SET `patch_min`='4' WHERE  `guid`=17650;
 
 -- Set min patch for Badlands, Graveyard NE GY
 UPDATE `game_graveyard_zone` SET `patch_min`='10' WHERE  `id`=8;
--- Add Badlands and Uldaman to Loch Modan, Thelsamar GY
-INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES ('6', '3', '0', '0');
-INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES ('6', '1337', '0', '0');
+-- Add Uldaman to Kargath, Badlands GY
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `patch_min`) VALUES ('103', '1337', '0', '0');
 -- Set Badlands, Graveyard NE GY Spirit Healer to patch 1.12
 UPDATE `creature` SET `patch_min`='10' WHERE  `guid`=40593;
 

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -6921,7 +6921,7 @@ void ObjectMgr::LoadGraveyardZones()
 {
     m_GraveYardMap.clear();                                  // need for reload case
 
-    std::unique_ptr<QueryResult> result(WorldDatabase.PQuery("SELECT `id`, `ghost_zone`, `faction` FROM `game_graveyard_zone` WHERE `patch_min` <= %u", sWorld.GetWowPatch()));
+    std::unique_ptr<QueryResult> result(WorldDatabase.PQuery("SELECT `id`, `ghost_zone`, `faction` FROM `game_graveyard_zone` WHERE ((%u >= patch_min) && (%u <= patch_max))", sWorld.GetWowPatch(), sWorld.GetWowPatch()));
 
     uint32 count = 0;
 

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -6921,7 +6921,7 @@ void ObjectMgr::LoadGraveyardZones()
 {
     m_GraveYardMap.clear();                                  // need for reload case
 
-    std::unique_ptr<QueryResult> result(WorldDatabase.PQuery("SELECT `id`, `ghost_zone`, `faction` FROM `game_graveyard_zone` WHERE `build_min` <= %u", SUPPORTED_CLIENT_BUILD));
+    std::unique_ptr<QueryResult> result(WorldDatabase.PQuery("SELECT `id`, `ghost_zone`, `faction` FROM `game_graveyard_zone` WHERE `patch_min` <= %u", sWorld.GetWowPatch()));
 
     uint32 count = 0;
 

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -6921,7 +6921,7 @@ void ObjectMgr::LoadGraveyardZones()
 {
     m_GraveYardMap.clear();                                  // need for reload case
 
-    std::unique_ptr<QueryResult> result(WorldDatabase.PQuery("SELECT `id`, `ghost_zone`, `faction` FROM `game_graveyard_zone` WHERE ((%u >= patch_min) && (%u <= patch_max))", sWorld.GetWowPatch(), sWorld.GetWowPatch()));
+    std::unique_ptr<QueryResult> result(WorldDatabase.PQuery("SELECT `id`, `ghost_zone`, `faction` FROM `game_graveyard_zone` WHERE %u BETWEEN `patch_min` AND `patch_max`", sWorld.GetWowPatch()));
 
     uint32 count = 0;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR changes build_min to patch_min and adds patch_max to game_graveyard_zone.
It will read patch set in mangosd.conf, so you will not be sent to a graveyard that is not for the set patch.
If you build vmangos for a patch below 1.12.1, it will still work just as before and use correct graveyards.

Includes SQL fixes for all graveyards that was changed from between 1.2 to 1.12.
### Proof
<!-- Link resources as proof -->
- Patch notes.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/vmangos/core/issues/1590
- Fixes https://github.com/vmangos/core/issues/1492

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1. Set patch 3 in mangosd.conf
2. .tele ravenhill
3. .die
4. You will now spawn at Darkshire graveyard.
5. Set patch 10 in mangosd.conf
6. .tele ravenhill
7. .die
8. You will spawn at Raven Hill graveyard.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] Make Goldshire GY neutral in pre 1.6
- [X] Set patch in creature table for all spirit healers that weren't spawned in prior patch.
- [X] Find a way to use Orgrimmar Durotar GY for Hall of Legends when Razor Hill GY is set to neutral.
- [X] Fix graveyard for dying in Uldaman on old patch.