### PR TITLE
Fix CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-project(MaNGOS)
-
 # CMake policies
 cmake_minimum_required(VERSION 3.1...3.20)
+
+project(MaNGOS)
 
 # Allow -DACE_ROOT, -DTBB_ROOT, etc.
 if(${CMAKE_VERSION} VERSION_GREATER "3.11")


### PR DESCRIPTION
## 🍰 Pullrequest
Fix warning when configuring with latest CMake.
```
CMake Warning (dev) at CMakeLists.txt:18 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

### Proof
- None

### Issues
- None

### How2Test
- use latest CMake version (as of now: version 3.26.0)
- Configure project
- CMake Warning should no longer get printed.

### Todo / Checklist
- [X] None
