### PR TITLE
align Cell.data.Part fields by 8 bits and enlarge Cell structure to 8 bytes

### DIFF
--- a/src/game/Maps/Cell.h
+++ b/src/game/Maps/Cell.h
@@ -48,8 +48,7 @@ struct CellArea
 
 struct Cell
 {
-    Cell() { data.All = 0; }
-    Cell(Cell const& cell) { data.All = cell.data.All; }
+    Cell() : data() { };
     explicit Cell(CellPair const& p);
 
     void Compute(uint32& x, uint32& y) const
@@ -84,12 +83,6 @@ struct Cell
         return CellPair(
             data.Part.grid_x*MAX_NUMBER_OF_CELLS+data.Part.cell_x,
             data.Part.grid_y*MAX_NUMBER_OF_CELLS+data.Part.cell_y);
-    }
-
-    Cell& operator=(Cell const& cell)
-    {
-        data.All = cell.data.All;
-        return *this;
     }
 
     bool operator==(Cell const& cell) const { return (data.All == cell.data.All); }

--- a/src/game/Maps/Cell.h
+++ b/src/game/Maps/Cell.h
@@ -99,14 +99,14 @@ struct Cell
     {
         struct
         {
-            unsigned grid_x : 6;
-            unsigned grid_y : 6;
-            unsigned cell_x : 6;
-            unsigned cell_y : 6;
-            unsigned nocreate : 1;
-            unsigned reserved : 7;
+            unsigned grid_x : 8;
+            unsigned grid_y : 8;
+            unsigned cell_x : 8;
+            unsigned cell_y : 8;
+            unsigned nocreate : 8;
+            unsigned reserved : 24;
         } Part;
-        uint32 All;
+        uint64 All;
     } data;
 
     template<class T, class CONTAINER> void Visit(CellPair const& cellPair, TypeContainerVisitor<T, CONTAINER>& visitor, Map& m, float x, float y, float radius) const;

--- a/src/game/Maps/Cell.h
+++ b/src/game/Maps/Cell.h
@@ -25,7 +25,6 @@
 #include "GameSystem/TypeContainer.h"
 #include "GameSystem/TypeContainerVisitor.h"
 #include "GridDefines.h"
-#include <cmath>
 
 class Map;
 class WorldObject;
@@ -99,12 +98,11 @@ struct Cell
     {
         struct
         {
-            unsigned grid_x : 8;
-            unsigned grid_y : 8;
-            unsigned cell_x : 8;
-            unsigned cell_y : 8;
-            unsigned nocreate : 8;
-            unsigned reserved : 24;
+            uint8  grid_x : 8;
+            uint8  grid_y : 8;
+            uint8  cell_x : 8;
+            uint8  cell_y : 8;
+            uint8  nocreate : 8;
         } Part;
         uint64 All;
     } data;

--- a/src/game/Maps/CellImpl.h
+++ b/src/game/Maps/CellImpl.h
@@ -27,14 +27,13 @@
 #include "Map.h"
 #include <cmath>
 
-inline Cell::Cell(CellPair const& p)
+inline Cell::Cell(CellPair const& p) : data()
 {
     data.Part.grid_x = p.x_coord / MAX_NUMBER_OF_CELLS;
     data.Part.grid_y = p.y_coord / MAX_NUMBER_OF_CELLS;
     data.Part.cell_x = p.x_coord % MAX_NUMBER_OF_CELLS;
     data.Part.cell_y = p.y_coord % MAX_NUMBER_OF_CELLS;
     data.Part.nocreate = 0;
-    data.Part.reserved = 0;
 }
 
 inline CellArea Cell::CalculateCellArea(float x, float y, float radius)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
All credits to @Lordron -  https://github.com/TrinityCore/TrinityCore/pull/29371

Aligns cell struct for better performance.

### Proof
<!-- Link resources as proof -->
Compiler explorer example with pre and post pr example code. 
https://godbolt.org/z/n7a8TP9Wz

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
