### PR TITLE
Add locale banning.

### DIFF
--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -148,6 +148,10 @@ ConfVersion=2020010501
 #        The SendGrid template GUID for geolocking emails
 #        Default: ""
 #
+#    BannedLocale
+#        List of banned locales as a comma-separated string
+# 	 Default: ""
+#
 ###################################################################################################################
 
 LoginDatabaseInfo = "127.0.0.1;3306;mangos;mangos;realmd"
@@ -179,3 +183,4 @@ MailFrom = ""
 MailCertChecks = 1
 SendGridKey = ""
 GeolockGUID = ""
+BannedLocale = ""


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds the ability to ban any locale client from connecting.
It is configurable in realmd.conf and supports banning of several locales.

![WoW_ZgVKxCGB78](https://github.com/vmangos/core/assets/6137576/27ab1f06-f759-448a-aca9-2e8136e2462a)

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
- Open realmd.conf
- Set BannedLocale to: "frFR, esES, zhCN, enUS"
- Try connecting with any of those clients.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
