### PR TITLE
Attempt to fix MovementInform crash

### DIFF
--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -642,6 +642,12 @@ void PetAI::DoAttack(Unit* target, bool chase)
 
 void PetAI::MovementInform(uint32 moveType, uint32 data)
 {
+    
+    if (!m_creature->GetCharmInfo())
+    {
+        return;
+    }
+    
     // Receives notification when pet reaches stay or follow owner
     switch (moveType)
     {


### PR DESCRIPTION
## 🍰 Pullrequest
this is the attempt to fix the MovementInform crash, it does not happen often, but it happens twice already this week.
there maybe a better fix.

```
2023-03-26 23:57:42 ./mangosd(_ZN9CharmInfo11IsReturningEv+0) [0x9862d0]
./mangosd(_ZN5PetAI14MovementInformEjj+0x150) [0x6d3120]
./mangosd(_ZN22PointMovementGeneratorI8CreatureE14MovementInformERS0_+0x24a) [0x8a363a]
./mangosd(_ZN12MotionMaster11DirectCleanEbb+0x172) [0x899092]
./mangosd(_ZN12MotionMaster10InitializeEv+0x36) [0x898cf6]
./mangosd(_ZN8Creature14AIM_InitializeEv+0x65) [0x8c0495]
./mangosd(_ZN4Unit10ModPossessEPS_b14AuraRemoveMode+0x468) [0xa16d28]
./mangosd(_ZN4Aura16HandleModPossessEbb+0x63) [0xa19e83]
./mangosd(_ZN4Aura13ApplyModifierEbbb+0x7c) [0xa1607c]
./mangosd(_ZN4Unit10RemoveAuraEP4Aura14AuraRemoveMode+0x71) [0x98dcc1]
./mangosd(_ZN4Unit21RemoveSpellAuraHolderEP15SpellAuraHolder14AuraRemoveMode+0x12b) [0x995d1b]
./mangosd(_ZN4Unit24RemoveAurasByCasterSpellEj10ObjectGuid14AuraRemoveMode+0x7b) [0x99841b]
./mangosd(_ZN5Spell6cancelEv+0x1b4) [0xa02a94]
./mangosd(_ZN11SpellCaster14InterruptSpellE17CurrentSpellTypesb+0x3b) [0x975a0b]
./mangosd(_ZN12WorldSession13ExecuteOpcodeERK13OpcodeHandlerP11WorldPacket+0x41) [0x6b6e01]
./mangosd(_ZN12WorldSession14ProcessPacketsER12PacketFilter+0x286) [0x6bac56]
./mangosd(_ZN3Map21ProcessSessionPacketsE16PacketProcessing+0xd6) [0x8480f6]
./mangosd(_ZN3Map39UpdateSessionsMovementAndSpellsIfNeededEv+0x50) [0x8481a0]
./mangosd(_ZN3Map6UpdateEj+0x44) [0x850e84]
./mangosd(_ZN15BattleGroundMap6UpdateEj+0x1a) [0x85162a]
./mangosd(_ZN15MapAsyncUpdater3runEv+0x49) [0x8645f9]
./mangosd(_ZN9ACE_Based6Thread10ThreadTaskEPv+0x27) [0xd185f7]

```