### PR TITLE
Remove ability that is unused in classic from Skeram script

### DIFF
--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
@@ -22,7 +22,6 @@ EndScriptData */
 #define FULFILLMENT_RANGE           90.0f
 #define SPELL_TF_HASTE              2313
 #define SPELL_TF_MOD_HEAL           26525
-#define SPELL_TF_IMMUNITY           26526
 #define SPELL_TF_CANCEL             26589
 
 #define SPELL_BLINK_0               4801
@@ -112,7 +111,6 @@ struct boss_skeramAI : public ScriptedAI
             FulfilledPlayer->RemoveAurasDueToSpellByCancel(SPELL_TRUE_FULFILLMENT);
             FulfilledPlayer->RemoveAurasDueToSpellByCancel(SPELL_TF_HASTE);
             FulfilledPlayer->RemoveAurasDueToSpellByCancel(SPELL_TF_MOD_HEAL);
-            FulfilledPlayer->RemoveAurasDueToSpellByCancel(SPELL_TF_IMMUNITY);
         }
     }
 
@@ -248,7 +246,6 @@ struct boss_skeramAI : public ScriptedAI
 
                     m_creature->CastSpell(target, SPELL_TF_HASTE, true);
                     m_creature->CastSpell(target, SPELL_TF_MOD_HEAL, true);
-                    m_creature->CastSpell(target, SPELL_TF_IMMUNITY, true);
 
                     FullFillment_Timer = urand(20500, 25000);
                     ControlledPlayerGUID = target->GetObjectGuid();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
True fulfillment has an added spell that makes the player immune to stuns, roots and snares. In classic this is an unused spell, not applied with the mind control, so removing it from here to match that.

### Proof
<!-- Link resources as proof -->
https://youtu.be/tZpkoxwS6ns?t=335
timestamp 5:35
look at the druid that gets mind controlled. He is affected by paladin stun and frost nova proving that Skeram didn't make him immune to either mechanic.
It doesn't exist in wowhead https://www.wowhead.com/classic/spell=26526
while [the](https://www.wowhead.com/classic/spell=785/true-fulfillment) [other](https://www.wowhead.com/classic/spell=2313/true-fulfillment) [ones](https://www.wowhead.com/classic/spell=26525/true-fulfillment) [exist](https://www.wowhead.com/classic/spell=26589/cancel-true-fulfillment)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- `.go creature 87571`
- kill trash leading to skeram
- spawn many partybots
- `.learn 10230` for frostnova
- `.learn 10308` for hammer of justice
- engage the boss, wait for it to use True Fulfillment
- use the abilities on the mind controlled partybot

![image](https://github.com/vmangos/core/assets/111737968/c5a9532d-03d4-4ce6-9eef-694e4773d3ed)


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] none