### PR TITLE
MMAP generator - don't filter passages with height above 1.5 yards

### DIFF
--- a/contrib/mmap/config.json
+++ b/contrib/mmap/config.json
@@ -1,13 +1,5 @@
 {
 	"0": {
-		"3652": {
-			"quick": 1,
-			"_Info": "fixes terrain beneath a bridge at deadwind pass"
-		},
-		"3328": {
-			"quick": 1,
-			"_Info": "fixes terrain beneath a barricade at the bulwark"
-		},
 		"3147": {
 			"maxSimplificationError": 1.0,
 			"detailSampleDist": 0.5,
@@ -15,16 +7,6 @@
 		},
 		"3050": {
 			"_Info": "TODO:westbrook garrison"
-		}
-	},
-	"1": {
-		"3541": {
-			"quick": 1,
-			"_Info": "fixes terrain beneath a bridge allowing galak messenger to path correctly"
-		},
-		"4045": {
-			"quick": 1,
-			"_Info": "fixes terrain beneath a tent so wastewander bandit is no longer stuck"
 		}
 	}
 }

--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -767,7 +767,11 @@ namespace MMAP
                     float outDist = -1.0f;
                     float inDist  = -1.0f;
                     if (it->IsUnderObject(v, up, isM2, &outDist, &inDist)) // inDist < outDist
-                        terrainInsideModelsVerts[t] = inDist;
+                    {
+                        //if there are less than 1.5y between terrain and model then mark the terrain as unwalkable
+                        if (inDist < 1.5f)
+                            terrainInsideModelsVerts[t] = inDist;
+                    }
                 }
         }
         /// Correct triangles partially under models


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
As mentioned on discord. This PR changes how movemapgen filters terrain beneath models. Now only terrain within 1.5 yards will be filtered, therefore allowing NPCs to pass.

Thereby also eliminating the quickmode fixes from the config.

Generated tiles will be slightly bigger - for map 0 the total increase is 7 MB.
Build times for tiles are estimated to be roughly 1-2 % longer.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
