### PR TITLE
fix illumination mana return

### DIFF
--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -1514,12 +1514,11 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 d
                     return SPELL_AURA_PROC_FAILED;
 
                 // procspell is triggered spell but we need mana cost of original casted spell
-                // The casted spell is in a variable: Player::m_castingSpell. Otherwise we can not find the spell that caused the proc.
-
-                SpellEntry const* originalSpell = sSpellMgr.GetSpellEntry(pPlayer->m_castingSpell);
+                
+                SpellEntry const* originalSpell = sSpellMgr.GetSpellEntry(procSpell->Id);
                 if (!originalSpell)
                 {
-                    sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Unit::HandleProcTriggerSpell: Spell %u unknown but selected as original in Illu", pPlayer->m_castingSpell);
+                    sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Unit::HandleProcTriggerSpell: Spell %u unknown but selected as original in Illu", procSpell->Id);
                     return SPELL_AURA_PROC_FAILED;
                 }
                 // Histoire de pas reproc une autre fois ... :S


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changes illumination to return mana based on spell causing the proc instead of m_castingSpell.
This prevents incorrect mana return and therefore an exploit where proccing illumination and casting a higher manacost spell - would refund the mana of the spell being cast.

### Proof
<!-- Link resources as proof -->
- I can find no references to this bug being blizzlike.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- (https://github.com/Wall-core/Everlook-Bugtracker/issues/722)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .m spellcrit 100
- Spam various holy light, flash and shock
- Notice that mana return is from the spell critting, and not from the next spell being cast.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
