### PR TITLE
Change AV BG announcer to correct NPC.

### DIFF
--- a/sql/migrations/20221022011155_world.sql
+++ b/sql/migrations/20221022011155_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20221022011155');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20221022011155');
+-- Add your query below.
+
+
+-- Change AV BG announcer from Stormpike Herald to Herald
+UPDATE `creature` SET `id`='14848' WHERE  `guid`=150155;
+DELETE FROM `creature_battleground` WHERE  `guid`=150154 AND `event1`=60;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changes AV BG announcer from Stormpike Herald to Herald.
Stormpike Herald ever only yelled the BG announcements in 1.5.0 PTR. From release 1.5.0 and forward it has been Herald that does all the announcements.

Screenshot taken after PR applied:
![WoW_856N4Reapj](https://user-images.githubusercontent.com/6137576/197310145-99ea4e02-5ecc-4650-b9fa-7a429a3a9ea9.png)

### Proof
<!-- Link resources as proof -->
- Check the issue this PR fixes.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/vmangos/core/issues/1370

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .level 59
- .debug bg
- .go alterac
- Cap any graveyard, bunker or tower.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
