### PR TITLE
Refactor worldteleport

### DIFF
--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1160,20 +1160,11 @@ void WorldSession::HandleWorldTeleport (WorldPacket& msg) {
   msg >> position.z;
   msg >> position.o;
 
-  DEBUG_LOG("Received worldport command from player %s (0x%x):\n" \
-            "timeMs: %u\n"                                        \
-            "coordinates: %u, %f, %f, %f, %f\n",
-            player->GetName(),
-            player->GetGUID(),
-            timeMs,
-            mapId,
-            position.x,
-            position.y,
-            position.z,
-            position.o);
-
-  if (GetSecurity() < SEC_GAMEMASTER)
-    return SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+  // Validate the user's security credentials
+  if (GetSecurity() < SEC_GAMEMASTER) {
+    SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+    return;
+  }
 
   player->TeleportTo(mapId,
                     position.x,

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1146,41 +1146,41 @@ void WorldSession::HandleInspectHonorStatsOpcode(WorldPacket& recv_data)
     SendPacket(&data);
 }
 
-void WorldSession::HandleWorldTeleportOpcode(WorldPacket& recv_data)
+//===========================================================================
+void WorldSession::HandleWorldTeleport (WorldPacket& msg)
 {
-    // write in client console: worldport 469 452 6454 2536 180 or /console worldport 469 452 6454 2536 180
-    // Received opcode CMSG_WORLD_TELEPORT
-    // Time is ***, map=469, x=452.000000, y=6454.000000, z=2536.000000, orient=3.141593
+    Player* player = GetPlayer();
+    Position position = {};
+    uint32 timeMs = 0;
+    uint32 mapId = 0;
 
-    uint32 time;
-    uint32 mapId;
-    float positionX;
-    float positionY;
-    float positionZ;
-    float orientation;
+    msg >> timeMs;
+    msg >> mapId;
+    msg >> position.x;
+    msg >> position.y;
+    msg >> position.z;
+    msg >> position.o;
 
-    recv_data >> time;                                      // time in m.sec.
-    recv_data >> mapId;
-    recv_data >> positionX;
-    recv_data >> positionY;
-    recv_data >> positionZ;
-    recv_data >> orientation;                               // o (3.141593 = 180 degrees)
+    DEBUG_LOG("Received worldport command from player %s (0x%x):\n" \
+             "timeMs: %u\n"                                         \
+             "coordinates: %u, %f, %f, %f, %f\n",
+             player->GetName(),
+             player->GetGUID(),
+             timeMs,
+             mapId,
+             position.x,
+             position.y,
+             position.z,
+             position.o);
 
-    //DEBUG_LOG("Received opcode CMSG_WORLD_TELEPORT");
+    if (GetSecurity() < SEC_GAMEMASTER)
+        return SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
 
-    if (GetPlayer()->IsTaxiFlying())
-    {
-        DEBUG_LOG("Player '%s' (GUID: %u) in flight, ignore worldport command.", GetPlayer()->GetName(), GetPlayer()->GetGUIDLow());
-        return;
-    }
-
-    DEBUG_LOG("Time %u sec, map=%u, x=%f, y=%f, z=%f, orient=%f", time / 1000, mapId, positionX, positionY, positionZ, orientation);
-
-    if (GetSecurity() >= SEC_ADMINISTRATOR)
-        GetPlayer()->TeleportTo(mapId, positionX, positionY, positionZ, orientation);
-    else
-        SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
-    DEBUG_LOG("Received worldport command from player %s", GetPlayer()->GetName());
+    player->TeleportTo(mapId,
+                      position.x,
+                      position.y,
+                      position.z,
+                      position.o);
 }
 
 void WorldSession::HandleMoveSetRawPosition(WorldPacket& recv_data)

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1148,38 +1148,38 @@ void WorldSession::HandleInspectHonorStatsOpcode(WorldPacket& recv_data)
 
 //===========================================================================
 void WorldSession::HandleWorldTeleport (WorldPacket& msg) {
-    Player* player = GetPlayer();
-    Position position = {};
-    uint32 timeMs = 0;
-    uint32 mapId = 0;
+  Player* player = GetPlayer();
+  Position position = {};
+  uint32 timeMs = 0;
+  uint32 mapId = 0;
 
-    msg >> timeMs;
-    msg >> mapId;
-    msg >> position.x;
-    msg >> position.y;
-    msg >> position.z;
-    msg >> position.o;
+  msg >> timeMs;
+  msg >> mapId;
+  msg >> position.x;
+  msg >> position.y;
+  msg >> position.z;
+  msg >> position.o;
 
-    DEBUG_LOG("Received worldport command from player %s (0x%x):\n" \
-             "timeMs: %u\n"                                         \
-             "coordinates: %u, %f, %f, %f, %f\n",
-             player->GetName(),
-             player->GetGUID(),
-             timeMs,
-             mapId,
-             position.x,
-             position.y,
-             position.z,
-             position.o);
+  DEBUG_LOG("Received worldport command from player %s (0x%x):\n" \
+            "timeMs: %u\n"                                        \
+            "coordinates: %u, %f, %f, %f, %f\n",
+            player->GetName(),
+            player->GetGUID(),
+            timeMs,
+            mapId,
+            position.x,
+            position.y,
+            position.z,
+            position.o);
 
-    if (GetSecurity() < SEC_GAMEMASTER)
-        return SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+  if (GetSecurity() < SEC_GAMEMASTER)
+    return SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
 
-    player->TeleportTo(mapId,
-                      position.x,
-                      position.y,
-                      position.z,
-                      position.o);
+  player->TeleportTo(mapId,
+                    position.x,
+                    position.y,
+                    position.z,
+                    position.o);
 }
 
 void WorldSession::HandleMoveSetRawPosition(WorldPacket& recv_data)

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1147,8 +1147,7 @@ void WorldSession::HandleInspectHonorStatsOpcode(WorldPacket& recv_data)
 }
 
 //===========================================================================
-void WorldSession::HandleWorldTeleport (WorldPacket& msg)
-{
+void WorldSession::HandleWorldTeleport (WorldPacket& msg) {
     Player* player = GetPlayer();
     Position position = {};
     uint32 timeMs = 0;

--- a/src/game/Protocol/Opcodes.cpp
+++ b/src/game/Protocol/Opcodes.cpp
@@ -61,7 +61,7 @@ void Opcodes::BuildOpcodeList()
     /*0x005*/  StoreOpcode(SMSG_QUERY_OBJECT_POSITION,        "SMSG_QUERY_OBJECT_POSITION",       STATUS_NEVER,     PACKET_PROCESS_MAX_TYPE,      &WorldSession::Handle_ServerSide);
     /*0x006*/  StoreOpcode(CMSG_QUERY_OBJECT_ROTATION,        "CMSG_QUERY_OBJECT_ROTATION",       STATUS_NEVER,     PACKET_PROCESS_MAX_TYPE,      &WorldSession::Handle_NULL);
     /*0x007*/  StoreOpcode(SMSG_QUERY_OBJECT_ROTATION,        "SMSG_QUERY_OBJECT_ROTATION",       STATUS_NEVER,     PACKET_PROCESS_MAX_TYPE,      &WorldSession::Handle_ServerSide);
-    /*0x008*/  StoreOpcode(CMSG_WORLD_TELEPORT,               "CMSG_WORLD_TELEPORT",              STATUS_LOGGEDIN,  PACKET_PROCESS_WORLD,         &WorldSession::HandleWorldTeleportOpcode);
+    /*0x008*/  StoreOpcode(CMSG_WORLD_TELEPORT,               "CMSG_WORLD_TELEPORT",              STATUS_LOGGEDIN,  PACKET_PROCESS_WORLD,         &WorldSession::HandleWorldTeleport);
     /*0x009*/  StoreOpcode(CMSG_TELEPORT_TO_UNIT,             "CMSG_TELEPORT_TO_UNIT",            STATUS_LOGGEDIN,  PACKET_PROCESS_MAX_TYPE,      &WorldSession::Handle_NULL);
     /*0x00A*/  StoreOpcode(CMSG_ZONE_MAP,                     "CMSG_ZONE_MAP",                    STATUS_NEVER,     PACKET_PROCESS_MAX_TYPE,      &WorldSession::Handle_NULL);
     /*0x00B*/  StoreOpcode(SMSG_ZONE_MAP,                     "SMSG_ZONE_MAP",                    STATUS_NEVER,     PACKET_PROCESS_MAX_TYPE,      &WorldSession::Handle_ServerSide);

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -514,7 +514,7 @@ class WorldSession
         void HandleMovementFlagChangeToggleAck(WorldPacket& recvData);
         void HandleMoveSplineDoneOpcode(WorldPacket& recvPacket);
         void HandleMoveSetRawPosition(WorldPacket& recv_data);
-        void HandleWorldTeleportOpcode(WorldPacket& recv_data);
+        void HandleWorldTeleport (WorldPacket& msg);
         void HandleMountSpecialAnimOpcode(WorldPacket& recvdata);
 
         void HandleInspectOpcode(WorldPacket& recvPacket);


### PR DESCRIPTION
Proposed changes would:

- Rename the **_WorldSession::HandleWorldTeleportOpcode_** method and renames it to **_WorldSession::HandleWorldTeleport_** ;
- Change the code style to something easier to read and comprehend by:
    - Removing irrelevant comments that take the main focus away from the code logic;
    - Renaming variables with more meaningful identifiers;
    - Using 2 spaces for code and limiting line width to 80 pixels for better productivity on monitors in portrait orientation
- Optimize the code by removing superfluous instructions