### PR TITLE
Creature_addon mount fallback

### DIFF
--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -2647,10 +2647,12 @@ void Creature::LoadCreatureAddon(bool reload)
     if (CreatureDataAddon const* cainfo = GetCreatureAddon())
     {
         if (!reload)
+        {
             if (cainfo->mount_display_id >= 0)
                 m_mountId = cainfo->mount_display_id;
             else
                 m_mountId = m_creatureInfo->mount_display_id;
+        }
 
         if (m_mountId != 0)
             Mount(m_mountId);

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -2646,8 +2646,11 @@ void Creature::LoadCreatureAddon(bool reload)
 {
     if (CreatureDataAddon const* cainfo = GetCreatureAddon())
     {
-        if (!reload && cainfo->mount_display_id >= 0)
-            m_mountId = cainfo->mount_display_id;
+        if (!reload)
+            if (cainfo->mount_display_id >= 0)
+                m_mountId = cainfo->mount_display_id;
+            else
+                m_mountId = m_creatureInfo->mount_display_id;
 
         if (m_mountId != 0)
             Mount(m_mountId);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
If creature_addon.mount_display_id is -1 we should use mount_display_id from creature template.

### Proof
<!-- Link resources as proof -->
- https://github.com/vmangos/wiki/wiki/creature_addon

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- The bug only affects one creature atm 12337 
`SELECT crea.* FROM creature crea, creature_addon addon, creature_template temp WHERE temp.mount_display_id>0 AND temp.entry=crea.id AND crea.guid=addon.guid AND addon.mount_display_id=-1`

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Crimson courier has mount_display_id set in template and -1 in creature_addon.
- Look at crimson courier before and after this fix.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
