### PR TITLE
Quest: Stinky's Escape - broadcast texts

### DIFF
--- a/sql/migrations/20230402213744_world.sql
+++ b/sql/migrations/20230402213744_world.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230402213744');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230402213744');
+-- Add your query below.
+
+DELETE FROM `script_texts` WHERE `entry`= -1780190;
+DELETE FROM `script_texts` WHERE `entry`= -1780191;
+DELETE FROM `script_texts` WHERE `entry`= -1780192;
+DELETE FROM `script_texts` WHERE `entry`= -1780193;
+DELETE FROM `script_texts` WHERE `entry`= -1780194;
+DELETE FROM `script_texts` WHERE `entry`= -1780195;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
@@ -1071,6 +1071,7 @@ enum
     QUEST_STINKYS_ESCAPE_A   = 1222,
     QUEST_STINKYS_ESCAPE_H   = 1270,
     SAY_IGNATZ_START         = 1610,
+    SAY_IGNATZ_0             = 1611,
     SAY_IGNATZ_1             = 1612,
     SAY_IGNATZ_2             = 1614,
     SAY_IGNATZ_3             = 1615,
@@ -1110,6 +1111,9 @@ struct npc_stinky_ignatzAI : public npc_escortAI
         {
             case 0:
                 DoScriptText(SAY_IGNATZ_START, m_creature);
+                break;;
+            case 4:
+                DoScriptText(SAY_IGNATZ_0, m_creature);
                 break;
             case 8:
                 DoScriptText(SAY_IGNATZ_1, m_creature);

--- a/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
@@ -1087,7 +1087,6 @@ struct npc_stinky_ignatzAI : public npc_escortAI
     {
         currWaypoint = 0;
         timer = 21000;
-        hasDoneAggroText = false;
         Reset();
     }
 
@@ -1097,13 +1096,11 @@ struct npc_stinky_ignatzAI : public npc_escortAI
     {
         currWaypoint = 0;
         timer = 21000;
-        hasDoneAggroText = false;
         npc_escortAI::JustRespawned();
     }
 
     uint32 currWaypoint;
     uint32 timer;
-    bool hasDoneAggroText;
 
     void WaypointReached(uint32 uiPointId) override
     {

--- a/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
@@ -1076,7 +1076,8 @@ enum
     SAY_IGNATZ_3             = 1615,
     SAY_IGNATZ_4             = 1617,
     SAY_IGNATZ_END           = 1618,
-    SAY_IGNATZ_AGGRO         = 1631,
+    SAY_IGNATZ_AGGRO_1       = 1630,
+    SAY_IGNATZ_AGGRO_2       = 1631,
     GOBJ_BOGBEAN_PLANT       = 20939
 };
 
@@ -1141,11 +1142,17 @@ struct npc_stinky_ignatzAI : public npc_escortAI
 
     void Aggro(Unit* pWho) override
     {
-        // random, only once
-        if (!hasDoneAggroText && urand(0, 3))
+        // not always
+        if (urand(0, 2))
+            return;
+
+        if (currWaypoint < 15)
         {
-            hasDoneAggroText = true;
-            DoScriptText(SAY_IGNATZ_AGGRO, m_creature, pWho);
+            DoScriptText(SAY_IGNATZ_AGGRO_1, m_creature, pWho);
+        }
+        else
+        {
+            DoScriptText(SAY_IGNATZ_AGGRO_2, m_creature, pWho);
         }
     }
 

--- a/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
@@ -1070,12 +1070,12 @@ enum
 {
     QUEST_STINKYS_ESCAPE_A   = 1222,
     QUEST_STINKYS_ESCAPE_H   = 1270,
-    SAY_IGNATZ_START         = -1780190,
-    SAY_IGNATZ_1             = -1780191,
-    SAY_IGNATZ_2             = -1780192,
-    SAY_IGNATZ_3             = -1780193,
-    SAY_IGNATZ_4             = -1780194,
-    SAY_IGNATZ_END           = -1780195,
+    SAY_IGNATZ_START         = 1610,
+    SAY_IGNATZ_1             = 1612,
+    SAY_IGNATZ_2             = 1614,
+    SAY_IGNATZ_3             = 1615,
+    SAY_IGNATZ_4             = 1617,
+    SAY_IGNATZ_END           = 1618,
     GOBJ_BOGBEAN_PLANT       = 20939
 };
 

--- a/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/dustwallow_marsh.cpp
@@ -1076,6 +1076,7 @@ enum
     SAY_IGNATZ_3             = 1615,
     SAY_IGNATZ_4             = 1617,
     SAY_IGNATZ_END           = 1618,
+    SAY_IGNATZ_AGGRO         = 1631,
     GOBJ_BOGBEAN_PLANT       = 20939
 };
 
@@ -1085,6 +1086,7 @@ struct npc_stinky_ignatzAI : public npc_escortAI
     {
         currWaypoint = 0;
         timer = 21000;
+        hasDoneAggroText = false;
         Reset();
     }
 
@@ -1094,11 +1096,13 @@ struct npc_stinky_ignatzAI : public npc_escortAI
     {
         currWaypoint = 0;
         timer = 21000;
+        hasDoneAggroText = false;
         npc_escortAI::JustRespawned();
     }
 
     uint32 currWaypoint;
     uint32 timer;
+    bool hasDoneAggroText;
 
     void WaypointReached(uint32 uiPointId) override
     {
@@ -1134,6 +1138,17 @@ struct npc_stinky_ignatzAI : public npc_escortAI
                 break;
         }
     }
+
+    void Aggro(Unit* pWho) override
+    {
+        // random, only once
+        if (!hasDoneAggroText && urand(0, 3))
+        {
+            hasDoneAggroText = true;
+            DoScriptText(SAY_IGNATZ_AGGRO, m_creature, pWho);
+        }
+    }
+
     void UpdateAI(uint32 const uiDiff) override
     {
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())


### PR DESCRIPTION
## 🍰 Pullrequest
Use broadcast texts for quest [Stinky's Escape](https://www.wowhead.com/classic/quest=1222/stinkys-escape).
Add missing aggro texts.

### Proof
- https://www.youtube.com/watch?v=UWhIWwPlhw4

### Issues
- None

### How2Test
- check texts during quest Stinky's Escape

### Todo / Checklist
- [X] None
