### PR TITLE
Chromaggus adjustments and bug fixes

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6816,6 +6816,15 @@ SpellAuraHolder::SpellAuraHolder(SpellEntry const* spellproto, Unit* target, Uni
     m_makesTargetSecondaryFocus = !GetSpellProto()->IsPositiveSpell() && (GetSpellProto()->HasAuraInterruptFlag(AURA_INTERRUPT_DAMAGE_CANCELS)
                                                                     ||  m_spellProto->HasAura(SPELL_AURA_MOD_CONFUSE)
                                                                     ||  m_spellProto->HasAura(SPELL_AURA_MOD_FEAR));
+    //  Exception spells for targetsecondaryfocus:
+    switch (m_spellProto->Id)
+    {
+        case 23310:                                         // Chromaggus Time Lapse
+        case 23312:                                         // Chromaggus Time Lapse
+            m_makesTargetSecondaryFocus = true;
+            break;
+        
+    }
 }
 
 void SpellAuraHolder::AddAura(Aura* aura, SpellEffectIndex index)

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_chromaggus.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_chromaggus.cpp
@@ -320,7 +320,7 @@ struct boss_chromaggusAI : public ScriptedAI
                     break;
             }
 
-            for (int i = 0; i < 15; ++i) // Affliction is applied 15 times per cast. Creatures such as pets can be targetted
+            for (int i = 0; i < urand(11, 15); ++i) // Affliction is applied 11-15 times per cast. Creatures such as pets can be targetted
             {
                 if (Unit* afflictionTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
                 {

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_chromaggus.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_chromaggus.cpp
@@ -62,14 +62,6 @@ enum
 
 static uint32 const aPossibleBreaths[MAX_BREATHS] = {SPELL_INCINERATE, SPELL_TIME_LAPSE, SPELL_CORROSIVE_ACID, SPELL_IGNITE_FLESH, SPELL_FROST_BURN};
 
-struct TimeLapseInfo
-{
-    TimeLapseInfo(ObjectGuid const targetGuid, float const targetThreat, uint32 const targetHealth) : m_targetGuid(targetGuid), m_targetThreat(targetThreat), m_targetHealth(targetHealth) { }
-    ObjectGuid const m_targetGuid;
-    float const m_targetThreat;
-    uint32 const m_targetHealth;
-};
-
 struct boss_chromaggusAI : public ScriptedAI
 {
     boss_chromaggusAI(Creature* pCreature) : ScriptedAI(pCreature), m_uiBreathOneSpell(0), m_uiBreathTwoSpell(0)
@@ -110,7 +102,6 @@ struct boss_chromaggusAI : public ScriptedAI
     bool m_bEnraged;
     bool m_bEngagedOnce;
 
-    std::vector<TimeLapseInfo*> m_vTimeLapseInfo;
     typedef std::vector<ObjectGuid> AfflictionGuids;
     AfflictionGuids m_lRedAfflictionPlayerGUID;
     AfflictionGuids m_lChromaticPlayerGUID;
@@ -121,11 +112,11 @@ struct boss_chromaggusAI : public ScriptedAI
 
         m_uiCurrentVulnerabilitySpell = 0;                  // We use this to store our last vulnerability spell so we can remove it later
 
-        m_uiShimmerTimer    = 0;                            // Time till we change vurlnerabilites
-        m_uiBreathOneTimer  = 30000;                        // First breath is 30 seconds
-        m_uiBreathTwoTimer  = 60000;                        // Second is 1 minute so that we can alternate
-        m_uiAfflictionTimer = 4000;                        // This is special - 5 seconds means that we cast this on 1 pPlayer every 5 sconds
-        m_uiFrenzyTimer     = 15000;
+        m_uiShimmerTimer    = 0;        // Vulnurability is applied at pull. Changes every 20 secs.
+        m_uiBreathOneTimer  = 30000;    // First breath happens in 30 secs. Repeats every 60 secs.
+        m_uiBreathTwoTimer  = 60000;    // Second breath happens in 60 secs. Repeats every 60 secs.
+        m_uiAfflictionTimer = 7500;     // Afflictions are applied every 7.5 secs.
+        m_uiFrenzyTimer     = 15000;    // Frenzy happens every 15 secs.
 
         m_bEnraged          = false;
         m_lRedAfflictionPlayerGUID.clear();
@@ -148,10 +139,6 @@ struct boss_chromaggusAI : public ScriptedAI
             else
                 m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_SPAWNING | UNIT_FLAG_IMMUNE_TO_NPC);
         }
-
-        for (const auto& itr : m_vTimeLapseInfo)
-            delete itr;
-        m_vTimeLapseInfo.clear();
     }
 
     void MoveInLineOfSight(Unit *pUnit) override
@@ -177,9 +164,6 @@ struct boss_chromaggusAI : public ScriptedAI
     {
         if (m_pInstance)
             m_pInstance->SetData(TYPE_CHROMAGGUS, DONE);
-        for (const auto& itr : m_vTimeLapseInfo)
-            delete itr;
-        m_vTimeLapseInfo.clear();
     }
 
     void JustReachedHome() override
@@ -193,14 +177,13 @@ struct boss_chromaggusAI : public ScriptedAI
         if (!pTarget)
             return;
 
+        /* Better to do this in SpellAuras.cpp
         if (pSpell->Id == SPELL_TIME_LAPSE)
         {
             if (SpellAuraHolder* holder = pTarget->GetSpellAuraHolder(SPELL_TIME_LAPSE))
                 holder->SetTargetSecondaryThreatFocus(true);
-            if (pTarget->GetTypeId() != TYPEID_PLAYER)
-                return;
-            m_vTimeLapseInfo.push_back(new TimeLapseInfo(pTarget->GetObjectGuid(), m_creature->GetThreatManager().getThreat(pTarget), pTarget->GetHealth()));
         }
+        */
     }
 
     void MovementInform(uint32 uiType, uint32 uiPointId) override
@@ -255,20 +238,6 @@ struct boss_chromaggusAI : public ScriptedAI
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
             return;
 
-        for (std::vector<TimeLapseInfo*>::iterator itr = m_vTimeLapseInfo.begin(); itr != m_vTimeLapseInfo.end(); ++itr)
-            if (Player* pTarget = m_creature->GetMap()->GetPlayer((*itr)->m_targetGuid))
-            {
-                if (!pTarget->HasAura(SPELL_TIME_LAPSE) && pTarget->IsAlive())
-                {
-                    if ((*itr)->m_targetHealth >= (pTarget->GetMaxHealth() / 2))
-                        pTarget->SetHealth(pTarget->GetMaxHealth());
-                    delete *itr;
-                    m_vTimeLapseInfo.erase(itr--);
-                }
-            }
-            else
-                m_vTimeLapseInfo.erase(itr--);
-
         // Shimmer Timer Timer
         if (m_uiShimmerTimer < uiDiff)
         {
@@ -302,7 +271,7 @@ struct boss_chromaggusAI : public ScriptedAI
                 m_uiCurrentVulnerabilitySpell = uiSpell;
 
                 DoScriptText(EMOTE_SHIMMER, m_creature);
-                m_uiShimmerTimer = 45000;
+                m_uiShimmerTimer = 20000;
             }
         }
         else
@@ -351,56 +320,51 @@ struct boss_chromaggusAI : public ScriptedAI
                     break;
             }
 
-            std::vector<ObjectGuid> m_vPossibleVictim;
-            ThreatList const& tList = m_creature->GetThreatManager().getThreatList();
-            for (const auto itr : tList)
-                if (Player* target = m_creature->GetMap()->GetPlayer(itr->getUnitGuid()))
-                    m_vPossibleVictim.push_back(target->GetObjectGuid());
-
-            int affli_rand = urand(0, 18);
-            for (int i = 0; i < affli_rand; ++i)
+            for (int i = 0; i < 15; ++i) // Affliction is applied 15 times per cast. Creatures such as pets can be targetted
             {
-                if (m_vPossibleVictim.empty())
-                    break;
-                std::vector<ObjectGuid>::iterator it = m_vPossibleVictim.begin() + urand(0, m_vPossibleVictim.size() - 1);
-                if (Player* pPlayer = m_creature->GetMap()->GetPlayer(*it))
+                if (Unit* afflictionTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
                 {
+                    if (afflictionTarget->HasAura(SPELL_CHROMATIC_MUT_1)) // To make sure mutated players are not being targeted with affliction.
+                        continue;
+
                     // Cast affliction
-                    if (DoCastSpellIfCan(pPlayer, m_uiSpellAfflict, CF_TRIGGERED) == CAST_OK)
+                    if (DoCastSpellIfCan(afflictionTarget, m_uiSpellAfflict, CF_TRIGGERED) == CAST_OK)
                     {
-                        if (m_uiSpellAfflict == SPELL_BROODAF_RED)
-                            m_lRedAfflictionPlayerGUID.push_back(pPlayer->GetObjectGuid());
+                        if (m_uiSpellAfflict == SPELL_BROODAF_RED && afflictionTarget->GetTypeId() == TYPEID_PLAYER)
+                            m_lRedAfflictionPlayerGUID.push_back(afflictionTarget->GetObjectGuid());
                     }
                     // Chromatic mutation if target is effected by all afflictions
-                    if (pPlayer->HasAura(SPELL_BROODAF_BLUE)
-                            && pPlayer->HasAura(SPELL_BROODAF_BLACK)
-                            && pPlayer->HasAura(SPELL_BROODAF_RED)
-                            && pPlayer->HasAura(SPELL_BROODAF_BRONZE)
-                            && pPlayer->HasAura(SPELL_BROODAF_GREEN))
+                    if (afflictionTarget->HasAura(SPELL_BROODAF_BLUE)
+                            && afflictionTarget->HasAura(SPELL_BROODAF_BLACK)
+                            && afflictionTarget->HasAura(SPELL_BROODAF_RED)
+                            && afflictionTarget->HasAura(SPELL_BROODAF_BRONZE)
+                            && afflictionTarget->HasAura(SPELL_BROODAF_GREEN))
                     {
-                        pPlayer->RemoveAurasDueToSpell(SPELL_BROODAF_BLUE);
-                        pPlayer->RemoveAurasDueToSpell(SPELL_BROODAF_BLACK);
-                        pPlayer->RemoveAurasDueToSpell(SPELL_BROODAF_RED);
-                        pPlayer->RemoveAurasDueToSpell(SPELL_BROODAF_BRONZE);
-                        pPlayer->RemoveAurasDueToSpell(SPELL_BROODAF_GREEN);
+                        afflictionTarget->RemoveAurasDueToSpell(SPELL_BROODAF_BLUE);
+                        afflictionTarget->RemoveAurasDueToSpell(SPELL_BROODAF_BLACK);
+                        afflictionTarget->RemoveAurasDueToSpell(SPELL_BROODAF_RED);
+                        afflictionTarget->RemoveAurasDueToSpell(SPELL_BROODAF_BRONZE);
+                        afflictionTarget->RemoveAurasDueToSpell(SPELL_BROODAF_GREEN);
 
-                        if (DoCastSpellIfCan(pPlayer, SPELL_CHROMATIC_MUT_1) == CAST_OK)
+                        if (afflictionTarget->GetTypeId() == TYPEID_PLAYER) // Only players are mutated
                         {
-                            // More Chromatic Mutation buffs
-                            pPlayer->AddAura(23175); //Mod DMG 500% + Mod Haste Melee 100 + Mod Haste Spell 300
-                            pPlayer->AddAura(23177); //Max Health 10000 + Mod healing 1000%
-                            m_lChromaticPlayerGUID.push_back(pPlayer->GetObjectGuid());
+                                afflictionTarget->AddAura(SPELL_CHROMATIC_MUT_1, ADD_AURA_NO_OPTION, m_creature); // Main MC aura
+                                afflictionTarget->AddAura(23175); // Mod DMG 500% + Mod Haste Melee 100 + Mod Haste Spell 300
+                                afflictionTarget->AddAura(23177); // Max Health 10000 + Mod healing 1000%
+                                m_lChromaticPlayerGUID.push_back(afflictionTarget->GetObjectGuid());
                         }
+                        else    // Pets die instantly
+                            afflictionTarget->DealDamage(afflictionTarget, afflictionTarget->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
+
                     }
                 }
-                m_vPossibleVictim.erase(it);
             }
-            m_uiAfflictionTimer = 4000;
+            m_uiAfflictionTimer = 7500;
         }
         else
             m_uiAfflictionTimer -= uiDiff;
 
-        // If player dies from a direct hit or dot while he had the aura SPELL_BROODAF_RED
+        // If player dies while he had the aura SPELL_BROODAF_RED
         for (AfflictionGuids::iterator itr = m_lRedAfflictionPlayerGUID.begin(); itr != m_lRedAfflictionPlayerGUID.end();)
         {
             Player* pTarget = m_creature->GetMap()->GetPlayer(*itr);
@@ -419,7 +383,7 @@ struct boss_chromaggusAI : public ScriptedAI
             ++itr;
         }
 
-        // If player dies from a direct hit or dot while he had the aura SPELL_CHROMATIC_MUT_1
+        // If player dies while he had the aura SPELL_CHROMATIC_MUT_1
         for (AfflictionGuids::iterator itr = m_lChromaticPlayerGUID.begin(); itr != m_lChromaticPlayerGUID.end();)
         {
             if (Player* pTarget = m_creature->GetMap()->GetPlayer(*itr))


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Adjust ability timers Shimmer to 20 secs, Brood Affliction to 7.5 secs
Change application behavior to attempt cast at a random unit 11 to 15 times. Can target pets. Can target same unit multiple times in one brood affliction "wave". This means very very rarely you can get a wave that targets one player 15 times and casts affliction on him 15 times. If it's the red one, he'll get 15 stacks in one wave.

Removed pointless code to change health at time lapse fade out. Correct behavior is to change your max and current hp without changing %hp

Hopefully fixed bug that was making players sometimes lose 5 afflictions but not get Mind Controlled.

### Proof
<!-- Link resources as proof -->
https://vanilla.warcraftlogs.com/reports/tJaxX3PVzmcHwynC#fight=33&type=auras&spells=debuffs&view=events&target=135
In here you can see the application of brood affliction debuffs. 11 to 15 per wave. Some of the applications are refreshes for units that were already targeted before by the same wave.

Creature_spell_timers of the largest parse database:
id [22276](https://github.com/vmangos/core/assets/111737968/6ae8d535-c606-4482-8146-7cd069f4a7e1) initial delay 20000ms, repeat 20000ms. This is blizzard's spell for implementing the shimmer swap. Vmangos codes it in the script file instead of using a dummy spell.

id [23173](https://github.com/vmangos/core/assets/111737968/2b95b16e-2359-42c9-b844-161364815f6e) Blizzard's spell for implementing brood affliction.

[Proof that it can target pets](https://github.com/vmangos/core/assets/111737968/2331f595-b649-451b-a8cc-fba229d46619)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- `.go creature 84648`
- [This video](https://www.youtube.com/watch?v=6G0y8mgb0Q8) showcases affliction on pet, duplicate application per wave (10 stacks of red are applied on the player), pet instantly dies at 5 afflictions, time lapse temporary threat drop.
Note this video was recorded with [this fix](https://github.com/vmangos/core/pull/2170) implemented. Without it, the succubus doesn't enter combat on its own, it has to auto chromaggus but once that's done the remaining behavior is the exact same.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
