### PR TITLE
Fix threat values of warrior abilities

### DIFF
--- a/sql/migrations/20230726131045_world.sql
+++ b/sql/migrations/20230726131045_world.sql
@@ -1,0 +1,71 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230726131045');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230726131045');
+-- Add your query below.
+
+UPDATE `spell_threat` SET `Threat` = 126 WHERE `entry` = 21992; -- thunderfury single target
+UPDATE `spell_threat` SET `Threat` = 126 WHERE `entry` = 27648; -- thunderfury chain
+
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (676, 99, 1, 0, 0, 5875); -- Disarm
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (7384, 0, 0.75, 0, 0, 5875); -- Overpower
+
+UPDATE `spell_threat` SET `Threat` = 178 WHERE `entry` = 23922; -- Shield slam R1
+UPDATE `spell_threat` SET `Threat` = 203 WHERE `entry` = 23923; -- Shield slam R2
+UPDATE `spell_threat` SET `Threat` = 229 WHERE `entry` = 23924; -- Shield slam R3
+UPDATE `spell_threat` SET `Threat` = 254 WHERE `entry` = 23925; -- Shield slam R4
+
+DELETE FROM `spell_threat` WHERE `entry` = 72; -- Shield Bash
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (72, 36, 1.5, 0, 0, 5875); -- Shield Bash R1
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (1671, 96, 1.5, 0, 0, 5875); -- Shield Bash R2
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (1672, 156, 1.5, 0, 0, 5875); -- Shield Bash R3
+
+UPDATE `spell_threat` SET `Threat` = 63, `multiplier` = 2.25 WHERE `entry` = 6572; -- Revenge R1
+UPDATE `spell_threat` SET `Threat` = 108, `multiplier` = 2.25 WHERE `entry` = 6574; -- Revenge R2
+UPDATE `spell_threat` SET `Threat` = 153, `multiplier` = 2.25 WHERE `entry` = 7379; -- Revenge R3
+UPDATE `spell_threat` SET `Threat` = 198, `multiplier` = 2.25 WHERE `entry` = 11600; -- Revenge R4
+UPDATE `spell_threat` SET `Threat` = 243, `multiplier` = 2.25 WHERE `entry` = 11601; -- Revenge R5
+UPDATE `spell_threat` SET `Threat` = 270, `multiplier` = 2.25 WHERE `entry` = 25288; -- Revenge R6	
+
+UPDATE `spell_threat` SET `Threat` = 45 WHERE `entry` = 7386; -- Sunder Armor R1
+UPDATE `spell_threat` SET `Threat` = 99 WHERE `entry` = 7405; -- Sunder Armor R2
+UPDATE `spell_threat` SET `Threat` = 153 WHERE `entry` = 8380; -- Sunder Armor R3
+UPDATE `spell_threat` SET `Threat` = 207 WHERE `entry` = 11596; -- Sunder Armor R4
+UPDATE `spell_threat` SET `Threat` = 261 WHERE `entry` = 11597; -- Sunder Armor R5
+
+UPDATE `spell_threat` SET `Threat` = 1 WHERE `entry` = 6673; -- Battle Shout R1
+UPDATE `spell_threat` SET `Threat` = 12 WHERE `entry` = 5242; -- Battle Shout R2
+UPDATE `spell_threat` SET `Threat` = 22 WHERE `entry` = 6192; -- Battle Shout R3
+UPDATE `spell_threat` SET `Threat` = 32 WHERE `entry` = 11549; -- Battle Shout R4
+UPDATE `spell_threat` SET `Threat` = 42 WHERE `entry` = 11550; -- Battle Shout R5
+UPDATE `spell_threat` SET `Threat` = 52 WHERE `entry` = 11551; -- Battle Shout R6
+UPDATE `spell_threat` SET `Threat` = 60 WHERE `entry` = 25289; -- Battle Shout R7
+
+UPDATE `spell_threat` SET `Threat` = 11 WHERE `entry` = 1160; -- Demoralizing Shout R1
+UPDATE `spell_threat` SET `Threat` = 19 WHERE `entry` = 6190; -- Demoralizing Shout R2
+UPDATE `spell_threat` SET `Threat` = 27 WHERE `entry` = 11554; -- Demoralizing Shout R3
+UPDATE `spell_threat` SET `Threat` = 35 WHERE `entry` = 11555; -- Demoralizing Shout R4
+UPDATE `spell_threat` SET `Threat` = 43 WHERE `entry` = 11556; -- Demoralizing Shout R5
+
+UPDATE `spell_threat` SET `Threat` = 20, `multiplier` = 1.25 WHERE `entry` = 1715; -- Hamstring R1
+UPDATE `spell_threat` SET `Threat` = 80, `multiplier` = 1.25 WHERE `entry` = 7372; -- Hamstring R2
+UPDATE `spell_threat` SET `Threat` = 135, `multiplier` = 1.25 WHERE `entry` = 7373; -- Hamstring R3
+
+DELETE FROM `spell_threat` WHERE `entry` = 6343; -- Thunderclap R1
+DELETE FROM `spell_threat` WHERE `entry` = 8198; -- Thunderclap R2
+DELETE FROM `spell_threat` WHERE `entry` = 8204; -- Thunderclap R3
+DELETE FROM `spell_threat` WHERE `entry` = 8205; -- Thunderclap R4
+DELETE FROM `spell_threat` WHERE `entry` = 11580; -- Thunderclap R5
+DELETE FROM `spell_threat` WHERE `entry` = 11581; -- Thunderclap R6
+INSERT INTO `spell_threat` (`entry`, `Threat`, `multiplier`, `ap_bonus`, `build_min`, `build_max`) VALUES (6343, 0, 2.5, 0, 0, 5875); -- Thunder clap generic all ranks
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -3667,18 +3667,6 @@ void Aura::HandleAuraModDisarm(bool apply, bool Real)
     else
         target->ApplyModFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISARMED, apply);
 
-    // Warrior 'Disarm' skill generates 104 base threat
-    // http://wowwiki.wikia.com/wiki/Disarm?direction=prev&oldid=200198 (2006) implies it
-    // generates a large amount
-    // http://wowwiki.wikia.com/wiki/Threat has threat listed at 104, which is in line
-    // with the values of other warrior abilities
-    // We can suppose that the same is true for all spells which apply disarm
-    if (apply)
-    {
-        float threat = 104.0f * sSpellMgr.GetSpellThreatMultiplier(GetHolder()->GetSpellProto());
-        target->AddThreat(GetCaster(), threat, false, SPELL_SCHOOL_MASK_NONE, GetHolder()->GetSpellProto());
-    }
-
     // Don't update damage if in feral
     if (!target->IsNoWeaponShapeShift())
         target->UpdateDamagePhysical(BASE_ATTACK);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Small changes to threat of warrior abilities to match them with values from classic testing.

### Proof
<!-- Link resources as proof -->
- https://github.com/magey/classic-warrior/wiki/Threat-Mechanics#threat-values
- https://docs.google.com/spreadsheets/d/1VLmhdNX_hZcud8Q0n2I1fPv7y8g8BHYhH_cmIkmd_-s/edit#gid=1992655717
- https://docs.google.com/spreadsheets/d/1z_I0oU5IOmQA5RQX26xOvj3ycLRMTVoZapFLY7OG-8c/edit#gid=1414903181

From these I discovered that most warrior abilities have static threat which is just spell level * (static multiplier)
- The classic testers found that revenge R1 (lvl 14) did 63 static threat, R5 (lvl 54) did 243 static threat, and R6 (lvl 60) did 270
63/14 = 243/54 = 270/60 = 4.5 from that I filled in the remaining ranks
- The classic testers found that sunder armor R1 (lvl 10) did 45 static threat, R5 (lvl 58) did 261 static threat.
45/10 = 261/58 = 4.5 same as Revenge, from that I filled in the remaining ranks
- I repeated this process for Shield Bash (static multiplier = 3 )
- For Hamstring (static multiplier = 2.5)
- For Battle Shout (static multiplier = 1)
- For Demoralizing Shout (static multiplier = 0.8), 

Note: static multiplier is just a hidden constant to calculate how much static threat the ability does based on its spell level. It is different from the multiplier in spell_threat table which is for how much threat the ability will do based on its damage.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a warrior character, level up to 60
- `.add 6619` use it then `.learn all_trainer`
- teleport to a level 59-60 mob .go creature 41697
- test abilities and use `.list threat` to see how much threat they're generating
I tested all the abilities individually.
Made sure static threat is applied BEFORE the multiplier for Revenge and Shield Bash and Hamstring.
Made sure thunder clap has the bonus threat on all ranks.

Use bloodthirst or pummel on the mob, find that it lands normally because it's using default (level * 5) skill, not your current weapon skill as it should.
### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] Heroic Strike and Cleave data is missing for lower ranks. Doesn't appear to use the `"static threat = spell level * static multiplier"` rule of other abilities
- [X] Other classes, especially bear demoralizing roar.
