### PR TITLE
prevent totems dodge/parry

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2145,6 +2145,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* pVictim, WeaponAttackT
     }
 
     bool from_behind = !pVictim->HasInArc(this);
+    bool victimIsTotem = ((Creature const*)pVictim)->IsTotem();
 
     if (from_behind)
         DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: attack came from behind.");
@@ -2152,7 +2153,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* pVictim, WeaponAttackT
     // Dodge chance
 
     // only players can't dodge if attacker is behind
-    if (!pVictim->IsPlayer() || !from_behind)
+    if ((!pVictim->IsPlayer() || !from_behind) && !victimIsTotem)
     {
         dodge_chance -= dodgeSkillBonus;
 
@@ -2170,7 +2171,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* pVictim, WeaponAttackT
 
     // parry chances
     // check if attack comes from behind, nobody can parry or block if attacker is behind
-    if (!from_behind && (parry_chance > 0))
+    if ((!from_behind && (parry_chance > 0)) && !victimIsTotem)
     {
         if (pVictim->IsPlayer() || !((Creature*)pVictim)->HasExtraFlag(CREATURE_FLAG_EXTRA_NO_PARRY))
         {
@@ -2609,7 +2610,7 @@ float Unit::GetUnitParryChance() const
     {
         // Can't really know for sure, but Totems probably shouldn't parry.
         // They are inanimate objects, have no arms nor weapons, and cannot move.
-        if (GetCreatureType() != CREATURE_TYPE_TOTEM)
+        if (!((Creature const*)this)->IsTotem())
         {
             chance = 5.0f;
             chance += GetTotalAuraModifier(SPELL_AURA_MOD_PARRY_PERCENT);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Prevent totems from parrying and dodging incoming attacks.

- GetUnitParryChance() was unexpectedly returning 5 for totems. This is changed to 0.
- RollMeleeOutcomeAgainst() no longer uses skilldifference for calculating dodge/parry for totems.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Log onto 2 accounts. One of them has to be a shaman - the other has to be lower level than the shaman
- Shaman targets player on different account and types .m mainspeed 10
- Shaman places totem, targets it and types .m hp 99999
- Player on 2nd account autoattacks totem
- Notice if dodges/parries occurs
