### PR TITLE
Bwl vael cleave

### DIFF
--- a/sql/migrations/20231124111109_world.sql
+++ b/sql/migrations/20231124111109_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20231124111109');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20231124111109');
+-- Add your query below.
+
+DELETE FROM `spell_effect_mod` WHERE `Id`=19983; -- "Cleave 19983 : bonus degats fix a 300"
+DELETE FROM `spell_effect_mod` WHERE `Id`=22540; -- "Cleave Vael (chaintarget 50 radius fix a 10yd)" NOT vael's spell
+DELETE FROM `spell_mod` WHERE `Id`=22540; -- "Cleave Vael (modification dmgclass : magic)" NOT vael's spell, makes it unable to dodge/parry/block
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
@@ -26,7 +26,6 @@ EndScriptData */
 
 enum
 {
-    // Last found data : HP : 3,331,000 (+20% = 3997200). Damage: 5,930 - 6,807. Armor: 4,691.
     NPC_VAELASTRAZ              = 13020,
     NPC_LORD_NEFARIAN_VAEL      = 10162,
 
@@ -67,12 +66,8 @@ enum
     SPELL_BURNING_ADRENALINE4   = 24701, // -75% threat : easy mode ???
     // See the heal of Kazzak
 
-    // TO FIX : The chain effect
-    // DB : spell_effect_mod.effectChainTarget = 25;
-    // Cleave attack that hits for 2k. This is a chain cleave, so if positioning is poor it can chain to the entire raid, even to behind him. It is critical that nobody be within approximately 10 yards of the main tank for this reason. Offtanks should be generating threat far enough from the MT to avoid chaining the cleave, but close enough to slide into place when BA hits the MT.
-    SPELL_CLEAVE                = 22540, // 22540 Chain Cleave hardcoded via the BD (Ustaag) // 19983 // 20684  ? // Chain cleave is most likely named something different and contains a dummy effect
-    // change spell.cpp "//FIXME: This very like horrible hack and wrong for most spells"
-    // Find out which creatures use both spells in the DB?
+    // This is a chain cleave, so if positioning is poor it can chain to the entire raid, even to behind him. It is critical that nobody be within approximately 10 yards of the main tank for this reason. Offtanks should be generating threat far enough from the MT to avoid chaining the cleave, but close enough to slide into place when BA hits the MT.
+    SPELL_CLEAVE                = 19983,
 
     SPELL_BANISHEMENT_OF_SCALE  = 16404,
     SPELL_NEFARIUS_CORRUPTION   = 23642,


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fix the spell ID used for Vael cleave

### Proof
<!-- Link resources as proof -->
- Sniffs show correct cleave id is 19983

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- It's a pain to test the ability on Vael with how hard it is to engage fight with him, burning adrenaline, and all the random fire damage you get. What I did was just give the ability to a random open world mob and see if it works correct.
- Cleave hits up to 10 people like the dbc implies it should without any mods.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
