### PR TITLE
Battlebots AutoJoin customizable.

### DIFF
--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -126,6 +126,7 @@ ChatCommand * ChatHandler::getCommandTable()
         { "removeall",    SEC_ADMINISTRATOR,    true,  &ChatHandler::HandleBattleBotRemoveAllCommand,    "", nullptr },
         { "showpath",     SEC_ADMINISTRATOR,    false, &ChatHandler::HandleBattleBotShowPathCommand,     "", nullptr },
         { "showallpaths", SEC_ADMINISTRATOR,    false, &ChatHandler::HandleBattleBotShowAllPathsCommand, "", nullptr },
+        { "autojoin",     SEC_ADMINISTRATOR,    false, &ChatHandler::HandleBattleBotAutoJoinCommand,     "", nullptr },
         { nullptr,        0,                    false, nullptr,                                          "", nullptr },
     };
 

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -281,6 +281,7 @@ class ChatHandler
         bool HandleBattleBotRemoveAllCommand(char* args);
         bool HandleBattleBotShowPathCommand(char* args);
         bool HandleBattleBotShowAllPathsCommand(char* args);
+        bool HandleBattleBotAutoJoinCommand(char* args);
 
         // spell_disabled
         bool HandleReloadSpellDisabledCommand(char *args);

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -589,7 +589,6 @@ void PlayerBotMgr::DeleteBattleBots()
         if (dynamic_cast<BattleBotAI*>(itr.second->ai.get()))
             itr.second->requestRemoval = true;
     }
-    m_confBattleBotAutoJoin = false;
 }
 
 bool PlayerBotMgr::ForceAccountConnection(WorldSession* sess)
@@ -1761,6 +1760,29 @@ bool ChatHandler::HandleBattleBotRemoveAllCommand(char* args)
     sPlayerBotMgr.DeleteBattleBots();
     SendSysMessage("Removed all battlebots.");
     return true;
+}
+
+bool ChatHandler::HandleBattleBotAutoJoinCommand(char* args)
+{
+    if (!*args)
+    {
+        bool autoJoin = m_confBattleBotAutoJoin;
+        SendSysMessage(autoJoin ? "Battlebots AutoJoin - on" : "Battlebots AutoJoin - off");
+        return true;
+
+    }
+
+    bool value;
+    if (!ExtractOnOff(&args, value))
+    {
+        SendSysMessage(LANG_USE_BOL);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    m_confBattleBotAutoJoin = value;
+
+    return true;    
 }
 
 #define SPELL_RED_GLOW 20370

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1776,7 +1776,7 @@ bool ChatHandler::HandleBattleBotAutoJoinCommand(char* args)
         SetSentErrorMessage(true);
         return false;
     }
-    sPlayerBotMgr.SwitchAutoJoinBattleBots(value)
+    sPlayerBotMgr.SwitchAutoJoinBattleBots(value);
     return true;    
 }
 

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -591,6 +591,11 @@ void PlayerBotMgr::DeleteBattleBots()
     }
 }
 
+void PlayerBotMgr::SwitchAutoJoinBattleBots(bool payload)
+{
+    m_confBattleBotAutoJoin = payload ? true : false;
+}
+
 bool PlayerBotMgr::ForceAccountConnection(WorldSession* sess)
 {
     if (sess->GetBot())
@@ -1764,13 +1769,6 @@ bool ChatHandler::HandleBattleBotRemoveAllCommand(char* args)
 
 bool ChatHandler::HandleBattleBotAutoJoinCommand(char* args)
 {
-    if (!*args)
-    {
-        SendSysMessage(m_confBattleBotAutoJoin ? "Battlebots AutoJoin - on" : "Battlebots AutoJoin - off");
-        return true;
-
-    }
-
     bool value;
     if (!ExtractOnOff(&args, value))
     {
@@ -1778,9 +1776,7 @@ bool ChatHandler::HandleBattleBotAutoJoinCommand(char* args)
         SetSentErrorMessage(true);
         return false;
     }
-
-    m_confBattleBotAutoJoin = value ? true : false;
-
+    sPlayerBotMgr.SwitchAutoJoinBattleBots(value)
     return true;    
 }
 

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1766,8 +1766,7 @@ bool ChatHandler::HandleBattleBotAutoJoinCommand(char* args)
 {
     if (!*args)
     {
-        bool autoJoin = m_confBattleBotAutoJoin;
-        SendSysMessage(autoJoin ? "Battlebots AutoJoin - on" : "Battlebots AutoJoin - off");
+        SendSysMessage(m_confBattleBotAutoJoin ? "Battlebots AutoJoin - on" : "Battlebots AutoJoin - off");
         return true;
 
     }
@@ -1780,7 +1779,7 @@ bool ChatHandler::HandleBattleBotAutoJoinCommand(char* args)
         return false;
     }
 
-    m_confBattleBotAutoJoin = value;
+    m_confBattleBotAutoJoin = value ? true : false;
 
     return true;    
 }

--- a/src/game/PlayerBots/PlayerBotMgr.h
+++ b/src/game/PlayerBots/PlayerBotMgr.h
@@ -88,6 +88,7 @@ class PlayerBotMgr
 
         void AddBattleBot(BattleGroundQueueTypeId queueType, Team botTeam, uint32 botLevel, bool temporary);
         void DeleteBattleBots();
+        void SwitchAutoJoinBattleBots(bool payload);
 
         void DeleteAll();
         void AddAllBots();


### PR DESCRIPTION
Sometimes you need to clean the BG, but do not disable the auto join function. For example, when atari lasts for several days.