### PR TITLE
Fix AddAura negative flag

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -10225,7 +10225,7 @@ SpellAuraHolder* Unit::AddAura(uint32 spellId, uint32 addAuraFlags, Unit* pCaste
             if (addAuraFlags & ADD_AURA_POSITIVE)
                 aur->SetPositive(true);
             else if (addAuraFlags & ADD_AURA_NEGATIVE)
-                aur->SetPositive(true);
+                aur->SetPositive(false);
 
             holder->AddAura(aur, SpellEffectIndex(i));
         }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fixes AddAura negative flags

### Proof
<!-- Link resources as proof -->
Should flag differently than Positive bool

### Issues
<!-- Which Issues does this fix, which are related?
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Use AddAura function, set to ADD_AURA_NEGATIVE, confirm it adds as positive


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
This function exists in the core but is not currently used. It is a useful function which could be utilized in many cases. An example of this would be recreating Corrupted Blood event.
