### PR TITLE
Remove unused WOTLK extraction of liquid(type.dbc) 

### DIFF
--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -64,7 +64,6 @@ typedef struct
 } map_id;
 
 map_id* map_ids;
-uint16* LiqType = 0;
 uint32 map_count;
 char output_path[128] = ".";
 char input_path[1024] = ".";
@@ -104,28 +103,6 @@ void strToLower(char* str)
         *str = tolower(*str);
         ++str;
     }
-}
-
-// copied from contrib/extractor/System.cpp
-void ReadLiquidTypeTableDBC()
-{
-    printf("Read LiquidType.dbc file...");
-    DBCFile dbc("DBFilesClient\\LiquidType.dbc");
-    if (!dbc.open())
-    {
-        printf("Fatal error: Invalid LiquidType.dbc file format!\n");
-        exit(1);
-    }
-
-    size_t LiqType_count = dbc.getRecordCount();
-    size_t LiqType_maxid = dbc.getRecord(LiqType_count - 1).getUInt(0);
-    LiqType = new uint16[LiqType_maxid + 1];
-    memset(LiqType, 0xff, (LiqType_maxid + 1) * sizeof(uint16));
-
-    for (uint32 x = 0; x < LiqType_count; ++x)
-        LiqType[dbc.getRecord(x).getUInt(0)] = dbc.getRecord(x).getUInt(3);
-
-    printf("Done! (%u LiqTypes loaded)\n", (unsigned int)LiqType_count);
 }
 
 bool ExtractWmo()
@@ -479,7 +456,6 @@ int main(int argc, char** argv)
         printf("FATAL ERROR: None MPQ archive found by path '%s'. Use -d option with proper path.\n", input_path);
         return 1;
     }
-    ReadLiquidTypeTableDBC();
 
     // extract data
     if (success)
@@ -522,6 +498,5 @@ int main(int argc, char** argv)
     }
 
     printf("Extract for %s. Work complete. No errors.\n", szRawVMAPMagic);
-    delete [] LiqType;
     return 0;
 }

--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -30,7 +30,6 @@
 #include "mpq_libmpq04.h"
 
 using namespace std;
-extern uint16* LiqType;
 
 WMORoot::WMORoot(std::string& filename)
     : filename(filename), color(0), nTextures(0), nGroups(0), nPortals(0), nLights(0),


### PR DESCRIPTION
## 🍰 Pullrequest
Updates the extractor so they no longer require liquidtype.dbc

The data is only used for the extraction of WotLK maps - and is not needed for vanilla.

### References
<!-- Link resources as proof -->
- (https://wowdev.wiki/ADT/v18) documentation for MCLQ and MH2O chunks in ADT files.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Extracting maps for older vanilla clients that don't contain the liquidtype.dbc
- https://github.com/vmangos/core/issues/639

