### PR TITLE
Fix openssl path for CI workflow

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -81,8 +81,9 @@ jobs:
 
           copy ${{github.workspace}}/ACE_wrappers/lib/ACE.dll ${{github.workspace}}/bin/Release/ACE.dll
           copy c:/mysql/lib/libmysql.dll ${{github.workspace}}/bin/Release/libmysql.dll
-          copy "c:/Program Files/OpenSSL-Win64/bin/libssl-1_1-x64.dll" ${{github.workspace}}/bin/Release/libssl-1_1-x64.dll
-          copy "c:/Program Files/OpenSSL-Win64/bin/libcrypto-1_1-x64.dll" ${{github.workspace}}/bin/Release/libcrypto-1_1-x64.dll
+          copy "c:/Program Files/OpenSSL/bin/libssl-1_1-x64.dll" ${{github.workspace}}/bin/Release/libssl-1_1-x64.dll
+          copy "c:/Program Files/OpenSSL/bin/libcrypto-1_1-x64.dll" ${{github.workspace}}/bin/Release/libcrypto-1_1-x64.dll
+          copy ${{github.workspace}}/dep/windows/lib/x64_release/libeay32.dll ${{github.workspace}}/bin/Release/libeay32.dll
 
           7z a -tzip ${{env.ARCHIVE_FILENAME}} Release
     - name: Archive this artefact
@@ -123,8 +124,9 @@ jobs:
 
           copy ${{github.workspace}}/ACE_wrappers/lib/ACE.dll ${{github.workspace}}/bin/Release/ACE.dll
           copy c:/mysql/lib/libmysql.dll ${{github.workspace}}/bin/Release/libmysql.dll
-          copy "c:/Program Files/OpenSSL-Win64/bin/libssl-1_1-x64.dll" ${{github.workspace}}/bin/Release/libssl-1_1-x64.dll
-          copy "c:/Program Files/OpenSSL-Win64/bin/libcrypto-1_1-x64.dll" ${{github.workspace}}/bin/Release/libcrypto-1_1-x64.dll
+          copy "c:/Program Files/OpenSSL/bin/libssl-1_1-x64.dll" ${{github.workspace}}/bin/Release/libssl-1_1-x64.dll
+          copy "c:/Program Files/OpenSSL/bin/libcrypto-1_1-x64.dll" ${{github.workspace}}/bin/Release/libcrypto-1_1-x64.dll
+          copy ${{github.workspace}}/dep/windows/lib/x64_release/libeay32.dll ${{github.workspace}}/bin/Release/libeay32.dll
 
           7z a -tzip ${{env.ARCHIVE_FILENAME}} Release
     - name: Archive this artefact


### PR DESCRIPTION
## 🍰 Pullrequest
Fix OpenSSL path for CI workflow, the OpenSSL binary path has changed in the GitHub virtual environment