### PR TITLE
Fix visible auras when loading player

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -15530,12 +15530,6 @@ float Player::GetMaxLootDistance(Unit const* pUnit) const
 
 void Player::_LoadAuras(QueryResult* result, uint32 timediff)
 {
-    //RemoveAllAuras(); -- some spells casted before aura load, for example in LoadSkills, aura list explicitly cleaned early
-
-    // all aura related fields
-    for (int i = UNIT_FIELD_AURA; i <= UNIT_FIELD_AURASTATE; ++i)
-        SetUInt32Value(i, 0);
-
     //QueryResult* result = CharacterDatabase.PQuery("SELECT caster_guid, item_guid, spell, stacks, charges, base_points0, base_points1, base_points2, periodic_time0, periodic_time1, periodic_time2, max_duration, duration, effect_index_mask FROM character_aura WHERE guid = '%u'",GetGUIDLow());
 
     if (result)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
**Bug explained:**
A warrior buffed with powerword: fortitude logs in while in battlestance.
player : LoadFromDB() -> _LoadSkills() 
sets Battlestance Aura into UNIT_FIELD_AURA+0

player : LoadFromDB() -> _LoadAuras()  
Resets UNIT_FIELD_AURA
Instead of adding battlestance to UNIT_FIELD_AURA, it calls SpellAuraHolder::Refresh()
Sets Powerword: fortitude  into UNIT_FIELD_AURA+0

If the player changes stance a SMSG_UPDATE_AURA_DURATION packet is sent that sets duration to -1 for UNIT_FIELD_AURA+0
Powerword:fortitude is removed from visible buffs on players client.

**Fix**
Don't reset UNIT_FIELD_AURA after _LoadSkills()

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Log into a warrior in battlestance
- Mount
- Change stance
- Notice that without this pullrequest mount icon disappears

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None