### PR TITLE
Change formula for crafting skill gain chance

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -5740,6 +5740,13 @@ inline int SkillGainChance(uint32 SkillValue, uint32 GrayLevel, uint32 GreenLeve
     return sWorld.getConfig(CONFIG_UINT32_SKILL_CHANCE_ORANGE) * 10;
 }
 
+inline int CraftingSkillGainChance(uint32 SkillValue, uint32 GrayLevel, uint32 YellowLevel)
+{
+    // Linear decrease in chance as you go from the YellowLevel -> GrayLevel.
+    // To avoid casting to floats and back to uint32 we multiply the numerator by 1000, to get into a range of 0-1000.
+    return G3D::iClamp(((GrayLevel - SkillValue) * 1000) / (GrayLevel - YellowLevel), 0, 1000);
+}
+
 bool Player::UpdateCraftSkill(uint32 spellid)
 {
     sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "UpdateCraftSkill spellid %d", spellid);
@@ -5754,9 +5761,8 @@ bool Player::UpdateCraftSkill(uint32 spellid)
 
             uint32 craft_skill_gain = sWorld.getConfig(CONFIG_UINT32_SKILL_GAIN_CRAFTING);
 
-            return UpdateSkillPro(_spell_idx->second->skillId, SkillGainChance(SkillValue,
+            return UpdateSkillPro(_spell_idx->second->skillId, CraftingSkillGainChance(SkillValue,
                                   _spell_idx->second->max_value,
-                                  (_spell_idx->second->max_value + _spell_idx->second->min_value) / 2,
                                   _spell_idx->second->min_value),
                                   craft_skill_gain);
         }


### PR DESCRIPTION
## 🍰 Pullrequest
Changes the formula for crafting skill gain to roughly match Classic

### Proof
<!-- Link resources as proof -->
See #1753, formula is `(greySkill - yourSkill) / (greySkill - yellowSkill)` which matches up to testing.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1753 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go to engineering trainer, create Rough Blasting Powder until lvl 35, should use roughly 28-29 rough stone.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Check if G3D::iClamp is acceptable or if I need to use if statements to clamp the values.
