### PR TITLE
Misc db fixes

### DIFF
--- a/sql/migrations/20221204184605_world.sql
+++ b/sql/migrations/20221204184605_world.sql
@@ -14,6 +14,11 @@ UPDATE `creature_loot_template` SET `condition_id`=0 WHERE `item`=1357;
 -- Change GO Schematic: Field Repair Bot 74A to patch 1.3
 UPDATE `gameobject_template` SET `patch`=1 WHERE `entry`=179552;
 
+-- crimson courier was missing her mount
+UPDATE `creature_addon` SET `mount_display_id`='2410' WHERE  `guid`=92287 AND `patch`=0;
+-- Change Crimson Courier weapon
+UPDATE `creature_equip_template` SET `equipentry1`='193' WHERE  `entry`=429 AND `patch`=0;
+
 -- End of migration.
 END IF;
 END??

--- a/sql/migrations/20221204184605_world.sql
+++ b/sql/migrations/20221204184605_world.sql
@@ -9,7 +9,7 @@ INSERT INTO `migrations` VALUES ('20221204184605');
 -- Add your query below.
 
 -- Remove alliance only condition from Captain Sander's Treasure Map
-UPDATE `creauture_loot_template` SET `condition_id`=0 WHERE item=1357;
+UPDATE `creature_loot_template` SET `condition_id`=0 WHERE `item`=1357;
 
 -- Change GO Schematic: Field Repair Bot 74A to patch 1.3
 UPDATE `gameobject_template` SET `patch`=1 WHERE `entry`=179552;

--- a/sql/migrations/20221204184605_world.sql
+++ b/sql/migrations/20221204184605_world.sql
@@ -19,6 +19,9 @@ UPDATE `creature_addon` SET `mount_display_id`='2410' WHERE  `guid`=92287 AND `p
 -- Change Crimson Courier weapon
 UPDATE `creature_equip_template` SET `equipentry1`='1903' WHERE  `entry`=429 AND `patch`=0;
 
+-- Replace equipment for crimson bodyguards according to sniffs
+UPDATE `creature_equip_template` SET `equipentry1`=3361, `equipentry2`=12932, `equipentry3`=0 WHERE `entry`=2058 AND `patch`=0;
+
 -- End of migration.
 END IF;
 END??

--- a/sql/migrations/20221204184605_world.sql
+++ b/sql/migrations/20221204184605_world.sql
@@ -14,13 +14,10 @@ UPDATE `creature_loot_template` SET `condition_id`=0 WHERE `item`=1357;
 -- Change GO Schematic: Field Repair Bot 74A to patch 1.3
 UPDATE `gameobject_template` SET `patch`=1 WHERE `entry`=179552;
 
--- crimson courier was missing her mount
-UPDATE `creature_addon` SET `mount_display_id`='2410' WHERE  `guid`=92287 AND `patch`=0;
--- Change Crimson Courier weapon
-UPDATE `creature_equip_template` SET `equipentry1`='1903' WHERE  `entry`=429 AND `patch`=0;
-
--- Replace equipment for crimson bodyguards according to sniffs
-UPDATE `creature_equip_template` SET `equipentry1`=3361, `equipentry2`=12932, `equipentry3`=0 WHERE `entry`=2058 AND `patch`=0;
+-- Remove creature addon from crimson courier and her bodyguards
+-- Not needed and referenced wrong equipment ids
+DELETE FROM `creature_addon` WHERE `guid`=92287 AND `patch`=0;
+DELETE FROM `creature_addon` WHERE `patch`=0 AND `guid` IN (92288,92289,92290,92291);
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20221204184605_world.sql
+++ b/sql/migrations/20221204184605_world.sql
@@ -17,7 +17,7 @@ UPDATE `gameobject_template` SET `patch`=1 WHERE `entry`=179552;
 -- crimson courier was missing her mount
 UPDATE `creature_addon` SET `mount_display_id`='2410' WHERE  `guid`=92287 AND `patch`=0;
 -- Change Crimson Courier weapon
-UPDATE `creature_equip_template` SET `equipentry1`='193' WHERE  `entry`=429 AND `patch`=0;
+UPDATE `creature_equip_template` SET `equipentry1`='1903' WHERE  `entry`=429 AND `patch`=0;
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20221204184605_world.sql
+++ b/sql/migrations/20221204184605_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20221204184605');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20221204184605');
+-- Add your query below.
+
+-- Remove alliance only condition from Captain Sander's Treasure Map
+UPDATE `creauture_loot_template` SET `condition_id`=0 WHERE item=1357;
+
+-- Change GO Schematic: Field Repair Bot 74A to patch 1.3
+UPDATE `gameobject_template` SET `patch`=1 WHERE `entry`=179552;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Misc database fixes.
Set patch 1.3 for the Schematic: Field Repair Bot 74A gameobject. 
Captain Sander's Treasure Map should be bootable for both factions.
Crimson courier was missing mount and used an incorrect weapon according to sniffs.

### Proof
<!-- Link resources as proof -->
Field repair bot was added in 1.3 - the looted schematic is already set to patch 1.3 - the change is updating the gameobject to the same patch.

There are several mentions of Captain Sander's Treasure Map to be looted and completed by horde players.
![image](https://user-images.githubusercontent.com/2223066/205509960-d2187d5a-8be8-470c-ab53-2b86b00b3b41.png)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
