### PR TITLE
Allowed physical abilities to use weapon skill

### DIFF
--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -382,7 +382,7 @@ SpellMissInfo SpellCaster::MeleeSpellHitResult(Unit* pVictim, SpellEntry const* 
         return SPELL_MISS_NONE;
 
     // bonus from skills is 0.04% per skill Diff
-    int32 attackerWeaponSkill = (spell->EquippedItemClass == ITEM_CLASS_WEAPON) ? int32(GetWeaponSkillValue(attType, pVictim)) : GetSkillMaxForLevel();
+    int32 attackerWeaponSkill = int32(GetWeaponSkillValue(attType, pVictim));
     int32 skillDiff = attackerWeaponSkill - int32(pVictim->GetSkillMaxForLevel(this));
     int32 fullSkillDiff = attackerWeaponSkill - int32(pVictim->GetDefenseSkillValue(this));
     int32 minWeaponSkill = GetSkillMaxForLevel(pVictim) < attackerWeaponSkill ? GetSkillMaxForLevel(pVictim) : attackerWeaponSkill;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Physical abilities that didn't require a melee weapon such as Bloodthirst and Pummel were specifically excluded from using weapon skill, instead simply using (level*5). This incorrect deviation from blizzlike behavior has been removed.

### Proof
<!-- Link resources as proof -->
- Indepth proof here #1971 
- Abridged [here](https://user-images.githubusercontent.com/111737968/248505592-affd7030-86bd-46c5-9964-f892ec5943e3.png)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixed #1971 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- create warrior, levelup to 60, `.learn all_myclass`
- teleport to a level 59-60 mob .go creature 41697
- .modify rage 1000 to give yourself enough rage to test
- Use bloodthirst or pummel on the mob. You'll find it use the weapon skill of the weapon your character is equipping.


https://github.com/vmangos/core/assets/111737968/6db466b6-cd67-4e69-801e-97aa75f4aed8
With low two handed axe skill, bloodthirst does not hit

https://github.com/vmangos/core/assets/111737968/12104b62-ad6b-4ff6-8297-26029f5d0722
With leveled up skill bloodthirst starts hitting. Disarmed myself, bloodthirst now uses unarmed skill.

https://github.com/vmangos/core/assets/111737968/43b9a60b-3220-4d44-b975-78f41038557d
I checked to make sure Druids are not accidentally affected by this change.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
