### PR TITLE
Four Horsemen Shield Wall Cooldown added

### DIFF
--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_four_horsemen.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_four_horsemen.cpp
@@ -110,6 +110,7 @@ struct boss_four_horsemen_shared : public ScriptedAI
     bool m_bShieldWall1;
     bool m_bShieldWall2;
     uint32 m_uiMarkTimer;
+    uint32 m_uiShieldWallTimer;
     uint32 const m_uiMarkId;
     uint32 const m_uiGhostId;
     bool const m_bIsSpirit;
@@ -229,6 +230,7 @@ struct boss_four_horsemen_shared : public ScriptedAI
 
         m_bShieldWall1 = true;
         m_bShieldWall2 = true;
+        m_uiShieldWallTimer = 0;
         m_uiMarkTimer = 20000;
         killSayCooldown = 0;
 
@@ -347,13 +349,19 @@ struct boss_four_horsemen_shared : public ScriptedAI
         {
             if ((DoCastSpellIfCan(m_creature, SPELL_SHIELDWALL)) == CAST_OK)
                 m_bShieldWall1 = false;
+                m_uiShieldWallTimer = 0;
         }
         else if (m_bShieldWall2 && m_creature->GetHealthPercent() < 20.0f)
         {
-            if ((DoCastSpellIfCan(m_creature, SPELL_SHIELDWALL)) == CAST_OK)
+            if (m_uiShieldWallTimer < 30000) // If a Horseman is taken from 50% to 20% health in less than 30 seconds, the second Shield Wall will never trigger.
+            {
+                m_bShieldWall2 = false;
+            }
+            else if ((DoCastSpellIfCan(m_creature, SPELL_SHIELDWALL)) == CAST_OK)
                 m_bShieldWall2 = false;
         }
-
+        m_uiShieldWallTimer += uiDiff;
+        
         if (m_uiMarkTimer < uiDiff)
         {
             if ((DoCastSpellIfCan(m_creature, m_uiMarkId)) == CAST_OK)

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_four_horsemen.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_four_horsemen.cpp
@@ -348,8 +348,10 @@ struct boss_four_horsemen_shared : public ScriptedAI
         if (m_bShieldWall1 && m_creature->GetHealthPercent() < 50.0f)
         {
             if ((DoCastSpellIfCan(m_creature, SPELL_SHIELDWALL)) == CAST_OK)
+            {
                 m_bShieldWall1 = false;
                 m_uiShieldWallTimer = 0;
+            }
         }
         else if (m_bShieldWall2 && m_creature->GetHealthPercent() < 20.0f)
         {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Added a cooldown to Four Horsemen Shield Wall based on classic behavior. Shield Wall has a 30 second cooldown, if the npc tries to trigger shield wall and finds that it is on cooldown, he will not never use it, even if the cooldown ends while he is still alive.

### Proof
<!-- Link resources as proof -->
- https://www.youtube.com/watch?v=MclF_m0WoUM&t=2138s
- Shield Wall triggers 35:48.
- Boss reaches 20% health 36:15 (barely 3 seconds left on cd)
- Boss never tries to use it again, even after cd ends.
- The ability has a 30 second cooldown in the database https://www.wowhead.com/classic/spell=29061/shield-wall
- Some Warcraft log showing Thane use Shield Wall only once https://vanilla.warcraftlogs.com/reports/vkV7GxYyBMw2HQAF#fight=27&type=resources&hostility=1&pins=0%24Separate%24%23244F4B%24auras-gained%241%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24false%2429061
- Looked in sniffs, [sample size is a bit low and it possibly only grabbed shield wall casts of targeted mobs, but there's no instance of shield wall happening in less than 30 seconds](https://github.com/vmangos/core/assets/111737968/93b230a2-f164-4330-98e0-10eb1b996c0f)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Engage four horsemen
- Damage one of them to 50% health, watch it use first shield wall.
- Damage it to 15% and wait 35 seconds. It should never use shield wall again.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
