### PR TITLE
Implement SPELL_ATTR_EX_NO_AUTOCAST_AI for charmed players

### DIFF
--- a/src/game/AI/PlayerAI.cpp
+++ b/src/game/AI/PlayerAI.cpp
@@ -24,12 +24,6 @@
 #include "MotionMaster.h"
 #include "Spell.h"
 
-// Part of code to make hunters always use Auto shot
-static std::vector<uint32> hunterSkipSpells =
-{
-    75, // auto shot
-};
-
 void PlayerAI::Remove()
 {
     me->SetAI(nullptr);
@@ -132,22 +126,6 @@ PlayerControlledAI::PlayerControlledAI(Player* pPlayer, Unit* caster) : PlayerAI
             continue;
         if (Spells::IsPositiveSpell(spell.first) && !enablePositiveSpells)
             continue;
-        switch (pPlayer->GetClass())
-        {
-        case CLASS_WARRIOR:
-        case CLASS_ROGUE:
-        case CLASS_PALADIN:
-        case CLASS_DRUID:
-        case CLASS_SHAMAN:
-        case CLASS_MAGE:
-        case CLASS_WARLOCK:
-        case CLASS_PRIEST:
-            break;
-        case CLASS_HUNTER:
-            if (std::find(hunterSkipSpells.begin(), hunterSkipSpells.end(), spell.first) != hunterSkipSpells.end())
-                continue;
-            break;
-        }
         usableSpells.push_back(spell.first);
     }
     // Ignore non-max rank
@@ -349,19 +327,6 @@ void PlayerControlledAI::UpdateAI(uint32 const uiDiff)
 
     if (uiGlobalCD < uiDiff)
     {
-        if (me->GetClass() == CLASS_HUNTER) // TODO: If hunter, use ONLY autoshoot and nothing else?
-        {
-            float dist = me->GetDistance(victim);
-            if (dist > 10.0f)
-            {
-                if (Spell* pSpell = me->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL))
-                {
-                    if (pSpell->m_spellInfo && pSpell->m_spellInfo->Id != 75) // auto shoot
-                        me->CastSpell(victim, 75, true);
-                }
-            }
-        }
-
         if (me->IsNonMeleeSpellCasted(true))
             uiGlobalCD = 200;
         else


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Blizzard appears to have used this attribute to exclude spells from being autocast by charmed players, instead of a hardcoded list of spells.

I also removed the hunter specific code. In practice, all it it seemed to do was disable auto shot and it doesn't make sense to do that.

### Proof
<!-- Link resources as proof -->
[List of all spells in spell_template that have the attribute](https://docs.google.com/spreadsheets/d/1Fsp0-xR6qqx0r7x0yxz2V0d0Xr5D1BMHzHHqXxFaqGw/edit?usp=sharing)



### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->

https://github.com/vmangos/core/assets/111737968/8c5c17b2-8e39-4600-a6a4-5cd6b3a1aae1

Warlock does not use Curse of Recklessness and Drain Soul despite being only spells in his spellbook (I unlearned R1 Shadow bolt). When the warlock has shadow bolt and drain soul, he will spam shadow bolt and never use drain soul.
______________________________

https://github.com/vmangos/core/assets/111737968/5ef87dca-92c7-40a2-9e36-e35e6f193528

Hunter AI mixes abilities with auto shot.
______________________________

https://github.com/vmangos/core/assets/111737968/e166bdb0-49ae-4aed-8b0d-9ca4dad03543

Priest does not use Mind Soothe or Mind Vision because they have the attribute. Also does not use Fade possibly because it is a beneficial spell. (I unlearned R1 Smite)
Also doesn't try to heal the controller which should be fixed.



### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] Make charmed players to cast beneficial spells on the controlling creature. Currently looks like it only does that on [KT mind control?](https://github.com/vmangos/core/blob/2ed34467bcde8a0702981d9d212e49000bda7cdc/src/game/Spells/SpellAuras.cpp#L3431C7-L3431C7)
