### PR TITLE
Remove druid's Rip AP scaling pre 1.12

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4532,6 +4532,7 @@ float Aura::CalculateDotDamage() const
     {
         case SPELLFAMILY_DRUID:
         {
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_11_2
             // Rip
             if (spellProto->IsFitToFamilyMask<CF_DRUID_RIP_BITE>())
             {
@@ -4544,6 +4545,7 @@ float Aura::CalculateDotDamage() const
                     damage += caster->GetTotalAttackPowerValue(BASE_ATTACK) * cp / 100;
                 }
             }
+#endif
             break;
         }
         case SPELLFAMILY_ROGUE:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Feral druid Rip did not scale with AP before 1.12. Missing from official patch notes.

Tested 1.11 and 1.12.

### Proof
<!-- Link resources as proof -->
https://wowpedia.fandom.com/wiki/Rip
patch notes at the bottom for 1.12:
- Attack Power is now factored in for Rip, at a rate of 6% AP per combo point from 1 to 4 combo points, and then 24% AP again for 5 combo points.

Additionally, Rip (Rank 6) description in DBCs in 5875:
Finishing move that causes damage over time. Damage increases per combo point and by your Attack Power: 1 point : 270 damage over $d. 2 points: 438 damage over $d. 3 points: 606 damage over $d. 4 points: 774 damage over $d. 5 points: 942 damage over $d.

And in 5464:
Finishing move that causes damage over time. Damage increases per combo point: 1 point : 300 damage over $d. 2 points: 498 damage over $d. 3 points: 696 damage over $d. 4 points: 894 damage over $d. 5 points: 1092 damage over $d.

And EffectPointsPerCombo was decreased in 1.12 from 33 to 28.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- on 1.11 use rip, note damage
- .mod ap 10000 and check damage remains the same
- on 1.12 damage will go up

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
