### PR TITLE
Spell groups and aura exclusivity

### DIFF
--- a/sql/migrations/20230724142016_world.sql
+++ b/sql/migrations/20230724142016_world.sql
@@ -300,7 +300,7 @@ INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES
 INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
 (1030, 0, 26681, 5086, 5875),
 (1030, 1, 26682, 5086, 5875);
-INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1050, 0, 1);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1030, 0, 1);
 
 -- Debuff groups:
 -- Demoralizing shout + Demoralizing roar

--- a/sql/migrations/20230724142016_world.sql
+++ b/sql/migrations/20230724142016_world.sql
@@ -1,0 +1,357 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230724142016');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230724142016');
+-- Add your query below.
+
+-- Dumping structure for table mangos.spell_group
+DROP TABLE IF EXISTS `spell_group`;
+CREATE TABLE IF NOT EXISTS `spell_group` (
+  `group_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `group_spell_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `spell_id` int(11) NOT NULL DEFAULT '0',
+  `build_min` smallint(4) unsigned NOT NULL DEFAULT '0' COMMENT 'Minimum game client build to load this entry',
+  `build_max` smallint(4) unsigned NOT NULL DEFAULT '5875' COMMENT 'Maximum game client build to load this entry',
+  PRIMARY KEY (`group_id`,`group_spell_id`,`spell_id`),
+  UNIQUE KEY `group_id` (`group_id`,`group_spell_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Spell System';
+
+-- Dumping structure for table mangos.spell_group_stack_rules
+DROP TABLE IF EXISTS `spell_group_stack_rules`;
+CREATE TABLE IF NOT EXISTS `spell_group_stack_rules` (
+  `group_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `build` smallint(4) unsigned NOT NULL DEFAULT '0' COMMENT 'Game client build in which this exact stacking rule was added',
+  `stack_rule` tinyint(3) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`group_id`,`build`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+
+-- well fed
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1001, 0, 18125, 5086, 5875),
+(1001, 1, 18141, 5086, 5875),
+(1001, 2, 19705, 5086, 5875),
+(1001, 3, 19706, 5086, 5875),
+(1001, 4, 19708, 5086, 5875),
+(1001, 5, 19709, 5086, 5875),
+(1001, 6, 19710, 5086, 5875),
+(1001, 7, 19711, 5086, 5875),
+(1001, 8, 23697, 5086, 5875),
+(1001, 9, 24799, 5086, 5875),
+(1001, 10, 24870, 5086, 5875),
+(1001, 11, 25694, 5086, 5875),
+(1001, 12, 25941, 5086, 5875),
+(1001, 13, 18191, 5086, 5875),
+(1001, 14, 18194, 5086, 5875),
+(1001, 15, 22730, 5086, 5875),
+(1001, 16, 18222, 5086, 5875),
+(1001, 17, 18192, 5086, 5875),
+(1001, 18, 25661, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1001, 5086, 1);
+
+-- Zanzas
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1002, 0, 24417, 4695, 5875),
+(1002, 1, 24383, 4695, 5875),
+(1002, 2, 24382, 4695, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1002, 4695, 1);
+	
+-- Blasted lands
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1003, 0, 10693, 0, 5875),
+(1003, 1, 10668, 0, 5875),
+(1003, 2, 10669, 0, 5875),
+(1003, 3, 10667, 0, 5875),
+(1003, 4, 10692, 0, 5875),
+(1003, 5, 10670, 0, 5875),
+(1003, 6, 10671, 0, 5875),
+(1003, 7, 10672, 0, 5875),
+(1003, 8, 10690, 0, 5875),
+(1003, 9, 10691, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1003, 0, 1);
+	
+-- Alcohol
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1004, 0, 25804, 5086, 5875),
+(1004, 1, 20875, 0, 5875),
+(1004, 2, 25722, 5086, 5875),
+(1004, 3, 25037, 5086, 5875),
+(1004, 4, 22789, 0, 5875),
+(1004, 5, 22790, 0, 5875),
+(1004, 6, 6114, 0, 5875),
+(1004, 7, 5020, 0, 5875),
+(1004, 8, 5021, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1004, 0, 1);
+
+-- Stamina scrolls + fortitude. exclusives: 17537
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1005, 0, 1243, 0, 5875),
+(1005, 1, 8099, 0, 5875),
+(1005, 2, 8100, 0, 5875),
+(1005, 3, 1244, 0, 5875),
+(1005, 4, 8101, 0, 5875),
+(1005, 5, 12178, 0, 5875),
+(1005, 6, 1245, 0, 5875),
+(1005, 7, 2791, 0, 5875),
+(1005, 8, 10937, 0, 5875),
+(1005, 9, 10938, 0, 5875),
+(1005, 10, 21562, 0, 5875),
+(1005, 11, 21564, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1005, 0, 3);
+
+-- Intellect scrolls + arcane intellect + juju guile + elixir of greater intellect. exclusives: 17535
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES	
+(1006, 0, 1459, 0, 5875),
+(1006, 1, 8096, 0, 5875),
+(1006, 2, 1460, 0, 5875),
+(1006, 3, 8097, 0, 5875),
+(1006, 4, 8098, 0, 5875),
+(1006, 5, 1461, 0, 5875),
+(1006, 6, 12176, 0, 5875),
+(1006, 7, 10156, 0, 5875),
+(1006, 8, 11396, 0, 5875),
+(1006, 9, 16327, 0, 5875),
+(1006, 10, 16876, 0, 5875),
+(1006, 11, 10157, 0, 5875),
+(1006, 12, 23028, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1006, 0, 3);
+
+-- Spirit scrolls + divine spirit + crystal force. exclusives: 17535
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1007, 1, 8113, 0, 5875),
+(1007, 2, 8114, 0, 5875),
+(1007, 3, 12177, 0, 5875),
+(1007, 4, 14752, 0, 5875),
+(1007, 5, 14818, 0, 5875),
+(1007, 6, 15231, 0, 5875),
+(1007, 7, 14819, 0, 5875),
+(1007, 8, 27841, 5302, 5875),
+(1007, 9, 27681, 5302, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1007, 0, 3);
+
+-- Strength scrolls + elixirs + juju power. exclusives: 8212 17537
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1008, 0, 2367, 0, 5875),
+(1008, 1, 8118, 0, 5875),
+(1008, 2, 3164, 0, 5875),
+(1008, 3, 8119, 0, 5875),
+(1008, 4, 8120, 0, 5875),
+(1008, 5, 12179, 0, 5875),
+(1008, 6, 11405, 0, 5875),
+(1008, 7, 16323, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1008, 0, 3);
+	
+-- Agility scrolls + elixirs. exclusives: 17538
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1009, 0, 2374, 0, 5875),
+(1009, 1, 8115, 0, 5875),
+(1009, 2, 3160, 0, 5875),
+(1009, 3, 8116, 0, 5875),
+(1009, 4, 8117, 0, 5875),
+(1009, 5, 11328, 0, 5875),
+(1009, 6, 12174, 0, 5875),
+(1009, 7, 11334, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1009, 0, 3);
+
+-- Armor scrolls + elixirs.
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1010, 0, 673, 0, 5875),
+(1010, 1, 8091, 0, 5875),
+(1010, 2, 8094, 0, 5875),
+(1010, 3, 3220, 0, 5875),
+(1010, 4, 8095, 0, 5875),
+(1010, 5, 12175, 0, 5875),
+(1010, 6, 11349, 0, 5875),
+(1010, 7, 11348, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1010, 0, 3);
+
+-- Spell damage elixirs + mind control buffs
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1011, 0, 11390, 0, 5875),
+(1011, 1, 15288, 0, 5875),
+(1011, 2, 17539, 0, 5875),
+(1011, 3, 17150, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1011, 0, 3);
+
+-- Fire damage elixirs
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1012, 0, 7844, 0, 5875),
+(1012, 1, 26276, 5302, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1012, 0, 3);
+
+-- Shadow damage elixirs + mind control buffs
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1013, 0, 16587, 0, 5875),
+(1013, 1, 11474, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1013, 0, 3);
+
+-- Detect Invisibility
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1014, 0, 132, 0, 5875),
+(1014, 1, 2970, 0, 5875),
+(1014, 2, 11743, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1014, 0, 3);
+
+-- Blessing of might
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1015, 0, 19740, 0, 5875),
+(1015, 1, 19834, 0, 5875),
+(1015, 2, 19835, 0, 5875),
+(1015, 3, 19836, 0, 5875),
+(1015, 4, 19837, 0, 5875),
+(1015, 5, 19838, 0, 5875),
+(1015, 6, 25291, 5086, 5875),
+(1015, 7, 25782, 5086, 5875),
+(1015, 8, 25916, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1015, 0, 1);
+
+-- Blessing of wisdom
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1016, 0, 19742, 0, 5875),
+(1016, 1, 19850, 0, 5875),
+(1016, 2, 19852, 0, 5875),
+(1016, 3, 19853, 0, 5875),
+(1016, 4, 19854, 0, 5875),
+(1016, 5, 25290, 5086, 5875),
+(1016, 6, 25894, 5086, 5875),
+(1016, 7, 25918, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1016, 0, 1);
+
+-- Blessing of light
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1017, 0, 19977, 0, 5875),
+(1017, 1, 19978, 0, 5875),
+(1017, 2, 19979, 0, 5875),
+(1017, 3, 25890, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1017, 0, 1);
+
+-- Blessing of sanctuary
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1018, 0, 20911, 0, 5875),
+(1018, 1, 20912, 0, 5875),
+(1018, 2, 20913, 0, 5875),
+(1018, 3, 20914, 0, 5875),
+(1018, 4, 25899, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1018, 0, 1);
+
+-- Blessing of kings
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1019, 0, 20217, 0, 5875),
+(1019, 1, 25898, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1019, 0, 1);
+
+-- Blessing of salvation
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1020, 0, 1038, 0, 5875),
+(1020, 1, 25895, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1020, 0, 1);
+
+-- Arcane power + power infusion
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1021, 0, 10060, 5302, 5875),
+(1021, 1, 12042, 5302, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1021, 5302, 3);
+
+-- Attack power winterfall firewater + juju might
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1022, 0, 16329, 0, 5875),
+(1022, 1, 17038, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1022, 0, 1);
+
+-- Stealth + shadowmeld
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1023, 0, 20580, 0, 5875),
+(1023, 1, 1784, 0, 5875),
+(1023, 2, 1785, 0, 5875),
+(1023, 3, 1786, 0, 5875),
+(1023, 4, 1787, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1023, 0, 3);
+
+-- Inspiration + Ancestral Fortitude
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1024, 0, 16177, 0, 5875),
+(1024, 1, 16236, 0, 5875),
+(1024, 2, 16237, 0, 5875),
+(1024, 3, 14893, 0, 5875),
+(1024, 4, 15357, 0, 5875),
+(1024, 5, 15359, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1024, 0, 1);
+
+-- Protection potions
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1025, 0, 7233, 0, 5875),
+(1025, 1, 17543, 0, 5875),
+(1026, 0, 7239, 0, 5875),
+(1026, 1, 17544, 0, 5875),
+(1027, 0, 7254, 0, 5875),
+(1027, 1, 17546, 0, 5875),
+(1028, 0, 7242, 0, 5875),
+(1028, 1, 17548, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1025, 0, 1);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1026, 0, 1);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1027, 0, 1);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1028, 0, 1);
+
+-- Love is in the air perfume
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1030, 0, 26681, 5086, 5875),
+(1030, 1, 26682, 5086, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1050, 0, 1);
+
+-- Debuff groups:
+-- Demoralizing shout + Demoralizing roar
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1040, 0, 99, 0, 5875),
+(1040, 1, 1160, 0, 5875),
+(1040, 2, 1735, 0, 5875),
+(1040, 3, 6190, 0, 5875),
+(1040, 4, 9490, 0, 5875),
+(1040, 5, 11554, 0, 5875),
+(1040, 6, 9747, 0, 5875),
+(1040, 7, 11555, 0, 5875),
+(1040, 8, 9898, 0, 5875),
+(1040, 9, 11556, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1040, 0, 3);
+
+-- Sunder armor + expose armor
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1041, 0, 15235, 0, 5875),
+(1041, 1, 7386, 0, 5875),
+(1041, 2, 8647, 0, 5875),
+(1041, 3, 7405, 0, 5875),
+(1041, 4, 8649, 0, 5875),
+(1041, 5, 8380, 0, 5875),
+(1041, 6, 8650, 0, 5875),
+(1041, 7, 11596, 0, 5875),
+(1041, 8, 11197, 0, 5875),
+(1041, 9, 11597, 0, 5875),
+(1041, 10, 11198, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1041, 0, 3);
+
+-- Faerie fire + debuff weapons
+INSERT INTO `spell_group` (`group_id`, `group_spell_id`, `spell_id`, `build_min`, `build_max`) VALUES
+(1042, 0, 17315, 4878, 5875),
+(1042, 1, 11791, 4878, 5875),
+(1042, 2, 770, 0, 5875),
+(1042, 3, 778, 0, 5875),
+(1042, 4, 9749, 0, 5875),
+(1042, 5, 9907, 0, 5875),
+(1042, 6, 13752, 0, 5875),
+(1042, 7, 16857, 0, 5875),
+(1042, 8, 17390, 0, 5875),
+(1042, 9, 17391, 0, 5875),
+(1042, 10, 17392, 0, 5875),
+(1042, 11, 21670, 0, 5875),
+(1042, 12, 20656, 0, 5875);
+INSERT INTO `spell_group_stack_rules` (`group_id`, `build`, `stack_rule`) VALUES (1042, 0, 1);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -8231,163 +8231,92 @@ Sorts d'exemple:
 
 bool _IsExclusiveSpellAura(SpellEntry const* spellproto, SpellEffectIndex eff, AuraType auraname)
 {
-    // Flametongue Totem / Totem of Wrath / Strength of Earth Totem / Fel Intelligence / Leader of the Pack
-    // Moonkin Aura / Mana Spring Totem / Tree of Life Aura / Improved Devotion Aura / Improved Icy Talons / Trueshot Aura
-    // Improved Moonkin Form / Sanctified Retribution Aura / Blood Pact
-    if (spellproto->Effect[eff] == SPELL_EFFECT_APPLY_AREA_AURA_RAID)
-        return false;
-
-    // Exceptions - se stack avec tout.
+    // In vanilla, very few spells show exclusive behavior. Grouped spells usually cancel each other unless one has an additional effect 
     switch (spellproto->Id)
     {
-        // Terres foudroyees et Zanza
-        case 10693:
-        case 10691: // +25 esprit
-        case 10668:
-        case 10671: // +25 endu
-        case 10667:
-        case 10670: // +25 force
-        case 10669:
-        case 10672: // +25 agi
-        case 10692:
-        case 10690: // +25 intel
-        case 24382:             // Buff zanza
-        // Alcools
-        case 25804:
-        case 20875:
-        case 25722:
-        case 25037:
-        case 22789:
-        case 22790:
-        case 6114:
-        case 5020:
-        case 5021:
-        case 23179: //le proc de l'�p�e de Razorgore (+300 force) devrait se cumuler avec TOUT : ID 23179
-        case 20007: //le proc Crois� devrait se cumuler avec TOUT : ID 20007
-        case 20572: //Le racial Orc (ID 20572)
-        case 17038: //l'Eau des Tombe-Hiver (ID 17038)
-        case 16329: //le Juju's Might (ID 16329)
-        case 25891: //le buff du Bijou Choc de Terre (ID : 25891)
-        case 18264: // Charge du maitre (baton epique scholo)
-        case 12022: // Chapeau pirate
-        case 22817: // PA HT Nord
-        // Aura de precision (hunt)
-        case 19506:
-        case 20905:
-        case 20906:
-        case 18262: // Pierre � Aiguiser El�mentaire (+2% crit)
-        case 24932: // chef de la Meute
-        case 24907: // aura S�l�nien
-        case 22888: // Buff Onyxia
-        case 15366: // Buff Felwood
-        case 22820: // HT +3% crit sorts
-        case 17628: // Supreme Power
-        case 22730: // Bouffe +10 Intell
-        case 18141: // Bouffe +10 Esprit
-        case 18125: // Bouffe +10 Force
-        case 18192: // Bouffe +10 Agility
-        case 18191: // Bouffe +10 Endu
-        case 25661: // Bouffe +25 Endu
-        case 24427: // Diamond Flask
-        case 17528: // Mighty Rage Potion
-        case 23697: // Alterac Spring Water
-        // Love is in the Air buffs
-        case 27664:
-        case 27665:
-        case 27666:
-        case 27669:
-        case 27670:
-        case 27671:
-            return false;
-
-        case 17538: // Le +crit du buff de l'Elixir de la Mangouste 17538, devrait se stack avec TOUT.
-            return (eff == EFFECT_INDEX_0);
+        // Spells that give two effects. Reason for the existence of this whole thing:
+        case 17537: // Elixir of Brute Force stam + str
+        case 17535: // Elixir of the Sages int + spi
+        case 8212:  // Elixir of Giant Growth str + size mod
+        case 17538: // Elixir of the Mongoose agi + phys crit
+        // Spells that give one effect, and can exclude or be excluded by the spells above:
+        // Stamina
+        case 1243:
+        case 8099:
+        case 8100:
+        case 1244:
+        case 8101:
+        case 12178:
+        case 1245:
+        case 2791:
+        case 10937:
+        case 10938:
+        case 21562:
+        case 21564:
+        // Strength
+        case 2367:
+        case 8118:
+        case 3164:
+        case 8119:
+        case 8120:
+        case 12179:
+        case 11405:
+        case 16323:
+        // Intellect
+        case 1459:
+        case 8096:
+        case 1460:
+        case 8097:
+        case 8098:
+        case 1461:
+        case 12176:
+        case 10156:
+        case 11396:
+        case 16327:
+        case 16876:
+        case 10157:
+        case 23028:
+        // Spirit
+        case 8113:
+        case 8114:
+        case 12177:
+        case 14752:
+        case 14818:
+        case 15231:
+        case 14819:
+        case 27841:
+        case 27681:
+        // Agility
+        case 2374:
+        case 8115:
+        case 3160:
+        case 8116:
+        case 8117:
+        case 11328:
+        case 12174:
+        case 11334:
+            return true;
     }
-    switch (spellproto->SpellFamilyName)
-    {
-        case SPELLFAMILY_WARLOCK:
-            // Blood Pact
-            if (spellproto->IsFitToFamilyMask<CF_WARLOCK_IMP_BUFFS>())
-                return false;
-            break;
-        case SPELLFAMILY_SHAMAN:
-            // Strength of Earth (ID 8076, 8162, 8163, 10441, 25362)
-            if (spellproto->IsFitToFamilyMask<CF_SHAMAN_STRENGTH_OF_EARTH>())
-                return false;
-            break;
-        case SPELLFAMILY_WARRIOR:
-            // Battle Shout (ID 6673, 5242, 6192, 11549, 11550, 11551, 25289)
-            if (spellproto->IsFitToFamilyMask<CF_WARRIOR_BATTLE_SHOUT>())
-                return false;
-            break;
-        case SPELLFAMILY_PALADIN:
-            // Blessing of Might (ID 19740, 19834, 19835, 19836, 19837, 19838, 25291, 25782, 25916)
-            if (spellproto->IsFitToFamilyMask<CF_PALADIN_BLESSING_OF_MIGHT, CF_PALADIN_BLESSINGS>())
-                return false;
-            break;
-        case SPELLFAMILY_HUNTER:
-            // Aspect of the Hawk
-            if (spellproto->IsFitToFamilyMask<CF_HUNTER_ASPECT_OF_THE_HAWK>())
-                return false;
-            break;
-        case SPELLFAMILY_DRUID:
+
 #if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_7_1
-            // World of Warcraft Client Patch 1.8.0 (2005-10-11)
-            // - Multiple Druids casting Hurricane will no longer stack the slowdown effect
-            if (spellproto->IsFitToFamilyMask<CF_DRUID_HURRICANE>())
-                return false;
-#endif
-            break;
-    }
-
-    // La bouffe
-    if (spellproto->AttributesEx2 & SPELL_ATTR_EX2_RETAIN_ITEM_CAST)
+    // World of Warcraft Client Patch 1.8.0 (2005-10-11)
+    // Multiple Druids casting Hurricane will no longer stack the slowdown effect.
+    if (spellproto->IsFitToFamilyMask<CF_DRUID_HURRICANE>())
         return false;
+#endif
 
     switch (auraname)
     {
-        //case SPELL_AURA_PERIODIC_DAMAGE:
-        //case SPELL_AURA_DUMMY:
-        //    return false;
-        case SPELL_AURA_MOD_HEALING_DONE:                               // Demonic Pact
-        case SPELL_AURA_MOD_DAMAGE_DONE:                                // Demonic Pact
-        case SPELL_AURA_MOD_ATTACK_POWER_PCT:                           // Abomination's Might / Unleashed Rage
-        case SPELL_AURA_MOD_RANGED_ATTACK_POWER_PCT:
-        case SPELL_AURA_MOD_ATTACK_POWER:                               // (Greater) Blessing of Might / Battle Shout
-        case SPELL_AURA_MOD_RANGED_ATTACK_POWER:
-        case SPELL_AURA_MOD_POWER_REGEN:                                // (Greater) Blessing of Wisdom
-        case SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN:                       // Glyph of Salvation / Pain Suppression / Safeguard ?
-        case SPELL_AURA_MOD_STAT:
-        case SPELL_AURA_WATER_BREATHING:
+        case SPELL_AURA_WATER_BREATHING: // Permanent water breathing disables undead extended water breathing racial
             return true;
-        case SPELL_AURA_MOD_SPELL_CRIT_CHANCE:
-            return true;
-        case SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_CHANCE:                 // Winter's Chill / Improved Scorch
-            if (spellproto->SpellFamilyName == SPELLFAMILY_MAGE)
-                return false;
-            return true;
-        case SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE: // A gere autrement (exlusif par rapport a la resistance)
-            return false;
-        case SPELL_AURA_MOD_HEALING_PCT:                                // Mortal Strike / Wound Poison / Aimed Shot / Furious Attacks
-            // Healing taken debuffs
+        case SPELL_AURA_MOD_MELEE_HASTE: // Attack speed reductions (Thunderclap, Thunderfury, Hurricane if running patch +1.8)
+        case SPELL_AURA_MOD_DECREASE_SPEED: // All movement speed slows don't stack with each other (Effect points negative despite saying "decrease speed")
+        case SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK: // Cast speed reductions (Curse of tongues, mind numbing poison)
+        case SPELL_AURA_MOD_HEALING_PCT: // Mortal Strike + Hex of Weakness doesn't stack https://www.wowhead.com/classic/spell=19285/hex-of-weakness#comments:id=3124997
             if (spellproto->EffectBasePoints[eff] < 0)
-                return false;
-            return true;
-        case SPELL_AURA_MOD_RESISTANCE_PCT:
-            // Ancestral Healing / Inspiration
-            if (spellproto->SpellFamilyName == SPELLFAMILY_SHAMAN ||
-                    spellproto->SpellFamilyName == SPELLFAMILY_PRIEST)
-                return false;
-            return true;
-        case SPELL_AURA_MOD_MELEE_HASTE:
-        case SPELL_AURA_MOD_DECREASE_SPEED:
-            // Attack and movement speed reduction
-            if (spellproto->EffectBasePoints[eff] >= 0)
-                return false;
-            return true;
-        default:
-            return false;
+                return true;
     }
+    return false;
 }
 
 void Aura::ComputeExclusive()


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
- Cleaned up spell groups table. 80% of the groups were duplicates, non-functional, or redundant from IsNoStackSpellDueToSpell.
- Rewrote wotlk code to something that makes much more sense for vanilla. Removed some exclusivity rules that had no logical reason to be there in the first place.

### Proof
<!-- Link resources as proof -->
- Spreadsheet documenting the new db tables in easy to read format [here](https://docs.google.com/spreadsheets/d/1Yfx8n_GjYcdyMcj1qWO5Xbc9iLibdKemDxPqtmCvHjg/edit?usp=sharing)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1884 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
