### PR TITLE
Fix missing despawn on wipe

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/blackrock_depths/blackrock_depths.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackrock_depths/blackrock_depths.cpp
@@ -63,7 +63,9 @@ bool GOHello_go_shadowforge_brazier(Player* pPlayer, GameObject* pGo)
 enum
 {
     //4 or 6 in total? 1+2+1 / 2+2+2 / 3+3. Depending on this, code should be changed.
-    MAX_MOB_AMOUNT      = 8
+    MAX_MOB_AMOUNT      = 8,
+
+    SPELL_GRIMSTONE_TELEPORT = 6422,
 };
 
 uint32 RingMob[] =
@@ -394,6 +396,7 @@ struct npc_grimstoneAI : public npc_escortAI
                     case 3:
                         DoGate(DATA_ARENA1, GO_STATE_ACTIVE);
                         Event_Timer = 3000;
+                        DoCastSpellIfCan(m_creature, SPELL_GRIMSTONE_TELEPORT);
                         break;
                     case 4:
                         CanWalk = true;
@@ -436,14 +439,17 @@ struct npc_grimstoneAI : public npc_escortAI
                         break;
                     case 11:
                         DoGate(DATA_ARENA2, GO_STATE_ACTIVE);
-                        Event_Timer = 5000;
+                        Event_Timer = 3000;
                         break;
                     case 12:
+                        DoCastSpellIfCan(m_creature, SPELL_GRIMSTONE_TELEPORT);
+                        Event_Timer = 2000;
+                    case 13:
                         m_creature->SetVisibility(VISIBILITY_OFF);
                         SummonRingBoss();
                         Event_Timer = 0;
                         break;
-                    case 13:
+                    case 14:
                         //if quest, complete
                         DoGate(DATA_ARENA2, GO_STATE_READY);
                         DoGate(DATA_ARENA3, GO_STATE_ACTIVE);
@@ -493,9 +499,13 @@ struct npc_grimstoneAI : public npc_escortAI
             if (!RingBossGUID)
             {
                 m_pInstance->SetData(TYPE_RING_OF_LAW, NOT_STARTED);
+                
+                for (uint64& guid : RingMobGUID)
+                    if (Creature* mob = m_creature->GetMap()->GetCreature(guid))
+                        mob->ForcedDespawn();                     
 
-                Reset();
                 m_creature->ForcedDespawn();
+                Reset();
             }
         }
         


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fixes mobs not despawning if wiping on first waves. 
Adds missing visual teleport spell to Grimstone.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Wipe on first waves.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None

I think the entire script could use an overhaul and be cross-checked with classic.