### PR TITLE
Add missing quest end script for Warrior quest The Affray (id:1719)

### DIFF
--- a/sql/migrations/20230320180317_world.sql
+++ b/sql/migrations/20230320180317_world.sql
@@ -8,11 +8,14 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20230320180317');
 -- Add your query below.
 
-UPDATE `quest_template` SET `CompleteScript` = 1719 WHERE `entry` = 1719;
 
+-- Add missing completion script for quest The Affray.
 DELETE FROM `quest_end_scripts` WHERE `id`=1719;
 INSERT INTO `quest_end_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1719, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 2354, 0, 0, 0, 0, 0, 0, 0, 0, 'Klannoc Macleod - Zone Yell - Champion of The Affray');
+(1719, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2354, 0, 0, 0, 0, 0, 0, 0, 0, 'The Affray: Klannoc Macleod - Yell Text');
+UPDATE `quest_template` SET `CompleteScript` = 1719 WHERE `entry` = 1719;
+UPDATE `broadcast_text` SET `chat_type`=1, `emote_id1`=22 WHERE `entry`=2354;
+
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20230320180317_world.sql
+++ b/sql/migrations/20230320180317_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230320180317');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230320180317');
+-- Add your query below.
+
+UPDATE `quest_template` SET `CompleteScript` = 1719 WHERE `entry` = 1719;
+
+DELETE FROM `quest_end_scripts` WHERE `id`=1719;
+INSERT INTO `quest_end_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1719, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 2354, 0, 0, 0, 0, 0, 0, 0, 0, 'Klannoc Macleod - Zone Yell - Champion of The Affray');
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/kalimdor/the_barrens/the_barrens.cpp
+++ b/src/scripts/kalimdor/the_barrens/the_barrens.cpp
@@ -199,7 +199,6 @@ enum
     SAY_TWIGGY_FRAY    = 2318,  
     SAY_TWIGGY_DOWN    = 2355,  
     SAY_TWIGGY_OVER    = 2320,  
-    SAY_QUEST_TURN_IN  = 2354, // TODO: implement Klannoc Macleod (id: 6236) yells after quest was turned in: Hail $n!  New Champion of The Affray!
 
     NPC_TWIGGY = 6248,
     NPC_BIG_WILL = 6238,


### PR DESCRIPTION
## 🍰 Pullrequest
Add missing zone yell when quest  [The Affray](https://www.wowhead.com/classic/quest=1719/the-affray) was turned in.

### Proof
- https://youtu.be/nLsm_iVOp1Y?t=224

### Issues
- None

### How2Test
- create level 30 warrior
- .go creature Klannoc Macleod
- .quest add 1719
- .quest compelte 1719
- turn in quest, npc should do zone wide yell: `Hail $n!  New Champion of The Affray!`

### Todo / Checklist
- [X] None
