### PR TITLE
Correct Brambleblade Ravine graveyard zone

### DIFF
--- a/sql/migrations/20220925022431
+++ b/sql/migrations/20220925022431
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20220925022431');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20220925022431');
+-- Add your query below.
+
+-- Set Mulgore, Red Cloud Mesa GY for Brambleblade Ravine
+INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `faction`, `build_min`) VALUES (34, 358, 67, 0);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Seeing @Daribon 's fix to Coldridge Pass graveyard in https://github.com/vmangos/core/pull/1635 made me realise that Brambleblade Ravine also needs to be set to use Red Cloud Mesa graveyard. I'm sorry for any mess/pain my mistakes caused.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Die in Brambleblade Ravine
- Get sent to Red Cloud Mesa

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
