### PR TITLE
Change max allowed packet size for db_check worlflow

### DIFF
--- a/.github/workflows/db_check.yml
+++ b/.github/workflows/db_check.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Start docker mysql
       run: |
         sudo docker pull mysql
-        sudo docker run --name mysqldb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:5.6
+        sudo docker run --name mysqldb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:5.6 --max_allowed_packet=128M
         sudo docker start mysqldb
 
     


### PR DESCRIPTION

## 🍰 Pullrequest

@ratkosrb did this already on the db_dump workflow, it applies to the db_check workflow as well for the PR checks.  

also attach some backup information is just for reference. see ```Configuration without a cnf file``` in here https://hub.docker.com/_/mysql/,

and here https://stackoverflow.com/questions/39369367/increase-max-allowed-packet-size-in-mysql-docker

