### PR TITLE
Fix Spell Scaling with Level formula

### DIFF
--- a/sql/migrations/20230706092629_world.sql
+++ b/sql/migrations/20230706092629_world.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230706092629');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230706092629');
+-- Add your query below.
+
+-- Remove hack fixes to spell damage that tried to balance some abilities damage according to the old incorrect formula
+DELETE FROM `spell_effect_mod` WHERE `Id`=26194; -- Skeram earth shock
+DELETE FROM `spell_effect_mod` WHERE `Id`=26192; -- Skeram arcane explosion
+DELETE FROM `spell_effect_mod` WHERE `Id`=14297; -- Anubisath Guardian Shadow Storm
+DELETE FROM `spell_effect_mod` WHERE `Id`=26546; -- Anubisath Sentinel Shadow Storm
+DELETE FROM `spell_effect_mod` WHERE `Id`=26555; -- Anubisath Defender Shadow Storm
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -911,8 +911,13 @@ float SpellCaster::CalculateSpellEffectValue(Unit const* target, SpellEntry cons
         spellProto->Effect[effect_index] != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE &&
         spellProto->Effect[effect_index] != SPELL_EFFECT_KNOCK_BACK &&
         (spellProto->Effect[effect_index] != SPELL_EFFECT_APPLY_AURA || spellProto->EffectApplyAuraName[effect_index] != SPELL_AURA_MOD_DECREASE_SPEED))
-        value = value * 0.25f * exp(GetLevel() * (70 - spellProto->spellLevel) / 1000.0f);
-
+    {
+        CreatureClassLevelStats const* pCLS = sObjectMgr.GetCreatureClassLevelStats(1, GetLevel());
+        float CLSPowerCreature = pCLS->melee_damage;
+        CreatureClassLevelStats const* spellCLS = sObjectMgr.GetCreatureClassLevelStats(1, spellProto->spellLevel);
+        float CLSPowerSpell = spellCLS->melee_damage;
+        value = value * (CLSPowerCreature / CLSPowerSpell);
+    }
     return value;
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changed the formula used by spells that scale with creature level into taking information from CLS. Essentially, how blizzard implemented it is simply:
real damage of the spell = damage of the spell in database multiplied by default melee damage of a mob in the level of the caster divided by default melee damage of a mob in the level of the spell.

Classic testing has shown the formula is based on CLS
### Proof
<!-- Link resources as proof -->
- [spreadsheet of all information](https://docs.google.com/spreadsheets/d/15aYaq4KR0QexXMO-cEcBZoBj-W4AuisYnPdFURkoMk8/edit#gid=888958498)
- sniff data for [classic sniffs](https://cdn.discordapp.com/attachments/1110919944973070336/1119805690224050247/spellscaling.sql) results thanks to Brotalnia. Organized into a graph 
![image](https://github.com/vmangos/core/assets/111737968/49a010e6-6c73-49ee-99a5-796a22b31f35)

- Sniffs overlapped on melee_damage from CLS table
![image](https://github.com/vmangos/core/assets/111737968/d7ba2759-20a7-4d84-aa0b-6a27b3fa143a)
Dark red line is vmangos' old wrong formula, yellow line is melee damage. Sniff data follows melee damage, and is nowhere near the old formula.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #241 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- `.npc summon 15200` to summon a level 60 npc with [mind flay](https://www.wowhead.com/classic/spell=17165/mind-flay) and [shadow word pain
](https://www.wowhead.com/classic/spell=15654/shadow-word-pain)

- look at damage per tick of mind flay and shadow word pain, it's increased by the correct multiplier (level 20 to level 60 is a 3.5 increase, in both auto damage and spell damage)

- unlevel the mob to 20 by `.level -40` , as a level 20 mob casting a level 20 spell, the two modifiers are equal and cancel each other out. Now mindflay ticks for 80 and SWP ticks for 48, same as their damage number in db.

- you can continue fiddling the mob's level and see the scaling happen
### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
