### PR TITLE
MMAP generation optimization

### DIFF
--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -690,12 +690,6 @@ namespace MMAP
                 tileCfg.bmax[0] = config.bmin[0] + float((x + 1) * config.tileSize + config.borderSize) * config.cs;
                 tileCfg.bmax[2] = config.bmin[2] + float((y + 1) * config.tileSize + config.borderSize) * config.cs;
 
-                float tbmin[2], tbmax[2];
-                tbmin[0] = tileCfg.bmin[0];
-                tbmin[1] = tileCfg.bmin[2];
-                tbmax[0] = tileCfg.bmax[0];
-                tbmax[1] = tileCfg.bmax[2];
-
                 // NOSTALRIUS - MMAPS TILE GENERATION
                 /// 1. Alloc heightfield for walkable areas
                 tile.solid = rcAllocHeightfield();
@@ -764,11 +758,8 @@ namespace MMAP
                             for (int v = 0; v < 3; ++v) // Coordinate
                                 verts[3*c + v] = (5*tVerts[tri[c]*3 + v] + tVerts[tri[(c+1)%3]*3 + v] + tVerts[tri[(c+2)%3]*3 + v]) / 7;
                         // A triangle is undermap if all corners are undermap
-                        bool undermap1 = m_terrainBuilder->IsUnderMap(&verts[0]);
-                        bool undermap2 = m_terrainBuilder->IsUnderMap(&verts[3]);
-                        bool undermap3 = m_terrainBuilder->IsUnderMap(&verts[6]);
 
-                        if ((undermap1 + undermap2 + undermap3) == 3)
+                        if (m_terrainBuilder->IsUnderMap(&verts[0]) && m_terrainBuilder->IsUnderMap(&verts[3]) && m_terrainBuilder->IsUnderMap(&verts[6]))
                         {
                             areas[i] = 0;
                             continue;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Logic change to avoid too many calls to the expensive isUnderModel function.

Performance test performed on extracting complete mmap for Zul'Farrak - Map 209:
Before: 278.10714 seconds
After: 156.21228 seconds

Bonus optimization: removed some not needed variables.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Extract maps without this PR - and time it
- Extract maps again with this PR - and compare time to before
- Compare generated mmaps to ensure they are exactly the same

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
