### PR TITLE
Removing the script that disables summons on evil twin

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -5631,10 +5631,6 @@ void Spell::EffectSummonPlayer(SpellEffectIndex /*effIdx*/)
     if (!pPlayerTarget)
         return;
 
-    // Evil Twin (ignore player summon, but hide this for summoner)
-    if (pPlayerTarget->HasAura(23445))
-        return;
-
     float x, y, z;
     SpellCaster* landingObject = m_caster;
     // summon to the ritual go location if any


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Seems to be an urban legend/myth from old vanilla days that was proven incorrect so this effect can be removed.

I found no mentions of Evil Twin in the vanilla documented patchnotes. It's impossible to say for sure whether it used to have this effect then it was removed before 1.12.1

They changed the spell  in build 5464 to give it the the attribute `SPELL_ATTR_NO_IMMUNITIES`, that might hint that they made other server side changes at the same time.

### Proof
<!-- Link resources as proof -->
- Classic testing
- [wiki talk page](https://wowpedia.fandom.com/wiki/Talk:Evil_Twin) says it has no effect on warlock summons

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- cast spell id 7720 targeting a player with evil twin. It should be able to receive summons.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] Finding if blizzard changed it and removed the no-summons effect before the end of vanilla.
