### PR TITLE
Changes to deduction calculation from Rep and Honor

### DIFF
--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -841,7 +841,7 @@ void WorldSession::SendListInventory(ObjectGuid vendorguid, uint8 menu_type)
                 ++count;
 
                 // reputation discount
-                uint32 price = uint32(floor(pProto->BuyPrice * discountMod));
+                uint32 price = uint32(pProto->BuyPrice * discountMod + 0.5f);
 
                 data << uint32(count);
                 data << uint32(crItem->item);

--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -119,7 +119,7 @@ static void SendTrainerSpellHelper(WorldPacket& data, TrainerSpell const* tSpell
 
     data << uint32(tSpell->spell);
     data << uint8(state == TRAINER_SPELL_GREEN_DISABLED ? TRAINER_SPELL_GREEN : state);
-    data << uint32(floor(tSpell->spellCost * fDiscountMod));
+    data << uint32(tSpell->spellCost * fDiscountMod + 0.5f);
 
     data << uint32(primary_prof_first_rank && can_learn_primary_prof ? 1 : 0);
     // primary prof. learn confirmation dialog
@@ -318,7 +318,7 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPacket& recv_data)
     SpellEntry const* proto = sSpellMgr.GetSpellEntry(trainer_spell->spell);
 
     // Apply reputation discount.
-    uint32 nSpellCost = uint32(floor(trainer_spell->spellCost * _player->GetReputationPriceDiscount(unit)));
+    uint32 nSpellCost = uint32(trainer_spell->spellCost * _player->GetReputationPriceDiscount(unit) + 0.5f);
 
     // Check money requirement.
     if (_player->GetMoney() < nSpellCost)

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1196,7 +1196,7 @@ class Player final: public Unit
         bool BuyItemFromVendor(ObjectGuid vendorGuid, uint32 item, uint8 count, uint8 bag, uint8 slot);
         void OnReceivedItem(Item* item);
 
-        float GetReputationPriceDiscount(Creature const* pCreature) const;
+        float GetReputationPriceDiscount(Creature const* pCreature, bool taxi = false) const;
 
         Player* GetTrader() const { return m_trade ? m_trade->GetTrader() : nullptr; }
         TradeData* GetTradeData() const { return m_trade; }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changes the price after deduction to be rounded to the nearest integer. 
Changes price deduction for using a taxi to 5% at rank2 and an additional 5% at rank4.

### Proof
<!-- Link resources as proof -->
Screenshots to compare prices:
![image](https://user-images.githubusercontent.com/2223066/211127544-becedf9a-1dd7-4bb6-bdda-e2494964a938.png)
Math tells us that prices are rounded to the nearest int.

Decompiled TaxiNodeCost from 1.12.1 client:
![image](https://user-images.githubusercontent.com/2223066/211127781-4723c00e-e6b5-4b32-9689-0c6d2c65ffbe.png)

This is also seen in classic
![image](https://user-images.githubusercontent.com/2223066/211127816-149efe40-daa9-4e97-881b-4ba56e15a724.png)
https://youtu.be/vnWPqK1VBXs?t=1118
Stormwind -> Ironforge : 50c
Ironforge -> Menethil Harbor : 330c
Menethil Harbor to Southshore: 330c
Total: 710c * 0,85 = 603,5c

10% reputation +5% discount for Rank2 (he is rank3 according to footage)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- (https://github.com/vmangos/core/issues/539)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Set ranking points/reputation value 
- Buy stuff / Train stuff / Fly somewhere
- Compare prices to known values and use a calculator - or compare taxiflight prices with the value shown on screen, as this is calculated by the client.


### Notes
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- There is some minor precision loss with float calculations. Maybe we should add flt_epsilon to mod. Blizzard seems to do it :>
- 
