### PR TITLE
movemapgen - minor fix

### DIFF
--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -751,9 +751,7 @@ namespace MMAP
             /// Check every map vertice
             // x, y * -1
             Vector3 up(0, 0, 1);
-            up.x *= -1.0f;
-            up.y *= -1.0f;
-            up = up * rotation.inverse() / scale;
+
             for (vector<GroupModel>::iterator it = groupModels.begin(); it != groupModels.end(); ++it)
                 for (int t = 0; t < mapVertsCount / 3; ++t)
                 {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Vector3 up describes the direction up - and is used for checking whether a terrain vertice is inside a model. So unpassable terrain is filtered and NPCs can't move inside objects.

This small change can be summarized as:

- Don't do multiplications with 0
- Don't scale the direction, since it's used in a G3D::Ray where a direction always should have a length of 1. This also allows movemapgen to be run in debug - as it will no longer trigger an assertation.
- Don't adjust orientation as up is always up, no matter how the model is orientated. This removes some artifacts generated on boundaries between terrain and tilted models.

![image](https://github.com/vmangos/core/assets/2223066/9bae5f1b-2357-43db-b1b4-8052a2ea33a1)

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
