### PR TITLE
Make bots can use their mainhand weapon effect.

### DIFF
--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -3121,6 +3121,9 @@ void CombatBotBaseAI::UseTrinketEffects()
     if (Item* pItem = me->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_TRINKET2))
         if (UseItemEffect(pItem))
             return;
+    if (Item* pItem = me->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND)) //add use of mainhand weapon effect
+        if (UseItemEffect(pItem))
+            return;
 }
 
 bool CombatBotBaseAI::UseItemEffect(Item* pItem)


### PR DESCRIPTION
Add this change because some main hand weapon has effect can be used for example [manual-crowd-pummele](https://www.wowhead.com/classic/item=9449/manual-crowd-pummeler)

