### PR TITLE
Serverside check for combopoints

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7543,6 +7543,16 @@ SpellCastResult Spell::CheckPower() const
     if (m_casterUnit->GetPower(powerType) < m_powerCost)
         return SPELL_FAILED_NO_POWER;
 
+    if (m_spellInfo->NeedsComboPoints())
+    {
+        if (Player* pPlayer = m_caster->ToPlayer())
+        {
+            if (!pPlayer->GetComboPoints())
+                return SPELL_FAILED_NO_COMBO_POINTS;
+        }
+    }
+
+
     return SPELL_CAST_OK;
 }
 

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7547,7 +7547,7 @@ SpellCastResult Spell::CheckPower() const
     {
         if (Player* pPlayer = m_caster->ToPlayer())
         {
-            if (!pPlayer->GetComboPoints())
+            if (pPlayer->GetComboTargetGuid() != pPlayer->GetTargetGuid())
                 return SPELL_FAILED_NO_COMBO_POINTS;
         }
     }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Adds a serverside check to spells that requires combopoints.

Apparently classic clients ignores clientside combopoint checks for some spells. I believe its due to the SPELL_ATTR_EX_IGNORE_CASTER_AND_TARGET_RESTRICTIONS flag.

This would allow classic client to cast Slize and dize without combopoints.

Notes:
should this check belong in checkPower() ? is combopoints a power? semantics 😩 
checked that this doesn't break spells like overpower - that uses a hidden combopoint.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- (https://github.com/TeamEverlook/Everlook-BugTracker/issues/266)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
