### PR TITLE
Fixes for Warden on Mac.

### DIFF
--- a/sql/migrations/20221111031829_logon.sql
+++ b/sql/migrations/20221111031829_logon.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20221111031829');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20221111031829');
+-- Add your query below.
+
+
+ALTER TABLE `account`
+	ADD COLUMN `platform` VARCHAR(4) NOT NULL DEFAULT '' AFTER `os`;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Anticheat/WardenAnticheat/Warden.cpp
+++ b/src/game/Anticheat/WardenAnticheat/Warden.cpp
@@ -273,8 +273,11 @@ void Warden::RequestScans(std::vector<std::shared_ptr<const Scan>> &&scans)
     // all scan requests
     buff.append(scan);
 
-    // indicates to the client that there are no further requests in this packet
-    buff << _xor;
+    if (_session->GetOS() == CLIENT_OS_WIN)
+    {
+        // indicates to the client that there are no further requests in this packet
+        buff << _xor;
+    }
 
     BeginTimeoutClock();
     SendPacket(buff);

--- a/src/game/Anticheat/WardenAnticheat/Warden.hpp
+++ b/src/game/Anticheat/WardenAnticheat/Warden.hpp
@@ -92,8 +92,6 @@ class Warden
         void RequestChallenge();
         void HandleChallengeResponse(ByteBuffer &buff);
 
-        std::vector<std::shared_ptr<const Scan>> SelectScans(ScanFlags flags) const;
-
         void ReadScanResults(ByteBuffer &buff);
 
     protected:
@@ -103,6 +101,7 @@ class Warden
         static constexpr size_t KeyLength = 16;
 
         virtual uint32 GetScanFlags() const = 0;
+        std::vector<std::shared_ptr<const Scan>> SelectScans(ScanFlags flags) const;
 
         void BeginScanClock();
 

--- a/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
@@ -82,7 +82,7 @@ WardenMac::WardenMac(WorldSession *session, const BigNumber &K)
 
     Sha1Hash sha1;
     sha1.UpdateData(_hashString);
-    if (_session->GetPlatform() == CLIENT_PLATFORM_X86) // Not on PPC
+    if (_module) // this constant is only used if there is a module
         sha1.UpdateData(reinterpret_cast<const uint8 *>(&magic), sizeof(magic));
     sha1.Finalize();
 

--- a/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
@@ -68,7 +68,7 @@ void WardenMac::LoadScriptedScans()
 }
 
 WardenMac::WardenMac(WorldSession *session, const BigNumber &K)
-    : _fingerprintSaved(false), Warden(session, sWardenModuleMgr.GetMacModule(), K)
+    : _fingerprintSaved(false), Warden(session, session->GetPlatform() == CLIENT_PLATFORM_X86 ? sWardenModuleMgr.GetMacModule() : nullptr, K)
 {
     std::stringstream hash;
 
@@ -82,7 +82,8 @@ WardenMac::WardenMac(WorldSession *session, const BigNumber &K)
 
     Sha1Hash sha1;
     sha1.UpdateData(_hashString);
-    sha1.UpdateData(reinterpret_cast<const uint8 *>(&magic), sizeof(magic));
+    if (_session->GetPlatform() == CLIENT_PLATFORM_X86) // Not on PPC
+        sha1.UpdateData(reinterpret_cast<const uint8 *>(&magic), sizeof(magic));
     sha1.Finalize();
 
     memcpy(_hashSHA, sha1.GetDigest(), sizeof(_hashSHA));
@@ -91,6 +92,20 @@ WardenMac::WardenMac(WorldSession *session, const BigNumber &K)
     MD5_Init(&md5);
     MD5_Update(&md5, _hashString.c_str(), _hashString.size());
     MD5_Final(_hashMD5, &md5);
+
+    // PPC no module, begin string hashing requests directly
+    if (session->GetPlatform() != CLIENT_PLATFORM_X86)
+    {
+        // at this point the client has our module loaded.  send whatever packets are necessary to initialize Warden
+        InitializeClient();
+
+        // send any initial hack scans that the scan manager may have for us
+        RequestScans(SelectScans(ScanFlags::InitialLogin));
+
+        // begin the scan clock (note that even if the clock expires before any initial scans are answered, no new
+        // checks will be requested until the reply is received).
+        BeginScanClock();
+    }
 }
 
 void WardenMac::Update()

--- a/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
@@ -94,7 +94,7 @@ WardenMac::WardenMac(WorldSession *session, const BigNumber &K)
     MD5_Final(_hashMD5, &md5);
 
     // PPC no module, begin string hashing requests directly
-    if (session->GetPlatform() != CLIENT_PLATFORM_X86)
+    if (_module)
     {
         // at this point the client has our module loaded.  send whatever packets are necessary to initialize Warden
         InitializeClient();

--- a/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenMac.cpp
@@ -47,8 +47,7 @@ void WardenMac::LoadScriptedScans()
 
         MANGOS_ASSERT(macWarden->_hashString.size() <= 0xFF);
 
-        scan << static_cast<uint8>(WARDEN_SMSG_CHEAT_CHECKS_REQUEST)
-             << static_cast<uint8>(macWarden->_hashString.size());
+        scan << static_cast<uint8>(macWarden->_hashString.size());
 
         // skip null terminator this way
         scan.append(macWarden->_hashString.c_str(), macWarden->_hashString.size());

--- a/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
@@ -1149,7 +1149,7 @@ void WardenWin::ValidateEndScene(const std::vector<uint8> &code)
     // int3 breakpoint
     if (*p == 0xCC)
     {
-        sLog.Player(_session, LOG_ANTICHEAT, "Warden", LOG_LVL_BASIC, "Detected INT3 EndScene hook.  NOP count = %d.",
+        sLog.OutWardenPlayer(_session, LOG_ANTICHEAT, LOG_LVL_BASIC, "Detected INT3 EndScene hook.  NOP count = %d.",
             nopCount);
     }
     // JMP hook
@@ -1158,7 +1158,7 @@ void WardenWin::ValidateEndScene(const std::vector<uint8> &code)
         auto const dest = *reinterpret_cast<const uint32 *>(p + 1);
 
         auto const absoluteDest = _endSceneAddress + nopCount + dest + 5;
-        sLog.Player(_session, LOG_ANTICHEAT, "Warden", LOG_LVL_BASIC, "Detected JMP EndScene hook.  NOP count = %d.",
+        sLog.OutWardenPlayer(_session, LOG_ANTICHEAT, LOG_LVL_BASIC, "Detected JMP EndScene hook.  NOP count = %d.",
             nopCount);
 
         // request a custom scan just to check the JMP destination
@@ -1208,7 +1208,7 @@ uint32 WardenWin::GetScanFlags() const
 
     if (!found)
     {
-        sLog.Player(_session, LOG_ANTICHEAT, "Warden", LOG_LVL_BASIC, "Invalid client build %u.  Kicking.", _session->GetGameBuild());
+        sLog.OutWardenPlayer(_session, LOG_ANTICHEAT, LOG_LVL_BASIC, "Invalid client build %u.  Kicking.", _session->GetGameBuild());
         _session->KickPlayer();
         return ScanFlags::None;
     }

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -22410,6 +22410,26 @@ void Log::Player(WorldSession const* session, LogType logType, LogLevel logLevel
     }
 }
 
+void Log::OutWardenPlayer(WorldSession const* session, LogType logType, LogLevel logLevel, char const* format, ...)
+{
+    char buff[4096];
+    va_list ap;
+    va_start(ap, format);
+    vsnprintf(buff, sizeof(buff), format, ap);
+    va_end(ap);
+
+    std::string log;
+
+    if (m_wardenDebug && logLevel > LOG_LVL_MINIMAL)
+        logLevel = LOG_LVL_MINIMAL;
+
+    if (PlayerLogFormatted(session->GetAccountId(), session, logType, "Warden", logLevel, buff, log))
+    {
+        OutConsole(logType, logLevel, log);
+        OutFile(logType, logLevel, log);
+    }
+}
+
 void Log::Player(WorldSession const* session, LogType logType, char const* subType, LogLevel logLevel, char const* format, ...)
 {
     char buff[4096];

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -75,7 +75,7 @@ WorldSession::WorldSession(uint32 id, WorldSocket *sock, AccountTypes sec, time_
     m_accountFlags(0), m_idleTime(WorldTimer::getMSTime()), _player(nullptr), m_socket(sock), m_security(sec), m_accountId(id), m_logoutTime(0), m_inQueue(false),
     m_playerLoading(false), m_playerLogout(false), m_playerRecentlyLogout(false), m_playerSave(false), m_sessionDbcLocale(sWorld.GetAvailableDbcLocale(locale)),
     m_sessionDbLocaleIndex(sObjectMgr.GetIndexForLocale(locale)), m_latency(0), m_tutorialState(TUTORIALDATA_UNCHANGED), m_warden(nullptr), m_cheatData(nullptr),
-    m_bot(nullptr), m_clientOS(CLIENT_OS_UNKNOWN), m_gameBuild(0),
+    m_bot(nullptr), m_clientOS(CLIENT_OS_UNKNOWN), m_clientPlatform(CLIENT_PLATFORM_UNKNOWN), m_gameBuild(0),
     m_charactersCount(10), m_characterMaxLevel(0), m_lastPubChannelMsgTime(0), m_moveRejectTime(0), m_masterPlayer(nullptr)
 {
     if (sock)

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -86,6 +86,13 @@ enum ClientOSType
     CLIENT_OS_MAC
 };
 
+enum ClientPlatformType
+{
+    CLIENT_PLATFORM_UNKNOWN,
+    CLIENT_PLATFORM_X86,
+    CLIENT_PLATFORM_PPC
+};
+
 enum PartyOperation
 {
     PARTY_OP_INVITE = 0,
@@ -281,6 +288,8 @@ class WorldSession
         void SetGameBuild(uint32 v) { m_gameBuild = v; }
         ClientOSType GetOS() const { return m_clientOS; }
         void SetOS(ClientOSType os) { m_clientOS = os; }
+        ClientPlatformType GetPlatform() const { return m_clientPlatform; }
+        void SetPlatform(ClientPlatformType platform) { m_clientPlatform = platform; }
         uint32 GetDialogStatus(Player* pPlayer, Object* questgiver, uint32 defstatus);
         uint32 GetAccountMaxLevel() const { return m_characterMaxLevel; }
         void SetAccountFlags(uint32 f) { m_accountFlags = f; }
@@ -847,6 +856,7 @@ class WorldSession
         LocaleConstant m_sessionDbcLocale;
         int m_sessionDbLocaleIndex;
         ClientOSType    m_clientOS;
+        ClientPlatformType m_clientPlatform;
         uint32          m_gameBuild;
         std::shared_ptr<PlayerBotEntry> m_bot;
 

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -1454,6 +1454,11 @@ Antiflood.Sanction = 8
 #        Default:     86400 - (24 hours)
 #                     0     - (Permanent ban)
 #
+#    Warden.DebugLog
+#        Description: Prints additional information about performed checks.
+#        Default:     0 - (Disabled)
+#                     1 - (Enabled)
+#
 #    Warden.ModuleDir
 #        Description: Directory where warden modules are stored.
 #        Default: "warden_modules"
@@ -1468,6 +1473,7 @@ Warden.ClientResponseDelay   = 30
 Warden.ScanFrequency         = 15
 Warden.DefaultPenalty        = 0
 Warden.BanDuration           = 86400
+Warden.DebugLog              = 0
 Warden.ModuleDir             = "warden_modules"
 
 ###################################################################################################

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -767,9 +767,10 @@ bool AuthSocket::_HandleLogonProof()
         ///- Update the sessionkey, last_ip, last login time and reset number of failed logins in the account table for this account
         // No SQL injection (escaped user name) and IP address as received by socket
         const char* K_hex = srp.GetStrongSessionKey().AsHexStr();
-        const char *os = reinterpret_cast<char *>(&_os);    // no injection as there are only two possible values
-        auto result = LoginDatabase.PQuery("UPDATE `account` SET `sessionkey` = '%s', `last_ip` = '%s', `last_login` = NOW(), `locale` = '%u', `failed_logins` = 0, `os` = '%s' WHERE `username` = '%s'",
-            K_hex, get_remote_address().c_str(), GetLocaleByName(_localizationName), os, _safelogin.c_str() );
+        const char *os = reinterpret_cast<char *>(&_os); // no injection as there are only two possible values
+        const char *platform = reinterpret_cast<char *>(&_platform); // no injection as there are only two possible values
+        auto result = LoginDatabase.PQuery("UPDATE `account` SET `sessionkey` = '%s', `last_ip` = '%s', `last_login` = NOW(), `locale` = '%u', `failed_logins` = 0, `os` = '%s', `platform` = '%s' WHERE `username` = '%s'",
+            K_hex, get_remote_address().c_str(), GetLocaleByName(_localizationName), os, platform, _safelogin.c_str() );
         delete result;
         OPENSSL_free((void*)K_hex);
 

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -1399,6 +1399,9 @@ bool AuthSocket::GeographicalLockCheck()
 
 bool AuthSocket::VerifyVersion(uint8 const* a, int32 aLength, uint8 const* versionProof, bool isReconnect)
 {
+    if (!((_platform == X86 || _platform == PPC) && (_os == Win || _os == OSX)))
+        return false;
+
     if (!sConfig.GetBoolDefault("StrictVersionCheck", false))
         return true;
 
@@ -1406,9 +1409,6 @@ bool AuthSocket::VerifyVersion(uint8 const* a, int32 aLength, uint8 const* versi
     std::array<uint8, 20> const* versionHash = nullptr;
     if (!isReconnect)
     {
-        if (!((_platform == X86 || _platform == PPC) && (_os == Win || _os == OSX)))
-            return false;
-
         RealmBuildInfo const* buildInfo = FindBuildInfo(_build);
         if (!buildInfo)
             return false;

--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -127,6 +127,7 @@ Log::Log() :
     logFiles[LOG_ANTICHEAT] = openLogFile("LogFile.Anticheat", "Anticheat.log", log_file_timestamp, false);
 
     // Main log file settings
+    m_wardenDebug = sConfig.GetBoolDefault("Warden.DebugLog", false);
     m_includeTime = sConfig.GetBoolDefault("LogTime", false);
     m_consoleLevel = LogLevel(sConfig.GetIntDefault("LogLevel.Console", 2));
     m_fileLevel = LogLevel(sConfig.GetIntDefault("LogLevel.File", 2));

--- a/src/shared/Log.h
+++ b/src/shared/Log.h
@@ -163,7 +163,7 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, std::m
         // for player-specific messages
         void Player(WorldSession const* session, LogType logType, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(5, 6);
         void Player(WorldSession const* session, LogType logType, char const* subTytpe, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(6, 7);
-        void OutWardenPlayer(WorldSession const* session, LogType logType, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(6, 7);
+        void OutWardenPlayer(WorldSession const* session, LogType logType, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(5, 6);
         void Player(uint32 accountId, LogType logType, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(5, 6);
         void Player(uint32 accountId, LogType logType, char const* subTytpe, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(6, 7);
 

--- a/src/shared/Log.h
+++ b/src/shared/Log.h
@@ -163,6 +163,7 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, std::m
         // for player-specific messages
         void Player(WorldSession const* session, LogType logType, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(5, 6);
         void Player(WorldSession const* session, LogType logType, char const* subTytpe, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(6, 7);
+        void OutWardenPlayer(WorldSession const* session, LogType logType, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(6, 7);
         void Player(uint32 accountId, LogType logType, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(5, 6);
         void Player(uint32 accountId, LogType logType, char const* subTytpe, LogLevel logLevel, char const* format, ...) ATTR_PRINTF(6, 7);
 
@@ -209,6 +210,7 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, std::m
         uint16 const m_defaultColor;
 
         // include timestamp in console output
+        bool m_wardenDebug;
         bool m_includeTime;
         uint32 m_logFilter;
 


### PR DESCRIPTION
- Scans for Mac weren't even being loaded, so the string hash request was never sent.
- The game crashed if you connected with the PPC client, because it was being sent a x86 module.
- The structure of WARDEN_SMSG_CHEAT_CHECKS_REQUEST was wrong for Mac.
- Added back the Warden.DebugLog option so I can actually see what's happening in the console.

Thanks to @Daribon and @GrenderG for helping to test.