### PR TITLE
Fix GeoLocking config check

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -1321,7 +1321,7 @@ void AuthSocket::LoadAccountSecurityLevels(uint32 accountId)
 
 bool AuthSocket::GeographicalLockCheck()
 {
-    if (!sConfig.GetBoolDefault("GeoLocking"), false)
+    if (!sConfig.GetBoolDefault("GeoLocking", false))
     {
         return false;
     }


### PR DESCRIPTION
## 🍰 Pullrequest
misplaced ')' leading to an unexpected result.