### PR TITLE
Fix macOS builds and add Apple Silicon support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ CMakeSettings.json
 
 # CLion files
 cmake-build-debug
+cmake-build-release
 
 #
 # Top-level generic files

--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -40,17 +40,20 @@ else( OPENSSL_INCLUDE_DIR AND OPENSSL_LIBRARIES )
 
   find_path(OPENSSL_INCLUDE_DIR
     NAMES
-      ssl.h
+      openssl/ssl.h
     PATHS
       /usr/include
       /usr/include/openssl
       /usr/local/include
       /usr/local/include/openssl
       /usr/local/openssl/include
+      /usr/local/opt/openssl@1.1/include
       /usr/local/opt/openssl
+      /opt/homebrew/opt/openssl@1.1/include
+      /opt/homebrew/opt/openssl/include
       ${TMP_OPENSSL_INCLUDE_DIR}
     DOC
-      "Specify the directory containing openssl.h."
+      "Specify the directory containing ssl.h."
   )
 
   find_library(OPENSSL_LIBRARIES
@@ -63,7 +66,10 @@ else( OPENSSL_INCLUDE_DIR AND OPENSSL_LIBRARIES )
       /usr/local/lib
       /usr/local/lib/ssl
       /usr/local/ssl/lib
+      /usr/local/opt/openssl@1.1/lib
       /usr/local/opt/openssl/lib
+      /opt/homebrew/opt/openssl@1.1/lib
+      /opt/homebrew/opt/openssl/lib
       ${TMP_OPENSSL_LIBRARIES}
     DOC "Specify the OpenSSL library here."
   )
@@ -89,6 +95,10 @@ else( OPENSSL_INCLUDE_DIR AND OPENSSL_LIBRARIES )
         /usr/local/lib
         /usr/local/lib/ssl
         /usr/local/ssl/lib
+        /usr/local/opt/openssl@1.1/lib
+        /usr/local/opt/openssl/lib
+        /opt/homebrew/opt/openssl@1.1/lib
+        /opt/homebrew/opt/openssl/lib
         ${TMP_OPENSSL_LIBRARIES}
       DOC "if more libraries are necessary to link in a OpenSSL client, specify them here."
     )

--- a/dep/src/g3dlite/FileSystem.cpp
+++ b/dep/src/g3dlite/FileSystem.cpp
@@ -40,6 +40,13 @@
 #   define strnicmp strncasecmp 
 #endif
 
+#if defined __aarch64__ && defined __APPLE__
+#    if defined stat64
+#        undef stat64
+#    endif
+#    define stat64 stat
+#endif
+
 namespace G3D {
 
 static FileSystem* common = NULL;

--- a/src/game/Maps/GridDefines.h
+++ b/src/game/Maps/GridDefines.h
@@ -185,7 +185,7 @@ namespace MaNGOS
     }
     inline bool IsValidMapCoord(float c)
     {
-        return finite(c) && (std::fabs(c) <= MAP_HALFSIZE - 0.5);
+        return std::isfinite(c) && (std::fabs(c) <= MAP_HALFSIZE - 0.5);
     }
 
     inline bool IsValidMapCoord(float x, float y)
@@ -200,7 +200,7 @@ namespace MaNGOS
 
     inline bool IsValidMapCoord(float x, float y, float z, float o)
     {
-        return IsValidMapCoord(x,y,z) && finite(o) && fabs(o) <= 4 * M_PI;
+        return IsValidMapCoord(x,y,z) && std::isfinite(o) && fabs(o) <= 4 * M_PI;
     }
 }
 #endif

--- a/src/shared/Common.h
+++ b/src/shared/Common.h
@@ -127,7 +127,6 @@ typedef off_t ACE_OFF_T;
 #  define I64FMT "%016I64X"
 //#  define snprintf _snprintf
 #  define vsnprintf _vsnprintf
-#  define finite(X) _finite(X)
 
 #else
 
@@ -151,7 +150,7 @@ typedef off_t ACE_OFF_T;
 
 #define SIZEFMTD ACE_SIZE_T_FORMAT_SPECIFIER
 
-inline float finiteAlways(float f) { return finite(f) ? f : 0.0f; }
+inline float finiteAlways(float f) { return std::isfinite(f) ? f : 0.0f; }
 
 #define atol(a) strtoul(a, nullptr, 10)
 

--- a/src/shared/SystemConfig.h
+++ b/src/shared/SystemConfig.h
@@ -49,6 +49,10 @@
 # define ARCHITECTURE "x64"
 #elif defined(__ia64)  || defined(__IA64__)  || defined(_M_IA64)
 # define ARCHITECTURE "IA64"
+#elif defined(__aarch64__)
+# define ARCHITECTURE "AArch64"
+#elif defined(__arm__)
+# define ARCHITECTURE "ARM32"
 #else
 # define ARCHITECTURE "x32"
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
This PR provides necessary path locations in the Cmake macro `FindOpenSSL` of where openssl tends to lie when installed via [homebrew](https://brew.sh/). The `/opt/` prefix ones are the newer way packages are stored via homebrew on Apple Silicon (M1/M2) Macs, and the `/usr/` ones on older, Intel Macs. I do not have an Intel Mac capable of running the latest macOS, so I cannot guarantee these work, but since Apple no longer sells Intel Macs for several years now (with the exception of the Mac Pro I doubt few own), this is probably okay for now. I can verify the Arm-based ones do work. The PR's primary purpose is Apple Silicon support for modern Macs anyway.

Note: Once OpenSSL 3.x support is added in vmangos, the @1.1 version tagging can be dropped.

Additionally, other minor changes are made to facilitate proper building, such as redefining stat64 on arm Macs ([as was done in cmangos](https://github.com/cmangos/mangos-tbc/commit/3c5ceabbb225bd1a1a900d23092b087de7adbab5)), removing the old finite def for std's, etc.

### Proof
<!-- Link resources as proof -->
- N/A

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Off the top of my head, may miss a step or two:
- Have a M1/M2 type Apple Silicon Mac
- Install homebrew
- `brew install openssl@1.1 ace mysql tbb cmake`
- Attempt to build normal way by invoking cmake and building as you would on Linux. Can also use CLion IDE.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
