### PR TITLE
Feign death exploit fix

### DIFF
--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -374,7 +374,7 @@ void WorldSession::HandleLogoutCancelOpcode(WorldPacket& /*recv_data*/)
     SendPacket(&data);
 
     // not remove flags if can't free move - its not set in Logout request code.
-    if (GetPlayer()->CanFreeMove() || GetPlayer()->IsFeigningDeath())
+    if (GetPlayer()->CanFreeMove())
     {
         //!we can move again
         GetPlayer()->SetRooted(false);
@@ -383,6 +383,11 @@ void WorldSession::HandleLogoutCancelOpcode(WorldPacket& /*recv_data*/)
         GetPlayer()->SetStandState(UNIT_STAND_STATE_STAND);
 
         //! DISABLE_ROTATE
+        GetPlayer()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
+    }
+    else if (GetPlayer()->IsFeigningDeath() && !GetPlayer()->HasAuraType(SPELL_AURA_MOD_STUN))
+    {
+        GetPlayer()->SetRooted(false);
         GetPlayer()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
     }
 }

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -313,7 +313,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket& /*recv_data*/)
 
     uint8 reason = 0;
 
-    if (GetPlayer()->IsInCombat())
+    if (GetPlayer()->IsInCombat() || GetPlayer()->IsFeigningDeath())
         reason = 1;
     else if (GetPlayer()->m_movementInfo.HasMovementFlag(MovementFlags(MOVEFLAG_JUMPING | MOVEFLAG_FALLINGFAR)))
         reason = 3;                      // is jumping or falling

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -313,7 +313,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket& /*recv_data*/)
 
     uint8 reason = 0;
 
-    if (GetPlayer()->IsInCombat() || GetPlayer()->IsFeigningDeath())
+    if (GetPlayer()->IsInCombat())
         reason = 1;
     else if (GetPlayer()->m_movementInfo.HasMovementFlag(MovementFlags(MOVEFLAG_JUMPING | MOVEFLAG_FALLINGFAR)))
         reason = 3;                      // is jumping or falling
@@ -344,7 +344,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket& /*recv_data*/)
     }
 
     // not set flags if player can't free move to prevent lost state at logout cancel
-    if (GetPlayer()->CanFreeMove())
+    if (GetPlayer()->CanFreeMove() || GetPlayer()->IsFeigningDeath())
     {
         if (GetPlayer()->GetStandState() == UNIT_STAND_STATE_STAND &&
            !GetPlayer()->IsMounted() &&
@@ -374,7 +374,7 @@ void WorldSession::HandleLogoutCancelOpcode(WorldPacket& /*recv_data*/)
     SendPacket(&data);
 
     // not remove flags if can't free move - its not set in Logout request code.
-    if (GetPlayer()->CanFreeMove())
+    if (GetPlayer()->CanFreeMove() || GetPlayer()->IsFeigningDeath())
     {
         //!we can move again
         GetPlayer()->SetRooted(false);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fixes old exploit where a hunter can cast feign death and /camp. This enables the hunter to play normally while the logout timer is ticking.

### Proof
<!-- Link resources as proof -->
I have no evidence of how this should be handled. I guess one of 3 options:

- Player should not be able to log out while feigning death. (Which this pullrequest fixes)
- Player should be able to logout while in feign death, but not be able to cancel FD during that duration.  
- This is already working as intended :>

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- (https://github.com/LightsHope/issues/issues/163)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Feign death
- /camp or logout from the main menu
- With this PR an error message should appear

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
