### PR TITLE
Health funnel fix

### DIFF
--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -2220,7 +2220,7 @@ static void RewardGroupAtKill_helper(Player* pGroupGuy, Unit* pVictim, uint32 co
         if (pGroupGuy->IsAlive() && not_gray_member_with_max_level)
         {
             uint32 itr_xp = (member_with_max_level == not_gray_member_with_max_level) ? uint32(xp * rate) : uint32((xp * rate / 2) + 1);
-            if (pGroupGuy->GetLevel() <= not_gray_member_with_max_level->GetLevel())
+            if (pGroupGuy->GetLevel() <= not_gray_member_with_max_level->GetLevel() && !pGroupGuy->GetPersonalXpRate() == 0)
                 pGroupGuy->GiveXP(itr_xp, pVictim);
             if (Pet* pet = pGroupGuy->GetPet())
                 if (pet->GetLevel() <= not_gray_member_with_max_level->GetLevel())

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -10225,7 +10225,7 @@ SpellAuraHolder* Unit::AddAura(uint32 spellId, uint32 addAuraFlags, Unit* pCaste
             if (addAuraFlags & ADD_AURA_POSITIVE)
                 aur->SetPositive(true);
             else if (addAuraFlags & ADD_AURA_NEGATIVE)
-                aur->SetPositive(true);
+                aur->SetPositive(false);
 
             holder->AddAura(aur, SpellEffectIndex(i));
         }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6121,10 +6121,8 @@ void Aura::PeriodicTick(SpellEntry const* sProto, AuraType auraType, uint32 data
 
             target->GetHostileRefManager().threatAssist(pCaster, float(gain) * 0.5f * sSpellMgr.GetSpellThreatMultiplier(spellProto), spellProto);
 
-            // heal for caster damage, warlock's health funnel already cost hps
-            if (target != pCaster && spellProto->SpellVisual == 163 &&
-                !(spellProto->SpellFamilyName == SPELLFAMILY_WARLOCK &&
-                spellProto->IsFitToFamilyMask<CF_WARLOCK_HEALTH_FUNNEL>()))
+            // heal for caster damage
+            if (target != pCaster && spellProto->SpellVisual == 163)
             {
                 uint32 dmg = spellProto->manaPerSecond;
                 if (pCaster->GetHealth() <= dmg && pCaster->GetTypeId() == TYPEID_PLAYER)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
fixes health funnel drain per second. Currently, the negative in-combat regen function of the spell (aura 88) isn't working. this fixes it by enabling 1:1 scaling with the drained amount.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Cast health funnel. Your health doesn't drain each second.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
