### PR TITLE
Fix whitespace in VMAP extractors

### DIFF
--- a/contrib/vmap_extractor/vmapextract/adtfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/adtfile.cpp
@@ -129,7 +129,8 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
         ADT.read(&size, 4);
         flipcc(fourcc);
         fourcc[4] = 0;
-
+		
+		printf("Map=%s, Chunk '%s' pos=%zd, size=%d\n", AdtMapNumber.c_str(), fourcc, ADT.getPos(), size);
         size_t nextpos = ADT.getPos() + size;
 
         if (!strcmp(fourcc, "MCIN"))

--- a/contrib/vmap_extractor/vmapextract/adtfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/adtfile.cpp
@@ -129,8 +129,7 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
         ADT.read(&size, 4);
         flipcc(fourcc);
         fourcc[4] = 0;
-		
-		printf("Map=%s, Chunk '%s' pos=%zd, size=%d\n", AdtMapNumber.c_str(), fourcc, ADT.getPos(), size);
+
         size_t nextpos = ADT.getPos() + size;
 
         if (!strcmp(fourcc, "MCIN"))

--- a/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
+++ b/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
@@ -22,8 +22,14 @@ bool ExtractSingleModel(std::string& origPath, std::string& fixedName, StringSet
     }
     // >= 3.1.0 ADT MMDX section store filename.m2 filenames for corresponded .m2 file
     // nothing do
+	
+    // Fix a few models with spaces instead of underscores in their filenames (razorfen leanto03)
+    std::string s = GetPlainName(origPath.c_str());
+    std::transform(s.begin(), s.end(), s.begin(), [](char ch) {
+        return ch == ' ' ? '_' : ch;
+        });
 
-    fixedName = GetPlainName(origPath.c_str());
+    fixedName = s;
 
     std::string output(szWorkDirWmo);                       // Stores output filename (possible changed)
     output += "/";


### PR DESCRIPTION
Fixes whitespace in filenames, which client normally parses and replaces with underscores (razorfen leanto03.m2)