### PR TITLE
Update TerrainBuilder.cpp

### DIFF
--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -768,11 +768,7 @@ namespace MMAP
                     {
                         // If terrain is under wmo, mark terrain as unwalkable
                         // If there are less than 1.5y between terrain and m2 then mark the terrain as unwalkable
-                        if (!isM2)
-                        {
-                            terrainInsideModelsVerts[t] = inDist;
-                        }
-                        else if (inDist < 1.5f)
+                        if (!isM2 || inDist < 1.5f)
                         {
                             terrainInsideModelsVerts[t] = inDist;
                         }

--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -766,9 +766,16 @@ namespace MMAP
                     float inDist  = -1.0f;
                     if (it->IsUnderObject(v, up, isM2, &outDist, &inDist)) // inDist < outDist
                     {
-                        //if there are less than 1.5y between terrain and model then mark the terrain as unwalkable
-                        if (inDist < 1.5f)
+                        // If terrain is under wmo, mark terrain as unwalkable
+                        // If there are less than 1.5y between terrain and m2 then mark the terrain as unwalkable
+                        if (!isM2)
+                        {
                             terrainInsideModelsVerts[t] = inDist;
+                        }
+                        else if (inDist < 1.5f)
+                        {
+                            terrainInsideModelsVerts[t] = inDist;
+                        }
                     }
                 }
         }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Slight update for PR https://github.com/vmangos/core/pull/1880 that caused an issue with MMAP at SW entrance.

To me, it looks like an ugly hackfix and I am not really happy with it, but I think it's time to at least do a PR and revisit this issue at a later time.

Pre 1880 behaviour:
Filter all terrain below models

1880 behavior:
Filter terrain if the distance between terrain and model is 1.5 or less.

This PR:
Filter all terrain below WMO models.
Filter terrain if the distance between terrain and M2 model is 1.5 or less.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
