### PR TITLE
Use bash shebang in sql/touch_migration.sh.

### DIFF
--- a/sql/touch_migration.sh
+++ b/sql/touch_migration.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 DATE=`date +%Y%m%d%H%M%S`
 FPATH=migrations/"$DATE"_world.sql
 


### PR DESCRIPTION
## 🍰 Pullrequest
Without it, at least on macOS it seems like it defaults to using sh (instead of bash or zsh, which is the new default interactive shell in newer macOS versions), which causes the `-e` flag of `echo` to not be interpreted and instead prepended to the created migration file.

This is what happend in https://github.com/vmangos/core/pull/2178/commits/7fa4fcc343c60bbb06eaeebc0a7f20141a148c34.

I am aware of the existence of the [Python script](https://github.com/vmangos/core/blob/e4a789da3c5362aee0fee8a631df9c40314683b7/sql/make_migration.py), so an alternative could also be to just delete the shell script instead.

### Proof
- None

### Issues
- None

### How2Test
- Run the `touch_migration.sh` script from an older commit on macOS and observe the `-e` being prepended to the created migration file
- Then run the updated script with the bash shebang from this commit and observe the `-e` no longer being prepended

### Todo / Checklist
- [X] None
