### PR TITLE
Add SQLite databases to DB dump action

### DIFF
--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -76,6 +76,21 @@ jobs:
         # cp ${{github.workspace}}/sql/migrations/logs_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/logs_db_updates.sql
         # cp ${{github.workspace}}/sql/migrations/characters_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/characters_db_updates.sql
 
+    - name: Install SQLite dependencies
+      run: |
+        sudo apt install sqlite3 mawk -y
+        git clone https://github.com/dumblob/mysql2sqlite
+        chmod +x ${{github.workspace}}/mysql2sqlite/mysql2sqlite
+
+    - name: Create SQLite databases
+      run: |
+        mkdir ${{github.workspace}}/dbexport/sqlite_dump || true
+        ${{github.workspace}}/mysql2sqlite/mysql2sqlite ${{github.workspace}}/dbexport/db_dump/mangos.sql | sqlite3 ${{github.workspace}}/dbexport/sqlite_dump/mangos.sqlite
+        ${{github.workspace}}/mysql2sqlite/mysql2sqlite ${{github.workspace}}/dbexport/db_dump/logon.sql | sqlite3 ${{github.workspace}}/dbexport/sqlite_dump/logon.sqlite
+        ${{github.workspace}}/mysql2sqlite/mysql2sqlite ${{github.workspace}}/dbexport/db_dump/logs.sql | sqlite3 ${{github.workspace}}/dbexport/sqlite_dump/logs.sqlite
+        ${{github.workspace}}/mysql2sqlite/mysql2sqlite ${{github.workspace}}/dbexport/db_dump/characters.sql | sqlite3 ${{github.workspace}}/dbexport/sqlite_dump/characters.sqlite
+
+
     - name: Create New tables
       run: |
         docker exec mysqldb sh -c 'exec mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS realmd2 DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"'
@@ -98,17 +113,30 @@ jobs:
       run: |
         cd ${{github.workspace}}/dbexport
         7z a -tzip db-${{steps.vars.outputs.sha_short}}.zip db_dump
+        7z a -tzip db-sqlite-${{steps.vars.outputs.sha_short}}.zip sqlite_dump
           
-    - name: Archive this artefact
+    - name: Archive SQL artifact
       uses: actions/upload-artifact@v2
       with:
           name: snapshot-db-dump
           path: "${{github.workspace}}/dbexport/db-${{steps.vars.outputs.sha_short}}.zip"
 
+    - name: Archive SQLite artifact
+      uses: actions/upload-artifact@v2
+      with:
+          name: snapshot-db-sqlite-dump
+          path: "${{github.workspace}}/dbexport/db-sqlite-${{steps.vars.outputs.sha_short}}.zip"
+
     - name: Download artifact snapshot-db-dump
       uses: actions/download-artifact@v1
       with:
         name: snapshot-db-dump
+        path: all_snapshots
+
+    - name: Download artifact snapshot-db-sqlite-dump
+      uses: actions/download-artifact@v1
+      with:
+        name: snapshot-db-sqlite-dump
         path: all_snapshots
 
     - name: Get current date


### PR DESCRIPTION
## 🍰 Pullrequest
Adds SQLite databases to DB releases in addition to the raw SQL files, and fixes #1812.

### Proof
https://github.com/gtker/vmangos-core/actions/runs/4264014193/jobs/7421506198 shows a successful run on my fork which uploads to https://github.com/gtker/vmangos-core/releases/tag/db_latest. https://github.com/gtker/vmangos-core/releases/download/db_latest/db-sqlite-fc33961.zip contains the zipped sqlite files.
The current branch doesn't pass on my own fork because the job requires the permissions from https://github.com/gtker/vmangos-core/commit/ecaf9a1981a57193eba8330dbdfce2c5e7272fa5.