### PR TITLE
Warden door checks for 1.12.3

### DIFF
--- a/sql/migrations/20230813191030_world.sql
+++ b/sql/migrations/20230813191030_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230813191030');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230813191030');
+-- Add your query below.
+
+UPDATE `warden_scans` SET build_max = "6141" WHERE `id` IN (74, 75, 76, 77, 78);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20230813191030_world.sql
+++ b/sql/migrations/20230813191030_world.sql
@@ -8,7 +8,7 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20230813191030');
 -- Add your query below.
 
-UPDATE `warden_scans` SET build_max = "6141" WHERE `id` IN (74, 75, 76, 77, 78);
+UPDATE `warden_scans` SET `build_max` = 6141 WHERE `id` IN (74, 75, 76, 77, 78);
 
 -- End of migration.
 END IF;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR extends the build_max to 6141 for the warden door scans.

### Proof
<!-- Link resources as proof -->
I have logged returned hash values from a clean 1.12.3 client - and they match already stored values.
scan 74 - build: 6141 - returned: B4 45 2B 6D 95 C9 8B 18 6A 70 B0 08 FA 07 BB AE F3 0D F7 A2
scan 75 - build: 6141 - returned: 75 19 5E 4A ED A0 BC AF 04 8C A0 E3 4D 95 A7 0D 4F 53 C7 46
scan 76 - build: 6141 - returned: 3D FF 01 1B 9A B1 34 F3 7F 88 50 97 E6 95 35 1B 91 95 35 64
scan 77 - build: 6141 - returned: DB D4 F4 07 C4 68 CC 36 13 4E 62 1D 16 01 78 FD A4 D0 D2 49
scan 78 - build: 6141 - returned: 0D C8 DB 46 C8 55 49 C0 FF 1A 60 0F 6C 23 63 57 C3 05 78 1A
scan 97 - build: 6141 - returned: 2A 43 94 7C A9 1F 92 B6 69 8A 52 86 A7 B8 83 EF F9 67 D6 B4

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Use a 1.12.3 client - if you got the client from you know where it has a door patch.
- If warden triggers - delete the modifications; patch-3.mpq and patch-8.mpq

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
