### PR TITLE
GetLosHitPosition return value

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -3023,7 +3023,7 @@ bool Map::GetLosHitPosition(float srcX, float srcY, float srcZ, float& destX, fl
         destZ = resultPos.z;
     }
 
-    return result0;
+    return result0 || result1;
 }
 
 bool Map::GetWalkHitPosition(GenericTransport* transport, float srcX, float srcY, float srcZ, float& destX, float& destY, float& destZ, uint32 moveAllowedFlags, float zSearchDist, bool locatedOnSteepSlope) const


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changes GetLosHitPosition to also return true if a dynamic object is hit.

Return value is currently used in:
https://github.com/vmangos/core/blob/56a7e74dbe399b3c92c91874b069f1987dbae706/src/game/Objects/Object.cpp#L2005-L2015
Used by spell::TargetMap to position targets according to caster position.
____________________________________________________________________________________________

https://github.com/vmangos/core/blob/56a7e74dbe399b3c92c91874b069f1987dbae706/src/game/Objects/Object.cpp#L3085
Seems to be unused.
____________________________________________________________________________________________

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
