### PR TITLE
fixed baron geddon inferno damage values and number of ticks

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_baron_geddon.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_baron_geddon.cpp
@@ -174,14 +174,13 @@ struct boss_baron_geddonAI : public ScriptedAI
                         break;
                     case 4:
                     case 5:
-                        Damage = 1500;
-                        break;
-                    case 6:
-                    case 7:
                         Damage = 2000;
                         break;
-                    case 8:
-                        Damage = 2500;
+                    case 6:
+                        Damage = 3000;
+                        break;
+                    case 7:
+                        Damage = 5000;
                         m_bInferno = false;
                         m_creature->ClearUnitState(UNIT_STAT_ROOT);
                         break;


### PR DESCRIPTION
## 🍰 Pullrequest
fixed baron geddon inferno damage values and number of ticks

### Proof
* Classic era warcraft logs - https://classic.warcraftlogs.com/reports/XN8bBwvVZyc6TMgC#fight=24&type=damage-taken&view=events&source=2
* 2005 boss guide - https://www.tentonhammer.com/guides/mc-boss-guide-boss-5-baron-geddon
> This inferno goes out in pulses to everything nearby. He does roughly 6 pulses. The first 2 pulses for 500 damage the next 2 pulses for 1000 damage and the last 2 pulses fo 2000 damage each.
* Screenshot from Fight Club discord of 2020 discussion of classic baron behavior
"The 8th and last tick is 5000"
<img width="565" alt="Screen Shot 2023-03-25 at 2 40 27 PM" src="https://user-images.githubusercontent.com/32000738/227735591-1bef1670-8c9c-406b-a1c7-298305a303f0.png">

### Issues
- None

### How2Test
.go creature baron (shazzrah may be more reliable)

engage in baron fight, wait for infernal, look for damage values of 500, 500, 1000, 1000, 2000, 2000, 3000, 5000 (8 total)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
