### PR TITLE
Update parry chance formula to match wowwiki description

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2120,10 +2120,9 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* pVictim, WeaponAttackT
 
     // bonus from skills is 0.04%
     int32    skillDiff = attackerWeaponSkill - victimMaxSkillValueForLevel;
-    int32    cappedSkillDiff = std::min(attackerMaxSkillValueForLevel, attackerWeaponSkill) - victimMaxSkillValueForLevel;
     int32    blockSkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 10 * skillDiff;
     int32    dodgeSkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 10 * skillDiff;
-    int32    parrySkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : cappedSkillDiff < -10 ? 60 * cappedSkillDiff : 20 * cappedSkillDiff;
+    int32    parrySkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : skillDiff < -10 ? 60 * skillDiff : 10 * skillDiff;
     int32    sum = 0, tmp = 0;
     int32    roll = urand(0, 9999);
 


### PR DESCRIPTION
https://github.com/vmangos/core/blob/c4ee2afb87502832892e9a50eedc10cfc5b315d0/src/game/Objects/Unit.cpp#L2126
I didn't compiled server, just traced it "on the paper".
From what I understand in code of Unit::RollMeleeOutcomeAgainst

### Tracing of current code

Function RollMeleeOutcomeAgainst decides what will be result of attack of "this" unit against "pVictim" of attack.
It is used for any situation. I mean player vs player, player vs mob, mob vs player, mob vs mob.
Result of attack is one of the: miss, dodge, parry, glancing, block, crit, crushing, hit.

I interested in situation when player attacks mob from the front because mobs doesn't parry from behind.
My specific mob also have nothing to increase dodge, parry or blocks. I will check all kinds of level difference and weapon skill bonuses of player.

Default value for dodge can be found at line https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2591
next line adds bonuses from equipment talents and skills. So I assume base chance to dodge of mob is 5.00%
Chance to parry can be found here https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2623
Base chance to parry of mob is 5.00
Chance to block can be found here
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2653
Base chance to block of mob is 5.00

To simplify calculations, number 5.00 is converted to 500.

First line mentioning skills is https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2115
It calls GetSkillMaxForLevel. It is implemented here https://github.com/vmangos/core/blob/development/src/game/Objects/SpellCaster.h#L328
It figures out level of attacker against current target and multiplies it by 5. It has complex logic when attacker is worldboss, but when attacker is player it just returns player level.

So if you are lvl 60 and attack normal mob of lvl 60, then
attackerMaxSkillValueForLevel = 60*5=300
victimMaxSkillValueForLevel = 60*5=300
here race and bonuses are irrelevant

If you are lvl 60 and attack worldboss, then
attackerMaxSkillValueForLevel = 60*5=300
victimMaxSkillValueForLevel = 63*5=315

After this, server takes into account weapon and defense skills https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2118
Checks current weapon, checks current player skill for this weapon. For example when you leveled your skill to 80 out of 100.
Logic is in function https://github.com/vmangos/core/blob/development/src/game/Objects/Player.cpp#L6119
Here you get permanent bonuses and temporary bonuses. I know that talents like Anticipation and racials like Axe Specialization works different than bonuses from Edgemaster's Handguards. But I don't know which are temporary and which are permanent.
Anyway, they sumed both.

So if you are orc with axe of lvl 60, leveled axe skill to 305 then
attackerWeaponSkill = 305
if you are orc with sword of lvl 60, leveled sword skill to 300 then
attackerWeaponSkill = 300
if you are orc with axe of lvl 60, leveled axe skill only to 280 then
attackerWeaponSkill = 280
if you are orc with axe of lvl 60, leveled axe skill only to 305 and wear Edgemaster's Hadguards then
attackerWeaponSkill = 312

Defense skill of mob depends of type and level. But we probably interested in two situations.
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2119
If you attack normal mob of 60 lvl
victimDefenseSkill = 300
If you attack worldboss
victimDefenseSkill = 315

After this, server calculates skillDiff https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2122
skillDiff = attackerWeaponSkill - victimMaxSkillValueForLevel
60 orc with axe with edgemaster (+7 to axe/sword/dagger skill) against worldboss
skillDiff = 312-315 = -3
60 orc with sword against worldboss 
skillDiff = 300-315 = -15
60 orc with axe with edgemaster against 60 mob
skillDiff = 312-300 = 12
60 orc with sword against 60 mob
skillDiff = 300-300 = 0

Then server finds minimum between attackerMaxSkillValueForLevel and attackerWeaponSkill
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2123
and substracts from this value victimMaxSkillValueForLevel
60 orc with axe with edgemaster against worldboss
cappedSkillDiff = min(300, 312)-315 = 300-315 = -15
60 orc with sword against worldboss 
cappedSkillDiff = min(300, 300)-315 = 300-315 = -15
60 orc with axe with edgemaster against 60 mob
cappedSkillDiff = min(300, 312)-300 = 0
60 orc with sword against 60 mob
cappedSkillDiff = min(300, 300)-300 = 0

Then server calculates bonus to block
expression "something ? one : another" means "if something then one else another"
blockSkillBonus = if (pVictim->IsPlayer()){4 * skillDiff } else { 10 * skillDiff}
victim in all our situations is not player

60 orc with axe with edgemaster against worldboss
blockSkillBonus = 10 * skillDiff = 10 * -3 = -30
60 orc with sword against worldboss 
blockSkillBonus = 10 * skillDiff = 10 * -15 = -150
60 orc with axe with edgemaster against 60 mob
blockSkillBonus = 10 * skillDiff = 10 * 12 = 120
60 orc with sword against 60 lvl mob
blockSkillBonus = 10 * skillDiff = 10 * 0 = 0

same for dodge

60 orc with axe with edgemaster against worldboss
dodgeSkillBonus = 10 * skillDiff = 10 * -3 = -30
60 orc with sword against worldboss 
dodgeSkillBonus = 10 * skillDiff = 10 * -15 = -150
60 orc with axe with edgemaster against 60 mob
dodgeSkillBonus = 10 * skillDiff = 10 * 12 = 120
60 orc with sword against 60 lvl mob
dodgeSkillBonus = 10 * skillDiff = 10 * 0 = 0

parry expression is pretty sophisticated
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2126
`int32    parrySkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : cappedSkillDiff < -10 ? 60 * cappedSkillDiff : 20 * cappedSkillDiff;`

I assume it means 
```
if (pVictim->IsPlayer()) {
  parrySkillBonus = 4 * skillDiff
} else {
  if (cappedSkillDiff < -10) {
    parrySkillBonus = 60 * cappedSkillDiff
  } else {
    parrySkillBonus = 20 * cappedSkillDiff
  }
}
```
pVictim is not a player in my case

60 orc with axe with edgemaster against worldboss. cappedSkillDiff = -15
parrySkillBonus = 60 * -15 = -900
60 orc with sword against worldboss. cappedSkillDiff = -15
parrySkillBonus = 60 * -15 = -900
60 orc with axe with edgemaster against 60 mob. cappedSkillDiff = 0
parrySkillBonus = 20 * 0 = 0
60 orc with sword against 60 lvl mob. cappedSkillDiff = 0
parrySkillBonus = 20 * 0 = 0
**Those numbers are equal in cases "with" and "without additional skill" but they should not be.**

Then server rolls one random number from 0 to 9999 (from 0% to 99.99%)
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2128
Let it be 7130

then server compares "roll" to miss chance.
7130 is more than 650, outcome is not miss

then server checks for crit against sitting. not our situation. skip it

dodge chance is reduced by dodgeSkillBonus.
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2158

60 orc with axe with edgemaster against worldboss
dodgeChance = dodgeChance - dodgeSkillBonus = 500 - (-30) = 530
60 orc with sword against worldboss
dodgeChance = 500 - (-150) = 650 it means 6.5% to dodge
60 orc with axe with edgemaster against 60 mob
dodgeChance = 500 - 120 = 380
60 orc with sword against 60 lvl mob
dodgeChance = 500 - 0 = 500

then server compares "roll" to sum of dodge chance + miss chance.
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2165
if victim is NPC below level 10, then dodge chance multiplied by (lvl / 10). When level is 1, then 5.0 * 1/10. When level 9 then 5.0 / 9/10.
Not our case with worldboss anyway.

7130 is more than 500+650, outcome is not dodge

parryChance of mob is reduced by skill bonus
https://github.com/vmangos/core/blob/development/src/game/Objects/Unit.cpp#L2178

60 orc with axe with edgemaster against worldboss
parryChance = parryChance - parrySkillBonus = 500 - (-900) = 1400
60 orc with sword against worldboss
parryChance = parryChance - parrySkillBonus = 500 - (-900) = 1400 it means 14% to parry
60 orc with axe with edgemaster against 60 mob
parryChance = 500 - 0 = 500
60 orc with sword against 60 lvl mob
parryChance = 500 - 0 = 500
actual skill doesn't seem to do anything for +3 lvl situation and even for equal level situation


### Why it is made like this?
https://github.com/vmangos/core/pull/218
originating from
https://github.com/lh-server/core/pull/236
> Some things that are still unknown / up to debate:
How exactly parry scales. I made it a linear 0.6 per skill point so it matches the 14% but the data shows much lower parry than expected on +1 and +2 level mobs.

It was made with intention to scale, but it don't scales.

### How it should be?
https://wowpedia.fandom.com/wiki/Weapon_skill#Player_attacking_a_mob

> The base chance for your attack to be parried by the mob:
If the difference between the mob's Defense Skill and your Weapon Skill is less than or equal to 10, your base parry rate is: 5% + (Defense Skill - Weapon Skill)*.1%.
If the difference between the mob's Defense Skill and your Weapon Skill is greater than 10, your base parry rate will be much higher. Exact figures are not known, but base parry rates of Boss mobs (effectively level 73 when attacked by level 70 players) are estimated to be between 10-15%, and may vary from one Boss to the next.

60 orc with axe with edgemaster against worldboss.
defense skill 315, weapon skill 312. difference is less than or equal to 10
5%+(315-312)*0.1%=5%+0.3%=5.3%
60 orc with sword against worldboss
defense skill 315, weapon skill 30. difference is greater or equal to 10
14%
60 orc with axe with edgemaster against 60 mob
defense skill 300, weapon skill 312. difference is less than or equal to 10
5%+(300-312)*0.1%=5%-1.2%=3.8%
60 orc with sword against 60 mob
defense skill 300, weapon skill 300. difference is less than or equal to 10
5%+0*0.1%=5%

### Tracing after the change
if (pVictim->IsPlayer()) {
  parrySkillBonus = 4 * skillDiff
} else {
  if (skillDiff < -10) {
    parrySkillBonus = 60 * skillDiff
  } else {
    parrySkillBonus = 10 * skillDiff
  }
}
pVictim is not a player

60 orc with axe with edgemaster against worldboss. skillDiff = -3 greater than -10
parrySkillBonus = 10 * -3 = -30
60 orc with sword against worldboss. skillDiff = -15 less than -10
parrySkillBonus = 60 * -15 = -900
60 orc with axe with edgemaster against 60 mob. skillDiff = 12 greater than -10
parrySkillBonus = 10 * 12 = 120
60 orc with sword against 60 lvl mob. skillDiff = 0 greater than -10
parrySkillBonus = 10 * 0 = 0

60 orc with axe with edgemaster against worldboss
parryChance = parryChance - parrySkillBonus = 500 - (-30) = 530 or 5.3%. matches wowwiki
60 orc with sword against worldboss
parryChance = parryChance - parrySkillBonus = 500 - (-900) = 1400 or 14%. matches wowwiki
60 orc with axe with edgemaster against 60 mob
parryChance = 500 - 120 = 380 or 3.8%. matches wowwiki
60 orc with sword against 60 lvl mob
parryChance = 500 - 0 = 500 or 5%. matches wowwiki