### PR TITLE
Linux openssl 3 support - crashfix

### DIFF
--- a/src/shared/Auth/ARC4.cpp
+++ b/src/shared/Auth/ARC4.cpp
@@ -15,9 +15,15 @@
  */
 
 #include "ARC4.h"
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#include <openssl/provider.h>
+#endif
 
 ARC4::ARC4(uint8 len) : m_ctx()
 {
+    #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+        OSSL_PROVIDER_load(NULL, "legacy");
+    #endif
     m_ctx = EVP_CIPHER_CTX_new();
     EVP_EncryptInit_ex(m_ctx, EVP_rc4(), nullptr, nullptr, nullptr);
     EVP_CIPHER_CTX_set_key_length(m_ctx, len);
@@ -25,6 +31,9 @@ ARC4::ARC4(uint8 len) : m_ctx()
 
 ARC4::ARC4(uint8* seed, uint8 len) : m_ctx()
 {
+    #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+        OSSL_PROVIDER_load(NULL, "legacy");
+    #endif
     m_ctx = EVP_CIPHER_CTX_new();
     EVP_EncryptInit_ex(m_ctx, EVP_rc4(), nullptr, nullptr, nullptr);
     EVP_CIPHER_CTX_set_key_length(m_ctx, len);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Adds support for OpenSSL 3.0.x on Linux by loading the legacy provider.

I tested with Ubuntu 22.04.1 and OpenSSL 3.0.2 15 Mar 2022.

### References
<!-- Link resources as proof -->
- https://www.openssl.org/docs/man3.1/man3/OSSL_PROVIDER_load.html
- https://github.com/transmission/transmission/issues/4716

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- https://github.com/vmangos/core/issues/1800

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Install OpenSSL 3.0.x
- Compile vmangos with anticheat
- Login with a non-gm account
- Log warden activity and/or notice it isn't crashing the server.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->

