### PR TITLE
Invisible auras should be sent to client and take an aura slot.

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -7171,7 +7171,7 @@ bool SpellAuraHolder::IsNeedSlot(Unit const* caster) const
 
     // passive auras (except totem auras and auras with a visual effect) do not get sent to client
     // passive auras are defined as either auras with SPELL_ATTR_PASSIVE or auras with SPELL_ATTR_DO_NOT_DISPLAY and DurationIndex == 21
-    return !m_isPassive || totemAura || m_spellProto->SpellVisual;
+    return !m_isPassive || totemAura || (m_spellProto->SpellVisual && m_spellProto->SpellIconID != 1);
 }
 
 void SpellAuraHolder::HandleSpellSpecificBoosts(bool apply)

--- a/src/game/Spells/SpellAuras.h
+++ b/src/game/Spells/SpellAuras.h
@@ -148,7 +148,7 @@ class SpellAuraHolder
         bool IsPositive() const;
         bool IsAreaAura() const;                            // if one from auras of holder applied as area aura
         bool IsWeaponBuffCoexistableWith(SpellAuraHolder const* ref) const;
-        bool IsNeedVisibleSlot(Unit const* caster) const;
+        bool IsNeedSlot(Unit const* caster) const;
         bool IsRemovedOnShapeLost() const { return m_isRemovedOnShapeLost; }
         bool IsInUse() const { return m_in_use;}
         bool IsDeleted() const { return m_deleted;}


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Persistent auras should be sent to client and take an aura slot no matter if their effect is exclusive damage or not.


In addition
```
case SPELL_EFFECT_APPLY_AREA_AURA_PET:
            case SPELL_EFFECT_APPLY_AREA_AURA_PARTY:
                // passive auras (except totem auras) do not get placed in caster slot
                return (m_target != caster || totemAura || !m_isPassive) && m_auras[i]->GetModifier()->m_auraname != SPELL_AURA_NONE;
```
The aforementioned appears entirely redundant, vanilla has no passive [area](https://www.wowhead.com/classic/spells?filter=50:109;1:35;0:0) auras or [pet](https://www.wowhead.com/classic/spells?filter=50:109;1:119;0:0) auras that warrant exclusion from buff cap.
### Proof
<!-- Link resources as proof -->
[Classic data about debuff priorities](https://www.dropbox.com/sh/fjp9112731g7870/AACQOTjtk9wcOU0gFA4553yKa?dl=0&preview=replacement_totals.csv). In the bottom you can find consecration, volley, blizzard, rain of fire. Confirming that they take a debuff slot and can push away existing debuffs.

[Youtube video timestamp 45:11](https://youtu.be/UwVNpHaFhUI?si=8TtPFAYF3qbJZLKR&t=2711) look at the rain of fire visual effect on the player, and the debuff applying on his scrolling combat text.

[Grainy video, but a source from 2005 vanilla.](https://youtu.be/HfvHFo7wEVk?si=cBqLsIDqQ23FkOXJ&t=4819)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->

https://github.com/vmangos/core/assets/111737968/641b6eb5-a68c-403a-8943-ca3da5123504



### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
