### PR TITLE
Fix undefined nullptr_t type in SqlPreparedStatement.h

### DIFF
--- a/src/shared/Database/SqlPreparedStatement.h
+++ b/src/shared/Database/SqlPreparedStatement.h
@@ -124,7 +124,7 @@ class SqlStmtFieldData
 };
 
 //template specialization
-template<> inline void SqlStmtFieldData::set(nullptr_t) { m_type = FIELD_NONE; }
+template<> inline void SqlStmtFieldData::set(std::nullptr_t) { m_type = FIELD_NONE; }
 template<> inline void SqlStmtFieldData::set(bool val) { m_type = FIELD_BOOL; m_binaryData.boolean = val; }
 template<> inline void SqlStmtFieldData::set(uint8 val) { m_type = FIELD_UI8; m_binaryData.ui8 = val; }
 template<> inline void SqlStmtFieldData::set(int8 val) { m_type = FIELD_I8; m_binaryData.i8 = val; }


### PR DESCRIPTION


## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
With clang 13 and 14 I get the following build error:

```
/build/source/src/shared/Database/SqlPreparedStatement.h:128:46: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
template<> inline void SqlStmtFieldData::set(nullptr_t) { m_type = FIELD_NONE; }
                                             ^~~~~~~~~
                                             std::nullptr_t
```


### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
