### PR TITLE
Fix gossip menu options for client version 1.5

### DIFF
--- a/src/game/GossipDef.cpp
+++ b/src/game/GossipDef.cpp
@@ -163,7 +163,7 @@ void PlayerMenu::SendGossipMenu(uint32 textId, ObjectGuid objectGuid)
 
     constexpr size_t gossipPartSize =
         sizeof(uint32) + // index
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_5_1
         sizeof(uint8) + // icon
         sizeof(uint8) + // coded
 #else
@@ -186,7 +186,7 @@ void PlayerMenu::SendGossipMenu(uint32 textId, ObjectGuid objectGuid)
     {
         GossipMenuItem const& gItem = mGossipMenu.GetItem(iI);
         data << uint32(iI);
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_5_1
         data << uint8(gItem.m_gIcon);
         data << uint8(gItem.m_gCoded);                      // makes pop up box password
 #else

--- a/src/game/GossipDef.cpp
+++ b/src/game/GossipDef.cpp
@@ -163,8 +163,12 @@ void PlayerMenu::SendGossipMenu(uint32 textId, ObjectGuid objectGuid)
 
     constexpr size_t gossipPartSize =
         sizeof(uint32) + // index
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
         sizeof(uint8) + // icon
         sizeof(uint8) + // coded
+#else
+        sizeof(uint32) + // icon
+#endif
         128; // message (average)
 
     constexpr size_t questPartSize =
@@ -182,8 +186,12 @@ void PlayerMenu::SendGossipMenu(uint32 textId, ObjectGuid objectGuid)
     {
         GossipMenuItem const& gItem = mGossipMenu.GetItem(iI);
         data << uint32(iI);
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
         data << uint8(gItem.m_gIcon);
         data << uint8(gItem.m_gCoded);                      // makes pop up box password
+#else
+        data << uint32(gItem.m_gIcon);
+#endif
         data << gItem.m_gMessage;                           // text for gossip item, max 0x800
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Decompiled 1.5 client code shows that...
1. The icon is read as a 32-bit integer instead of 8-bit.
2. The "coded" field is not read at all, indicating that that field was added in patch 1.6. This lines up with the Blue Murloc Egg being likely the first item obtainable by gossip-code in late 2005.

### Proof
<!-- Link resources as proof -->
- Decompiled client code.
- Gossip menus now work on the 1.5 client.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Opening a gossip menu containing options crashes the client.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None