### PR TITLE
[wip][needs testing] sort tris by z before rasterize

### DIFF
--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -762,7 +762,7 @@ namespace MMAP
                     }
                 }
                 /// 4. Every triangle is correctly marked now, we can rasterize everything
-                rcRasterizeTriangles(m_rcContext, tVerts, tVertCount, tTris, areas, tTriCount, *tile.solid, 0);
+                SortAndRasterizeTriangles(m_rcContext, tVerts, tVertCount, tTris, areas, tTriCount, *tile.solid, 0);
                 delete [] areas;
 
                 /// 5. Don't walk over too high Obstacles.

--- a/dep/recastnavigation/Recast/Include/Recast.h
+++ b/dep/recastnavigation/Recast/Include/Recast.h
@@ -873,6 +873,22 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
 						  const int* tris, const unsigned char* areas, const int nt,
 						  rcHeightfield& solid, const int flagMergeThr = 1);
 
+/// Rasterizes and sort an indexed triangle mesh into the specified heightfield.
+///  @ingroup recast
+///  @param[in,out]	ctx				The build context to use during the operation.
+///  @param[in]		verts			The vertices. [(x, y, z) * @p nv]
+///  @param[in]		nv				The number of vertices.
+///  @param[in]		tris			The triangle indices. [(vertA, vertB, vertC) * @p nt]
+///  @param[in]		areas			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+///  @param[in]		nt				The number of triangles.
+///  @param[in,out]	solid			An initialized heightfield.
+///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag. 
+///  								[Limit: >= 0] [Units: vx]
+///  @returns True if the operation completed successfully.
+bool SortAndRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
+	const int* tris, const unsigned char* areas, const int nt,
+	rcHeightfield& solid, const int flagMergeThr = 1);
+
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
 ///  @ingroup recast
 ///  @param[in,out]	ctx			The build context to use during the operation.

--- a/dep/recastnavigation/Recast/Source/RecastRasterization.cpp
+++ b/dep/recastnavigation/Recast/Source/RecastRasterization.cpp
@@ -455,7 +455,7 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const unsigned cha
 }
 
 // Following code is not part of the standard recast library - and used by vmangos movemapgen
-// See PR #### for more details
+// See PR 2197 for more details
 
 struct Face {
 	int indices[3];

--- a/dep/recastnavigation/Recast/Source/RecastRasterization.cpp
+++ b/dep/recastnavigation/Recast/Source/RecastRasterization.cpp
@@ -22,6 +22,7 @@
 #include "Recast.h"
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
+#include <algorithm>
 
 inline bool overlapBounds(const float* amin, const float* amax, const float* bmin, const float* bmax)
 {
@@ -442,6 +443,69 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const unsigned cha
 		const float* v0 = &verts[(i*3+0)*3];
 		const float* v1 = &verts[(i*3+1)*3];
 		const float* v2 = &verts[(i*3+2)*3];
+		// Rasterize.
+		if (!rasterizeTri(v0, v1, v2, areas[i], solid, solid.bmin, solid.bmax, solid.cs, ics, ich, flagMergeThr))
+		{
+			ctx->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+// Following code is not part of the standard recast library - and used by vmangos movemapgen
+// See PR #### for more details
+
+struct Face {
+	int indices[3];
+};
+
+struct CompareFaces {
+	CompareFaces(const Face* faces, const float* verts) : faces_(faces), verts_(verts) {}
+	bool operator()(int a, int b) const {
+		return Z(faces_[a]) > Z(faces_[b]);
+	}
+private:
+	float Z(const Face& face) const {
+		return verts_[3 * face.indices[0] + 1];
+	}
+	const Face* faces_;
+	const float* verts_;
+};
+
+/// @par
+///
+/// This is copy of rcRasterizeTriangles - but also sorts triangles before they are processed.  
+/// 
+/// Spans will only be added for triangles that overlap the heightfield grid.
+///
+/// @see rcHeightfield
+bool SortAndRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
+	const int* tris, const unsigned char* areas, const int nt,
+	rcHeightfield& solid, const int flagMergeThr)
+{
+	rcAssert(ctx);
+
+	rcTempVector<int> indices;
+	indices.resize(nt);
+	for (int i = 0; i < nt; i++) {
+		indices[i] = i;
+	}
+	std::sort(indices.begin(), indices.end(), CompareFaces((const Face*)tris, verts));
+
+	rcScopedTimer timer(ctx, RC_TIMER_RASTERIZE_TRIANGLES);
+
+	float const ics = 1.0f / solid.cs;
+	float const ich = 1.0f / solid.ch;
+	// Rasterize triangles.
+	for (int j = 0; j < nt; ++j)
+	{
+		int const i = indices[j];
+		const float* v0 = &verts[tris[i * 3 + 0] * 3];
+		const float* v1 = &verts[tris[i * 3 + 1] * 3];
+		const float* v2 = &verts[tris[i * 3 + 2] * 3];
+
 		// Rasterize.
 		if (!rasterizeTri(v0, v1, v2, areas[i], solid, solid.bmin, solid.bmax, solid.cs, ics, ich, flagMergeThr))
 		{


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Further description to come. Posting this as a work in progress - and also needs further testing.

How triangles are sorted before rasterization matters greatly for the outcome of spans. This PR sorts tris based on their Z from top to bottom. The effect is mostly seen on stairs and similar parts of the mesh.

Example the Cathedral in tyrs hand:
![image](https://github.com/vmangos/core/assets/2223066/51f70746-e4cb-4265-ba48-3649a2fd4aa8)


Building in Feathermoon Stronghold:
![image](https://github.com/vmangos/core/assets/2223066/6efb0f18-909d-4987-8b6a-f5f7b9637eeb)

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
