### PR TITLE
Update boss_kelthuzad.cpp

### DIFF
--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
@@ -696,6 +696,11 @@ struct boss_kelthuzadAI : public ScriptedAI
                         events.Repeat(5000 - timeSinceLastFrostBlast);
                         break;
                     }
+                    else if (timeSinceLastShadowFissure < 5000)
+                    {
+                        events.Repeat(5000 - timeSinceLastShadowFissure);
+                        break;
+                    }
                     if (DoCastSpellIfCan(m_creature, SPELL_FROST_BOLT_NOVA) == CAST_OK)
                     {
                         events.Repeat(Seconds(urand(15, 17)));
@@ -707,14 +712,14 @@ struct boss_kelthuzadAI : public ScriptedAI
                 }
                 case EVENT_FROST_BLAST:
                 {
-                    if (timeSinceLastShadowFissure < 4000)
+                    if (timeSinceLastShadowFissure < 5000)
                     {
-                        events.Repeat(4000 - timeSinceLastShadowFissure);
+                        events.Repeat(5000 - timeSinceLastShadowFissure);
                         break;
                     }
-                    else if (timeSinceLastAEFrostBolt < 5000)
+                    else if (timeSinceLastAEFrostBolt < 8000)
                     {
-                        events.Repeat(5000 - timeSinceLastAEFrostBolt);
+                        events.Repeat(8000 - timeSinceLastAEFrostBolt);
                         break;
                     }
                     if (m_creature->IsNonMeleeSpellCasted())
@@ -747,9 +752,14 @@ struct boss_kelthuzadAI : public ScriptedAI
                 }
                 case EVENT_SHADOW_FISSURE:
                 {
-                    if (timeSinceLastFrostBlast < 4000)
+                    if (timeSinceLastFrostBlast < 5000)
                     {
-                        events.Repeat(4000 - timeSinceLastFrostBlast);
+                        events.Repeat(5000 - timeSinceLastFrostBlast);
+                        break;
+                    }
+                    else if (timeSinceLastAEFrostBolt < 8000)
+                    {
+                        events.Repeat(8000 - timeSinceLastAEFrostBolt);
                         break;
                     }
                     if (m_creature->IsNonMeleeSpellCasted())


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- https://www.wowhead.com/classic/news/blizzard-on-timing-of-classic-kelthuzads-abilities-319613#p3443770

> Some bosses have abilities that share cooldowns in some way, similar to how players can’t activate two empowering on-use trinkets at the same time. This means that if a boss uses a significant ability, some of the other abilities that boss has may not be usable for a short period of time.
> There are, of course, exceptions. Not all mechanics encountered in combat are being controlled by the same logic, and spells can have different shared cooldown categories, or they can be excluded from this restriction altogether.
> In either case, these are typically purposeful design decisions, and the general intention was to prevent a boss from unloading all of its most impactful abilities within moments of each other. In the case of Kel’thuzad, we see it currently working correctly.


> The spells that can delay [ Frost Blast](https://www.wowhead.com/classic/spell=27808/frost-blast) are [ Shadow Fissure](https://www.wowhead.com/classic/spell=27810/shadow-fissure) and [ Frostbolt](https://www.wowhead.com/classic/spell=28479/frostbolt) (the aoe one). They all belong to the same cooldown category "Creature Special" (ID 1152). [ Frost Blast](https://www.wowhead.com/classic/spell=27808/frost-blast) and [ Shadow Fissure](https://www.wowhead.com/classic/spell=27810/shadow-fissure) trigger a 5 sec category-wide cooldown, [ Frostbolt](https://www.wowhead.com/classic/spell=28479/frostbolt) - an 8 sec.

### Issues
<!-- Which Issues does this fix, which are related?
-->
fixes #1886 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Reach second phase of the KT encounter, track his ability usage and should hopefully have no overlap between his abilities using the same category-wide cooldowns as Classic.