### PR TITLE
Fix SMSG_SPELLDISPELLOG packets for pre-1.12 clients

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3227,12 +3227,11 @@ void Spell::EffectDispel(SpellEffectIndex effIdx)
         {
             int32 count = successList.size();
             WorldPacket data(SMSG_SPELLDISPELLOG, 8 + 8 + 4 + count * 4);
-#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
             data << unitTarget->GetPackGUID();              // Victim GUID
             data << m_caster->GetPackGUID();                // Caster GUID
 #else
             data << unitTarget->GetGUID();              // Victim GUID
-            data << m_caster->GetGUID();                // Caster GUID
 #endif
             data << uint32(count);
             for (const auto& j : successList)


### PR DESCRIPTION
## 🍰 Pullrequest
The 1.9 to 1.11 clients expect the standard GUID for this packet, rather than the packed GUID. These clients weren't showing the
"&lt;spell&gt; is removed" dispel log when receiving the packed GUID. Pre-1.12 clients also don't expect the caster GUID in this packet, and including it causes the client to log an invalid extra dispel "Your Word of Recall (OLD) is removed". If an NPC cast the dispel, the caster GUID would also cause the client to completely freeze for a few seconds.

### Proof
Patch 1.11 - https://www.youtube.com/watch?v=OxxBIsx9rfk&t=70s
> Abuelo casts Dispel Magic on Meatball.
>
> Meatball's Ignite Mana is removed.

### Before and after screenshots
#### 1.6 client
|                               | Before | After |
| ----------------------------- | ------ | ----- |
| Creature dispels party member | ![Enemy-Player - Party](https://user-images.githubusercontent.com/9933525/206917687-fd728672-8099-4de1-9de7-094917f9af2e.png) | ![Enemy-Player - Party](https://user-images.githubusercontent.com/9933525/206917747-10e5611e-4f5e-4cbd-af1a-3755c359f8e7.png) |
| Creature dispels player       | ![Enemy-Player - Victim](https://user-images.githubusercontent.com/9933525/206919373-e43ff226-38e7-4128-aacf-14838bbb8bdb.png) | ![Enemy-Player - Victim](https://user-images.githubusercontent.com/9933525/206919402-3cdd86dc-869d-4c4c-8fd9-2edfbdaa6201.png) |
| Player dispels creature       | ![Player-Enemy - Caster](https://user-images.githubusercontent.com/9933525/206919545-de4984d9-b4d8-43d0-aad0-eb69d1cd4823.png) | ![Player-Enemy - Caster](https://user-images.githubusercontent.com/9933525/206919563-3a5fe74f-326b-48b1-b7d3-340021940b41.png) |
| Party member dispels creature | ![Player-Enemy - Party](https://user-images.githubusercontent.com/9933525/206920898-8cb4f82c-0219-4a06-b63e-978f401a21a1.png) | ![Player-Enemy - Party](https://user-images.githubusercontent.com/9933525/206920904-c0d5f89e-cf89-4aff-b69d-e0fb6db16d78.png) |
| Player dispels party member   | ![Player-Party - Caster](https://user-images.githubusercontent.com/9933525/206921274-bcac649f-4357-4585-9cfd-8cbbcbcff262.png) | ![Player-Party - Caster](https://user-images.githubusercontent.com/9933525/206921281-9607f74d-5e85-46eb-9d81-59ec007ced92.png) |
| Party member dispels player   | ![Player-Party - Victim](https://user-images.githubusercontent.com/9933525/206921347-f61cdea6-3a01-4d59-a495-c22b229ec499.png) | ![Player-Party - Victim](https://user-images.githubusercontent.com/9933525/206921356-d796e39f-4172-400b-b026-396112d06aba.png) |

#### 1.11 client
|                               | Before | After |
| ----------------------------- | ------ | ----- |
| Creature dispels party member | ![Enemy-Player - Party](https://user-images.githubusercontent.com/9933525/206921717-e5c8acd1-8b1f-472b-9d9a-b7b0d8f1a1f7.png) | ![Enemy-Player - Party](https://user-images.githubusercontent.com/9933525/206921725-29b36d3e-6fec-44fd-a6bd-31caf3e9395f.png) |
| Creature dispels player       | ![Enemy-Player - Victim](https://user-images.githubusercontent.com/9933525/206921833-b98ecd2c-bd81-461c-a5dc-df8a21650abe.png) | ![Enemy-Player - Victim](https://user-images.githubusercontent.com/9933525/206921843-58bbf4df-4698-40d7-9c42-8d692e3b4bfe.png) |
| Player dispels creature       | ![Player-Enemy - Caster](https://user-images.githubusercontent.com/9933525/206921939-2f664b1e-2a8b-490f-9379-a9d42d76a1fe.png) | ![Player-Enemy - Caster](https://user-images.githubusercontent.com/9933525/206921945-7fd0b44f-0cba-42f7-b7fa-2b0032a6ab5c.png) |
| Party member dispels creature | ![Player-Enemy - Party](https://user-images.githubusercontent.com/9933525/206922069-e8703b76-28c0-4771-b514-9ae6a1593101.png) | ![Player-Enemy - Party](https://user-images.githubusercontent.com/9933525/206922072-c1788045-e40f-4323-8552-efa2d30a108f.png) |
| Player dispels party member   | ![Player-Party - Caster](https://user-images.githubusercontent.com/9933525/206922748-a87da3b6-8c53-44b3-a8e2-ec28214cb78b.png) | ![Player-Party - Caster](https://user-images.githubusercontent.com/9933525/206922761-65436dc0-b587-4024-9944-16cee33fa21a.png) |
| Party member dispels player   | ![Player-Party - Victim](https://user-images.githubusercontent.com/9933525/206922842-8e0b5503-4a9c-4729-8570-1c367529929e.png) | ![Player-Party - Victim](https://user-images.githubusercontent.com/9933525/206922845-3240cd53-dfa7-4f47-ab81-4c0fe44aa564.png) |

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- 1.6 to 1.8: An extra, invalid dispel log is displayed, "Your Word of Recall (OLD) is removed." If cast by an NPC, the client also freezes for a few seconds.
- 1.9 to 1.11: No dispel log is displayed.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Dispel a buff on a creature.
- Dispel a debuff, or let a creature dispel a buff, on oneself or another nearby player.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
