### PR TITLE
Faerlina worshipper

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -5259,6 +5259,12 @@ void Spell::EffectScriptEffect(SpellEffectIndex effIdx)
 
                     return;
                 }
+                case 28732: // Naxxramas Worshipper - Widow's Embrace
+                {
+                    if (m_casterUnit)
+                        m_casterUnit->Kill(m_casterUnit, nullptr);
+                    return;
+                }
             }
             break;
         }

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_faerlina.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_faerlina.cpp
@@ -117,9 +117,6 @@ struct boss_faerlinaAI : public ScriptedAI
         {
             m_uiEnrageTimer = std::max(m_uiEnrageTimer, (uint32)30000);
             m_creature->RemoveAurasDueToSpell(SPELL_ENRAGE);
-
-            if (Unit* pUnit = pCaster->ToUnit())
-                pUnit->Kill(pUnit, nullptr);
         }
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Naxxramas Worshipper npc in Faerlina's boss encounter only dies if its ability lands on the boss and places the debuff on it. In classic the Worshipper always dies upon casting the ability, regardless of whether it hit Faerlina or not.

### Proof
<!-- Link resources as proof -->
https://www.youtube.com/watch?v=gdNPxPSI7AM&t=76s timestamp 1:10

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- `.go creature 302452`
- clear the room for more ease with testing
- Pull Faerlina to one end of the room on a character
- Have a different character with the Mind Control spell aggro one of the Naxxramas Worshippers away to the other corner and MC it far
- Use the ability
- https://www.youtube.com/watch?v=sxla2oory7k

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
