### PR TITLE
Do not generate movement log data when Anticheat.LogData = 0

### DIFF
--- a/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
+++ b/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
@@ -136,15 +136,15 @@ uint32 MovementAnticheat::Finalize(Player* pPlayer, std::stringstream& reason)
     {
         sLog.Player(m_session, LOG_ANTICHEAT, "Movement", LOG_LVL_BASIC, "DesyncMs %d DesyncDist %f Cheats %s",
             m_clientDesync, m_overspeedDistance, reason.rdbuf()->in_avail() ? reason.str().c_str() : "");
-    }
-
-    if ((result & (CHEAT_ACTION_KICK | CHEAT_ACTION_BAN_ACCOUNT | CHEAT_ACTION_BAN_IP_ACCOUNT)) && !m_packetLog.empty())
-    {
-        AddMessageToPacketLog("End of packet log. Penalty: " + std::to_string(result) + ", Detected cheats: " + reason.str());
-        std::string fileName = "movement_log_" +  m_session->GetUsername() + "_" + std::to_string(time(nullptr)) + ".pkt";
-        SniffFile packetDump(fileName.c_str());
-        std::lock_guard<std::mutex> guard(m_packetLogMutex);
-        packetDump.WriteToFile(m_packetLog);
+        
+        if ((result & (CHEAT_ACTION_KICK | CHEAT_ACTION_BAN_ACCOUNT | CHEAT_ACTION_BAN_IP_ACCOUNT)) && !m_packetLog.empty())
+        {
+            AddMessageToPacketLog("End of packet log. Penalty: " + std::to_string(result) + ", Detected cheats: " + reason.str());
+            std::string fileName = "movement_log_" +  m_session->GetUsername() + "_" + std::to_string(time(nullptr)) + ".pkt";
+            SniffFile packetDump(fileName.c_str());
+            std::lock_guard<std::mutex> guard(m_packetLogMutex);
+            packetDump.WriteToFile(m_packetLog);
+        }
     }
 
     // Reset to zero tick counts


### PR DESCRIPTION
this is a proposal that we should not generate movement_log data when Anticheat.LogData = 0, otherwise, it generates tons of files within the bin folder when there're mass players online.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
