### PR TITLE
Fix affect masks for the rest of Rogue talents pre 1.12

### DIFF
--- a/sql/migrations/20231022153238_world.sql
+++ b/sql/migrations/20231022153238_world.sql
@@ -1,0 +1,25 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20231022153238');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20231022153238');
+-- Add your query below.
+
+-- Improved Evasion/Endurance
+UPDATE `spell_affect` SET `build_min`='5875' WHERE `entry` IN (13742, 13872) AND `effectId`=0;
+
+-- Elusiveness
+UPDATE `spell_affect` SET `build_min`='5875' WHERE `entry` IN (13981, 14066, 14067) AND `effectId`=0;
+
+-- Improved Cheap Shot/Dirty Deeds
+UPDATE `spell_affect` SET `build_min`='5875' WHERE `entry` IN (14082, 14083) AND `effectId`=0;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Only talent Precision left working possibly incorrectly on all versions.
Tested 1.12 and 1.11.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Improved Evasion should no longer increase duration of Sprint.
- Elusiveness ranks 1-3 should now also reduce cooldown of Evasion.
- Improved Cheap Shot should no longer decrease cost of Garrote.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
