### PR TITLE
Fix grammar mistake in Hallowed Scroll item text.

### DIFF
--- a/sql/migrations/20230825224123_world.sql
+++ b/sql/migrations/20230825224123_world.sql
@@ -9,7 +9,7 @@ INSERT INTO `migrations` VALUES ('20230825224123');
 -- Add your query below.
 
 -- Fix grammar mistake in "Hallowed Scroll" item text.
-UPDATE `page_text` SET `text` = 'Feel blessed that your spirit was not released to the Nether, $N. Feel even more blessed that I decided you were worth the effort to write this scroll for.$B$BThe people you once knew, perhaps even cared for, are no longer! You must learn to "live" with that for the rest of your now unnatural life. I suggest you learn to deal with that first.$B$BIf you think you\'re ready for the trials ahead, then seek me out in the church in Deathknell.$B$B- Dark Cleric Duesten, Priest Trainer' WHERE `entry` = 2467;
+UPDATE `page_text` SET `text` = 'Feel blessed that your spirit was not released to the Nether, $N. Feel even more blessed that I decided you were worth the effort to write this scroll for.$B$BThe people you once knew, perhaps even cared for, are no longer! You must learn to \"live\" with that for the rest of your now unnatural life. I suggest you learn to deal with that first.$B$BIf you think you\'re ready for the trials ahead, then seek me out in the church in Deathknell.$B$B- Dark Cleric Duesten, Priest Trainer' WHERE `entry`=2467;
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20230825224123_world.sql
+++ b/sql/migrations/20230825224123_world.sql
@@ -1,0 +1,19 @@
+-e DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230825224123');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230825224123');
+-- Add your query below.
+
+-- Fix grammar mistake in "Hallowed Scroll" item text.
+UPDATE `page_text` SET `text` = 'Feel blessed that your spirit was not released to the Nether, $N. Feel even more blessed that I decided you were worth the effort to write this scroll for.$B$BThe people you once knew, perhaps even cared for, are no longer! You must learn to "live" with that for the rest of your now unnatural life. I suggest you learn to deal with that first.$B$BIf you think you\'re ready for the trials ahead, then seek me out in the church in Deathknell.$B$B- Dark Cleric Duesten, Priest Trainer' WHERE `entry` = 2467;
+
+-- End of migration.
+END IF;
+END??
+delimiter ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

This fixes a grammar mistake in the "Hallowed Scroll" item text. In the current text it wrongly says "Feel blessed that __you're__ spirit [...]" instead of "Feel blessed that __your__ spirit [...]" as it should.

### Proof
<!-- Link resources as proof -->
- See https://github.com/TrinityCore/TrinityCore/issues/26026.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Start an undead priest character and go to the church in Deathknell.
- Accept the first quest from https://www.wowhead.com/npc=1569/shadow-priest-sarvis.
- Run `.quest complete 364`.
- Accept the quest "Hallowed Scroll" from the same NPC.
- Read the text of the received "Hallowed Scroll" item and note the fixed mistake in the first sentence.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
