### PR TITLE
Prevent net-o-matic from backfiring at login

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1747,8 +1747,10 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                     {
                         // root to self part of (root_target->charge->root_self sequence
                         if (Unit* caster = GetCaster())
+                        {
                             caster->CastSpell(caster, 13138, true, nullptr, this);
-                        GetHolder()->SetAuraDuration(0); // Remove aura (else stays for ever, and casts at login)
+                            caster->RemoveAurasDueToSpell(13139);  // Remove aura (else stays for ever, and casts at login)
+                        }
                         return;
                     }
                     case 13910: // Force Create Elemental Totem


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
When net-o-matic backfires it places a dummy aura on the player - that wasn't removed properly. And would retrigger the backfire when the aura is reloaded at login.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- https://github.com/the-hyjal-project/bugtracker/issues/503
- https://github.com/the-hyjal-project/bugtracker/issues/398
- https://github.com/TeamEverlook/Everlook-BugTracker/issues/78
- https://github.com/vmangos/core/issues/1304#issuecomment-895776261

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .additem 10720
- .cheat cooldown on
- spam trinket on creature until it backfires
- use .list aura to check for aura 13139

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
