### PR TITLE
Remove pvp quests which should not be available in classic

### DIFF
--- a/sql/migrations/20221105134018_characters.sql
+++ b/sql/migrations/20221105134018_characters.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20221105134018');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20221105134018');
+-- Add your query below.
+
+DELETE FROM `character_queststatus` WHERE `quest` IN(8388, 8367, 8371, 8385);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20221105134018_world.sql
+++ b/sql/migrations/20221105134018_world.sql
@@ -1,0 +1,32 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20221105134018');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20221105134018');
+-- Add your query below.
+
+-- https://www.wowhead.com/tbc/quest=8388/for-great-honor
+DELETE FROM `creature_questrelation` WHERE `quest`=8388;
+DELETE FROM `quest_template` WHERE `entry`=8388;
+
+-- https://www.wowhead.com/tbc/quest=8367/for-great-honor
+DELETE FROM `creature_questrelation` WHERE `quest`=8367;
+DELETE FROM `quest_template` WHERE `entry`=8367;
+
+-- https://www.wowhead.com/tbc/quest=8371/concerted-efforts
+DELETE FROM `creature_questrelation` WHERE `quest`=8371;
+DELETE FROM `quest_template` WHERE `entry`=8371;
+
+-- https://www.wowhead.com/tbc/quest=8385/concerted-efforts
+DELETE FROM `creature_questrelation` WHERE `quest`=8385;
+DELETE FROM `quest_template` WHERE `entry`=8385;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Noticed that those quests should not be available in classic, since with German locales Shattrath is mentioned in quest description.
https://www.wowhead.com/tbc/quest=8388/for-great-honor
https://www.wowhead.com/tbc/quest=8367/for-great-honor
https://www.wowhead.com/tbc/quest=8371/concerted-efforts
https://www.wowhead.com/tbc/quest=8385/concerted-efforts

[Update]
Those quests do exist in wowhead classic, so they might belong to classic !?
https://www.wowhead.com/classic/quest=8388/for-great-honor
https://www.wowhead.com/classic/quest=8367/for-great-honor
https://www.wowhead.com/classic/quest=8371/concerted-efforts
https://www.wowhead.com/classic/quest=8385/concerted-efforts 

### Proof
Quest tag in client seems to be off for some of those quests:
<img width="200" alt="quest" src="https://user-images.githubusercontent.com/9536270/200124635-fc312cfb-1a39-4b6c-b837-a036fee74188.PNG">
<img width="200" alt="questa" src="https://user-images.githubusercontent.com/9536270/200124637-1aeeb420-3009-4ee2-81f5-13b76fdfeb30.PNG">


### Issues
- None

### How2Test
- None

### Todo / Checklist
- [ ] needs prove 
