### PR TITLE
Make `-march=native` configurable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CMAKE_MODULE_PATH
 
 set(SUPPORTED_CLIENT_BUILD "CLIENT_BUILD_1_12_1" CACHE STRING "Client version the core will support")
 option(USE_STD_MALLOC "Use standard malloc instead of TBB" OFF)
+option(BUILD_FOR_HOST_CPU "Build specifically for the host CPU via `-march=native` (might not run on different machines)" ON)
 option(TBB_DEBUG "Use TBB debug librairies" OFF)
 option(USE_ANTICHEAT "Use anticheat" OFF)
 option(USE_SCRIPTS "Compile scripts" ON)
@@ -78,7 +79,7 @@ if(WIN32)
       message(FATAL_ERROR "Only Visual Studio 2015 or newer is supported")
     endif()
   endif()
-  
+
   # Added by Giperion, in WIN32 output all compiled files in one directory
   set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin )
   set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib )
@@ -196,13 +197,13 @@ if(NOT USE_STD_MALLOC)
       ${TBB_LIBRARIES}
     )
   endif()
-  
+
   if (WIN32)
     list (GET TBB_LIBRARIES 1 TBB_SINGLE_FILEDIRECTORY)
     get_filename_component(TBB_LIB_DIRECTORY "${TBB_SINGLE_FILEDIRECTORY}" DIRECTORY)
     link_directories(${TBB_LIB_DIRECTORY})
   endif()
-  
+
 endif()
 
 # Win32 delifered packages
@@ -254,7 +255,7 @@ else()
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_QUIET
   )
-  
+
   if(NOT rev_hash)
     # No valid ways available to find/set the revision/hash, so let's force some defaults
     message(STATUS "
@@ -263,7 +264,7 @@ else()
     set(rev_date "1970-01-01 00:00:00 +0000")
     set(rev_hash "unknown")
   endif()
-  
+
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/revision.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/src/shared/revision.h)
 endif()
 
@@ -316,6 +317,12 @@ endif()
 message(STATUS "Memory allocation     : ${ALLOC_LIB_INFO_STRING} ${TBB_LIBRARIES}")
 message(STATUS "Detected compiler     : ${CMAKE_CXX_COMPILER_ID}")
 
+if(BUILD_FOR_HOST_CPU)
+  message(STATUS "Build for host CPU    : Yes (default)")
+else()
+  message(STATUS "Build for host CPU    : No")
+endif()
+
 message(STATUS "Build type            : ${CMAKE_BUILD_TYPE}")
 
 if(USE_ANTICHEAT)
@@ -338,7 +345,7 @@ if(UNIX)
   else()
     message(STATUS "Debug symbols         : Disabled")
   endif()
-  
+
   if(GCC_SANITIZE)
     set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
     set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -fsanitize=address")
@@ -353,7 +360,10 @@ if(UNIX)
     #set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -fsanitize=unsigned-integer-overflow")
   endif()
 
-  set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} --no-warnings -fexceptions -fnon-call-exceptions -march=native -pipe ")
+  set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} --no-warnings -fexceptions -fnon-call-exceptions -pipe")
+  if(BUILD_FOR_HOST_CPU)
+    set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -march=native")
+  endif()
   set(CMAKE_CXX_STANDARD 14)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(PROFILE_GENERATE)
@@ -392,7 +402,7 @@ if(MSVC)
   #if(PLATFORM MATCHES X86)
   #  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
   #endif()
-  
+
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 


### PR DESCRIPTION
## 🍰 Pullrequest
`-march=native` tells the compiler to specifically optimize for the host CPU which makes it unlikely that the resulting executable will run on other CPU models. This is obviously not suitable for builds that are supposed to be portable/distributable.

This PR introduces a new CMake option called `BUILD_FOR_HOST_CPU` that allows to control the usage of the `-march=native` flag. The default is that it _does_ build with the flag so that it doesn't change the current behavior.

Example use case: I provide [prebuilt Docker images](https://github.com/mserajnik/vmangos-deploy) and currently have to [patch out](https://github.com/mserajnik/vmangos-deploy/blob/33fa531950c47d3a19caa8e9d22f206cbec0813e/docker/server/Dockerfile#L46-L47) the `-march=native` flag.

### Proof
<!-- Link resources as proof -->
- None

### Issues
- Closes https://github.com/vmangos/core/issues/1748

### How2Test
- Make a build with `-DBUILD_FOR_HOST_CPU=0` and observe that the `-march=native` flag is not used

### Todo / Checklist
- [X] None
