### PR TITLE
allow mounts on elevators

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6973,7 +6973,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                     return SPELL_FAILED_ONLY_ABOVEWATER;
 
                 if (m_casterUnit->IsPlayer() && (static_cast<Player*>(m_casterUnit)->GetTransport() && static_cast<Player*>(m_casterUnit)->GetTransport()->IsMoTransport()))
-                        return SPELL_FAILED_NO_MOUNTS_ALLOWED;
+                    return SPELL_FAILED_NO_MOUNTS_ALLOWED;
 
                 /// Specific case for Temple of Ahn'Qiraj mounts as they are usable only in AQ40 and are the only mounts allowed here
                 /// TBC and above handle this by using m_spellInfo->AreaId

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6972,7 +6972,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                 if (m_casterUnit->IsInWater() && (!m_casterUnit->IsPlayer() || static_cast<Player*>(m_casterUnit)->IsInHighLiquid()))
                     return SPELL_FAILED_ONLY_ABOVEWATER;
 
-                if (m_casterUnit->IsPlayer() && (static_cast<Player*>(m_casterUnit)->GetTransport() && static_cast<Player*>(m_casterUnit)->GetTransport()->IsMoTransport()))
+                if (m_casterUnit->IsPlayer() && (m_casterUnit->GetTransport() && m_casterUnit->GetTransport()->IsMoTransport()))
                     return SPELL_FAILED_NO_MOUNTS_ALLOWED;
 
                 /// Specific case for Temple of Ahn'Qiraj mounts as they are usable only in AQ40 and are the only mounts allowed here

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6972,8 +6972,8 @@ SpellCastResult Spell::CheckCast(bool strict)
                 if (m_casterUnit->IsInWater() && (!m_casterUnit->IsPlayer() || static_cast<Player*>(m_casterUnit)->IsInHighLiquid()))
                     return SPELL_FAILED_ONLY_ABOVEWATER;
 
-                if (m_casterUnit->IsPlayer() && static_cast<Player*>(m_casterUnit)->GetTransport())
-                    return SPELL_FAILED_NO_MOUNTS_ALLOWED;
+                if (m_casterUnit->IsPlayer() && (static_cast<Player*>(m_casterUnit)->GetTransport() && static_cast<Player*>(m_casterUnit)->GetTransport()->IsMoTransport()))
+                        return SPELL_FAILED_NO_MOUNTS_ALLOWED;
 
                 /// Specific case for Temple of Ahn'Qiraj mounts as they are usable only in AQ40 and are the only mounts allowed here
                 /// TBC and above handle this by using m_spellInfo->AreaId


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Allows mounting on elevators and still keeps the restriction of no mounting on boats and zeppelins.

This affects elevators at Thunder Bluff, Freewind Post, Undercity, and The Cauldron in Searing gorge. All other elevators are restricted due to being indoors.

### Proof
<!-- Link resources as proof -->
- https://youtu.be/Wkbwmy-Ht6Y?t=137 - Mount on Thunder Bluff elevator - Uploaded 26. sep. 2006 - Patch 1.12.0 
- https://youtu.be/qOxnmvr5uwQ?t=117 - Mount on Freewind Post elevator - Uploaded 22. sep. 2006 - Patch 1.12.0 
- https://youtu.be/gN3Z2vVNQAE?t=1792 - Mount on Undercity undervator - Uploaded 21. mar. 2014 - Joanas 1-60 are recorded during Patch 1.10

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- (https://github.com/Wall-core/Everlook-Bugtracker/issues/432)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Mounting on various types of elevators.
- Being mounted and moving onto elevators.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
