### PR TITLE
Add missing spaces to translations in mangos_string

### DIFF
--- a/sql/migrations/20230921171542_world.sql
+++ b/sql/migrations/20230921171542_world.sql
@@ -1,0 +1,26 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20230921171542');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20230921171542');
+
+UPDATE `mangos_string` SET 
+	`content_loc1` = CONCAT( `content_loc1` , ' '),
+	`content_loc2` = CONCAT( `content_loc2` , ' '),
+	`content_loc3` = CONCAT( `content_loc3` , ' '),
+	`content_loc4` = CONCAT( `content_loc4` , ' '),
+	`content_loc6` = CONCAT( `content_loc6` , ' '),
+	`content_loc8` = CONCAT( `content_loc8` , ' ')
+WHERE `entry` IN (30, 45, 61, 62, 100, 206, 439, 441, 514, 515, 516, 518, 519, 520, 581, 1137, 1400, 1401, 1402, 1403, 1404, 1405, 
+	1406, 1407, 1408, 1409, 1410, 1411, 1412, 1413, 1414, 1415, 1416, 1417, 1418, 1419, 1420, 1421, 1422, 1423, 1424, 1425, 1426, 
+	1427, 1428, 1429, 1430, 1431, 1432, 1433, 2003, 2004, 2017, 2018, 2019, 2020, 2021, 2025, 2030, 618, 1176);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Several strings in mangos_string end with a space for formatting reasons. 61 rows are missing that space in all translations.


### Proof
<!-- Link resources as proof -->
![image](https://github.com/vmangos/core/assets/2223066/1ce3b4b3-14b1-485f-ba05-252b8ae82179)

SELECT *  FROM mangos_string where content_default LIKE "% " AND content_loc4  NOT LIKE "% "

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
