### PR TITLE
map::GetWalkHitPosition - fix wrong use of hitnormal

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -3143,8 +3143,14 @@ bool Map::GetWalkHitPosition(GenericTransport* transport, float srcX, float srcY
         sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "WalkHitPos: Navmesh raycast failed");
         return false;
     }
-    for (int i = 0; i < 3; ++i)
-        endPosition[i] += hitNormal[i] * 0.5f;
+
+    // We hit a wall - calculate new endposition
+    if (t < FLT_MAX)
+    {
+        for (int i = 0; i < 3; ++i)
+            endPosition[i] = point[i] + (endPosition[i] - point[i]) * t;
+    }
+
     if (dtStatusFailed(m_navMeshQuery->closestPointOnPoly(visited[visitedCount - 1], endPosition, endPosition, nullptr)))
         return false;
 

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -3148,7 +3148,7 @@ bool Map::GetWalkHitPosition(GenericTransport* transport, float srcX, float srcY
     if ((t < 1) && (t > 0))
     {
         for (int i = 0; i < 3; ++i)
-            endPosition[i] = point[i] + (endPosition[i] - point[i]) * t;
+            endPosition[i] = point[i] + (endPosition[i] - point[i]) * hitNormal[i];
     }
 
     if (dtStatusFailed(m_navMeshQuery->closestPointOnPoly(visited[visitedCount - 1], endPosition, endPosition, nullptr)))

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -3145,7 +3145,7 @@ bool Map::GetWalkHitPosition(GenericTransport* transport, float srcX, float srcY
     }
 
     // We hit a wall - calculate new endposition
-    if (t < FLT_MAX)
+    if ((t < 1) && (t > 0))
     {
         for (int i = 0; i < 3; ++i)
             endPosition[i] = point[i] + (endPosition[i] - point[i]) * t;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
hitnormal was being applied in a wrongful way.

Changes:
- Only alter endposition with hitnormal if a hit was made (0<t<1)
- Apply hitnormal to the delta between the start and end position.

**Example (2D for simplicity):**
![image](https://github.com/vmangos/core/assets/2223066/1b09a503-5457-4b7d-ad2b-c95676fbcc33)

Image shows a path from 3,3 to 13,5
Raycast will give a hitnormal of approx: 0.3333, 0.66666

Old calc would set endposition to ~ 13.1666, 5.3333
New calc tells us the hit is at (3+(13-3)*0.3333), (3+(5-3)*0.66666) = ~ 6.3333, 4.3333

### Proof
<!-- Link resources as proof -->
- (https://github.com/vmangos/core/blob/development/dep/recastnavigation/Detour/Source/DetourNavMeshQuery.cpp#L2350-L2365)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
