### PR TITLE
Flightmasters at Valors Rest in Silithus 1.2 -> 1.3

### DIFF
--- a/sql/migrations/20231001202124_world.sql
+++ b/sql/migrations/20231001202124_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20231001202124');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20231001202124');
+-- Add your query below.
+
+-- Flightmasters at Valors Rest in Silithus was added in 1.3
+UPDATE `creature` SET `patch_min`=1 WHERE  `guid`=14;
+UPDATE `creature` SET `patch_min`=1 WHERE  `guid`=18;
+UPDATE `creature_template` SET `patch`=1 WHERE  `entry`=1233 AND `patch`=0;
+UPDATE `creature_template` SET `patch`=1 WHERE  `entry`=14242 AND `patch`=0;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changes the flightmasters to not spawn until patch 1.3 instead of patch 1.2

### Proof
<!-- Link resources as proof -->
I don't believe the two flightmasters existed in patch 1.2

The Display_ids for both NPCs didn't exist in the client until 1.3.0.4284 

Valors rest wasn't added in taxinodes.dbc until 1.3.0.4284 

Reference to fligthpath from Gadgetzan to Valors Rest (doesn't prove anything, just for reference):
https://wowpedia.fandom.com/wiki/Patch_1.3.0#Flight_Paths

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
