### PR TITLE
Druid talent Furor did not work with Cat Form in 1.11.2

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2597,6 +2597,9 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
             switch (form)
             {
                 case FORM_CAT:
+#if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_11_2
+                    break;
+#endif
                 case FORM_BEAR:
                 case FORM_DIREBEAR:
                 {

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2598,6 +2598,8 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
             {
                 case FORM_CAT:
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_11_2
+                    // World of Warcraft Client Patch 1.12.0 (2006-08-22)
+                    // - Furor: This talent now works correctly with Cat Form again.
                     break;
 #endif
                 case FORM_BEAR:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Furor didn't grant energy to cats in 1.11.2.

Most likely broken in 1.11.2 only after this change:
- Fixed an issue where players with the Furor talent were not staying in combat mode when shifting to bear form and were losing the extra rage generated.

### Proof
<!-- Link resources as proof -->
- https://wowpedia.fandom.com/wiki/Patch_1.12.0
- Furor - This talent now works correctly with Cat Form again.
- https://thedruidsgrove.org/archive/wow/t-10826.html

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- On 1.11.2 grab Furor and shift to cat, shouldn't give any energy. Bear should get 10 rage.
- On any other version both get resources.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
