### PR TITLE
Damaged items sells for reduced price

### DIFF
--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -640,7 +640,7 @@ void WorldSession::HandleSellItemOpcode(WorldPacket& recv_data)
             }
 
             uint32 dmultiplier = dcost->multiplier[ItemSubClassToDurabilityMultiplierId(pProto->Class, pProto->SubClass)];
-            uint32 repaircost = uint32(LostDurability * dmultiplier * double(dQualitymodEntry->quality_mod));
+            uint32 repaircost = uint32(LostDurability * dmultiplier * dQualitymodEntry->quality_mod);
 
             if (repaircost == 0)
                 repaircost = 1;

--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -614,6 +614,45 @@ void WorldSession::HandleSellItemOpcode(WorldPacket& recv_data)
         }
     }
 
+    uint32 maxDurability = pItem->GetUInt32Value(ITEM_FIELD_MAXDURABILITY);
+    if (maxDurability)
+    {
+        uint32 curDurability = pItem->GetUInt32Value(ITEM_FIELD_DURABILITY);
+        uint32 LostDurability = maxDurability - curDurability;
+
+        if (LostDurability > 0)
+        {
+            DurabilityCostsEntry const* dcost = sDurabilityCostsStore.LookupEntry(pProto->ItemLevel);
+            if (!dcost)
+            {
+                _player->SendSellError(SELL_ERR_CANT_SELL_ITEM, pCreature, itemGuid, 0);
+                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "RepairDurability: Wrong item lvl %u", pProto->ItemLevel);
+                return;
+            }
+
+            uint32 dQualitymodEntryId = (pProto->Quality + 1) * 2;
+            DurabilityQualityEntry const* dQualitymodEntry = sDurabilityQualityStore.LookupEntry(dQualitymodEntryId);
+            if (!dQualitymodEntry)
+            {
+                _player->SendSellError(SELL_ERR_CANT_SELL_ITEM, pCreature, itemGuid, 0);
+                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "RepairDurability: Wrong dQualityModEntry %u", dQualitymodEntryId);
+                return;
+            }
+
+            uint32 dmultiplier = dcost->multiplier[ItemSubClassToDurabilityMultiplierId(pProto->Class, pProto->SubClass)];
+            uint32 repaircost = uint32(LostDurability * dmultiplier * double(dQualitymodEntry->quality_mod));
+
+            if (repaircost == 0)
+                repaircost = 1;
+
+            //starter items can cost more to repair than vendorprice
+            if (repaircost > money)
+                money = 1;
+            else
+                money -= repaircost;
+        }
+    }
+
     if (count < pItem->GetCount())              // need split items
     {
         Item *pNewItem = pItem->CloneItem(count, _player);

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -5215,7 +5215,7 @@ uint32 Player::DurabilityRepair(uint16 pos, bool cost, float discountMod)
             }
 
             uint32 dmultiplier = dcost->multiplier[ItemSubClassToDurabilityMultiplierId(ditemProto->Class, ditemProto->SubClass)];
-            uint32 costs = uint32(LostDurability * dmultiplier * double(dQualitymodEntry->quality_mod));
+            uint32 costs = uint32(LostDurability * dmultiplier * dQualitymodEntry->quality_mod);
 
             costs = uint32(costs * discountMod);
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Reduces vendorprice for sold items by repaircost.

Note: Repaircost is normally reduced by reputation. This isn't the case when we deduct repaircost here,

### Proof
<!-- Link resources as proof -->
- Proof in https://github.com/vmangos/core/issues/1664

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- https://github.com/vmangos/core/issues/1664
- https://github.com/Wall-core/Everlook-Bugtracker/issues/299

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Sell and buy back various damaged/broken items. Compare prices with tooltip.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
