### PR TITLE
Hammer of Wrath does not use weapon skill

### DIFF
--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -382,7 +382,7 @@ SpellMissInfo SpellCaster::MeleeSpellHitResult(Unit* pVictim, SpellEntry const* 
         return SPELL_MISS_NONE;
 
     // bonus from skills is 0.04% per skill Diff
-    int32 attackerWeaponSkill = int32(GetWeaponSkillValue(attType, pVictim));
+    int32 attackerWeaponSkill = (spell->SpellFamilyName == SPELLFAMILY_PALADIN) ? int32(GetWeaponSkillValue(BASE_ATTACK, pVictim)) : int32(GetWeaponSkillValue(attType, pVictim));
     int32 skillDiff = attackerWeaponSkill - int32(pVictim->GetSkillMaxForLevel(this));
     int32 fullSkillDiff = attackerWeaponSkill - int32(pVictim->GetDefenseSkillValue(this));
     int32 minWeaponSkill = GetSkillMaxForLevel(pVictim) < attackerWeaponSkill ? GetSkillMaxForLevel(pVictim) : attackerWeaponSkill;

--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -382,7 +382,7 @@ SpellMissInfo SpellCaster::MeleeSpellHitResult(Unit* pVictim, SpellEntry const* 
         return SPELL_MISS_NONE;
 
     // bonus from skills is 0.04% per skill Diff
-    int32 attackerWeaponSkill = (spell->SpellFamilyName == SPELLFAMILY_PALADIN) ? int32(GetWeaponSkillValue(BASE_ATTACK, pVictim)) : int32(GetWeaponSkillValue(attType, pVictim));
+    int32 attackerWeaponSkill = (spell->SpellFamilyName == SPELLFAMILY_PALADIN && attType == RANGED_ATTACK) ? GetSkillMaxForLevel() : int32(GetWeaponSkillValue(attType, pVictim));
     int32 skillDiff = attackerWeaponSkill - int32(pVictim->GetSkillMaxForLevel(this));
     int32 fullSkillDiff = attackerWeaponSkill - int32(pVictim->GetDefenseSkillValue(this));
     int32 minWeaponSkill = GetSkillMaxForLevel(pVictim) < attackerWeaponSkill ? GetSkillMaxForLevel(pVictim) : attackerWeaponSkill;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Recent commit to make special abilities use weapon skill competely broke Hammer of Wrath. Made it use ranged weapon skill (defaulted to 0 on paladin who don't have ranged weapon skill to begin with, the bug made the ability miss more than 50% of the time when fighting same level enemies)

Hammer of wrath seems to be the sole exception that **shouldn't** use weapon skill ever.

### Proof
<!-- Link resources as proof -->
[Videos from classic ptr](https://discord.com/channels/484741332850573317/484741332850573323/1129568118440734871) thanks to Brotalnia

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- 

https://github.com/vmangos/core/assets/111737968/feccca46-3a6d-45bd-8d09-4ac245d48d2a


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- Stop Hammer of Wrath from leveling up the equipped weapon skill maybe..?