### PR TITLE
Fix raid group set assistant leader pre 1.12

### DIFF
--- a/src/game/Handlers/GroupHandler.cpp
+++ b/src/game/Handlers/GroupHandler.cpp
@@ -575,7 +575,12 @@ void WorldSession::HandleGroupAssistantLeaderOpcode(WorldPacket& recv_data)
 {
     ObjectGuid guid;
     uint8 flag;
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_11_2
     recv_data >> guid;
+#else
+    std::string name;
+    recv_data >> name;
+#endif
     recv_data >> flag;
 
     Group* group = GetPlayer()->GetGroup();
@@ -586,6 +591,13 @@ void WorldSession::HandleGroupAssistantLeaderOpcode(WorldPacket& recv_data)
     if (!group->IsLeader(GetPlayer()->GetObjectGuid()))
         return;
     /********************/
+
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_11_2
+    if (Player* player = sObjectMgr.GetPlayer(name.c_str()))
+        guid = player->GetObjectGuid();
+    else
+        return;
+#endif
 
     // everything is fine, do it
     group->SetAssistant(guid, (flag != 0));


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Clients send player name instead of guid.
Tested on 1.11 and 1.12

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Make a raid group and promote/demote someone to assistant.
- Check /script PromoteToAssistant("name") works and is case insensitive.
- Check /script DemoteAssistant("name") works and is case insensitive.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
