### PR TITLE
Make RP decay adjustable.

### DIFF
--- a/src/game/HonorMgr.cpp
+++ b/src/game/HonorMgr.cpp
@@ -549,7 +549,9 @@ float HonorMaintenancer::CalculateRpEarning(float cp, HonorScores sc)
 
 float HonorMaintenancer::CalculateRpDecay(float rpEarning, float rp)
 {
-    float decay = floor((0.2f * rp) + 0.5f);
+    float decayMultiplier = sWorld.getConfig(CONFIG_FLOAT_RP_DECAY);
+
+    float decay = floor((decayMultiplier * rp) + 0.5f);
     float delta = rpEarning - decay;
 
     if (delta < 0)

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -633,6 +633,7 @@ void World::LoadConfigSettings(bool reload)
             setConfig(CONFIG_UINT32_MIN_HONOR_KILLS, MIN_HONOR_KILLS_PRE_1_10);
     }
 
+    setConfigMinMax(CONFIG_FLOAT_RP_DECAY, "RpDecay", 0.2f, 0.0f, 1.0f);
     setConfigMinMax(CONFIG_UINT32_MAINTENANCE_DAY, "MaintenanceDay", 4, 0, 6);
     setConfig(CONFIG_BOOL_AUTO_HONOR_RESTART, "AutoHonorRestart", true);
     setConfig(CONFIG_BOOL_ALL_TAXI_PATHS, "AllFlightPaths", false);

--- a/src/game/World.h
+++ b/src/game/World.h
@@ -449,6 +449,7 @@ enum eConfigFloatValues
     CONFIG_FLOAT_RATE_XP_PERSONAL_MAX,
     CONFIG_FLOAT_AC_MOVEMENT_CHEAT_TELEPORT_DISTANCE,
     CONFIG_FLOAT_AC_MOVEMENT_CHEAT_WALL_CLIMB_ANGLE,
+    CONFIG_FLOAT_RP_DECAY,
     CONFIG_FLOAT_VALUE_COUNT
 };
 
@@ -1047,7 +1048,7 @@ class World
         std::unique_ptr<MovementBroadcaster> m_broadcaster;
 
         std::unique_ptr<ThreadPool> m_updateThreads;
-        
+
         static uint32 m_currentMSTime;
         static TimePoint m_currentTime;
         static uint32 m_currentDiff;

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -845,6 +845,11 @@ PerformanceLog.SlowPacketBroadcast      = 0
 #        Min kills that players must obtain to enter in weekly honor calculation
 #        Default: 0 (auto select based on patch)
 #
+#    RpDecay
+#        Determines the percentage of rank points (RP) decay per week
+#        If set to 0 there will be no decay
+#        Default: 0.2 (20%)
+#
 #    MaintenanceDay
 #        The day of the week on which server maintenance is performed ( currently used for Honor distribution )
 #        range (0..6): 0 is the first day of the week (normally sunday), 6 is the latest
@@ -1076,6 +1081,7 @@ MaxPlayerLevel = 60
 StartPlayerLevel = 1
 StartPlayerMoney = 0
 MinHonorKills = 0
+RpDecay = 0.2
 MaintenanceDay = 3
 InstantLogout = 1
 ForceLogoutDelay = 0


### PR DESCRIPTION
## 🍰 Pullrequest
This makes it so the rank points decay can be adjusted to a different percentage than the default 20%.

### Proof
- None

### Issues
- None

### How2Test
- Earn contribution points
- Trigger rank points distribution through honor maintenance
- Observe rank points getting calculated based on configured decay

### Todo / Checklist
- [X] None