### PR TITLE
Fix a few mage talents that were changed in 1.11 for old versions.

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -1876,6 +1876,27 @@ void Unit::CalculateDamageAbsorbAndResist(SpellCaster* pCaster, SpellSchoolMask 
             // Need remove it later
             if (mod->m_amount <= 0)
                 existExpired = true;
+
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_10_2
+            // Patch 1.11.0 changed Mage talent Improved Frost Ward to Frost Warding.
+            // Improved Frost Ward - 50% of the damage absorbed by your Frost Ward is added to your mana.
+            const SpellEntry* absorbProto = (*i)->GetSpellProto();
+            if (absorbProto->IsFitToFamily<SPELLFAMILY_MAGE, CF_MAGE_FROST_WARD>() && HasAura(11189))
+                CastCustomSpell(this, 27679, currentAbsorb / 2, {}, {}, true);
+            else if (absorbProto->IsFitToFamily<SPELLFAMILY_MAGE, CF_MAGE_FIRE_WARD>())
+            {
+                Unit::AuraList const& mOverrideClassScript = GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+                for (const auto i : mOverrideClassScript)
+                    // Patch 1.11.0 changed Mage talent Improved Fire Ward.
+                    // Old effect - Causes your Fire Ward to reflect 20%/35% of the Fire damage absorbed back to the caster.
+                    // The % values don't show up anywhere in dbcs other than the tooltip
+                    if (i->GetModifier()->m_miscvalue == 948)
+                        if (i->GetId() == 11094) // Improved Fire Ward 1
+                            CastCustomSpell(pCaster->ToUnit(), 12559, 0.2 * currentAbsorb, {}, {}, true);
+                        else if (i->GetId() == 13043) // Improved Fire Ward 2
+                            CastCustomSpell(pCaster->ToUnit(), 12559, 0.35 * currentAbsorb, {}, {}, true);
+            }
+#endif
         }
 
         // Remove all expired absorb auras
@@ -5286,6 +5307,12 @@ bool Unit::IsSpellCrit(Unit const* pVictim, SpellEntry const* spellProto, SpellS
                 {
                     if (!(i->GetSpellProto()->SpellFamilyName == spellProto->SpellFamilyName))
                         continue;
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_10_2
+                    // 1.11.0 - Mage talent Shatter was changed to affect all spells, previously limited to Frost spells.
+                    const SpellEntry* modSpellProto = i->GetSpellProto();
+                    if (modSpellProto->EffectItemType[0] && !spellProto->IsFitToFamily(SpellFamily(modSpellProto->SpellFamilyName), modSpellProto->EffectItemType[0]))
+                        continue;
+#endif
                     switch (i->GetModifier()->m_miscvalue)
                     {
                         // Shatter

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -1880,7 +1880,7 @@ void Unit::CalculateDamageAbsorbAndResist(SpellCaster* pCaster, SpellSchoolMask 
 #if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_10_2
             // Patch 1.11.0 changed Mage talent Improved Frost Ward to Frost Warding.
             // Improved Frost Ward - 50% of the damage absorbed by your Frost Ward is added to your mana.
-            const SpellEntry* absorbProto = (*i)->GetSpellProto();
+            SpellEntry const* absorbProto = (*i)->GetSpellProto();
             if (absorbProto->IsFitToFamily<SPELLFAMILY_MAGE, CF_MAGE_FROST_WARD>() && HasAura(11189))
                 CastCustomSpell(this, 27679, currentAbsorb / 2, {}, {}, true);
             else if (absorbProto->IsFitToFamily<SPELLFAMILY_MAGE, CF_MAGE_FIRE_WARD>())
@@ -1892,9 +1892,9 @@ void Unit::CalculateDamageAbsorbAndResist(SpellCaster* pCaster, SpellSchoolMask 
                     // The % values don't show up anywhere in dbcs other than the tooltip
                     if (i->GetModifier()->m_miscvalue == 948)
                         if (i->GetId() == 11094) // Improved Fire Ward 1
-                            CastCustomSpell(pCaster->ToUnit(), 12559, 0.2 * currentAbsorb, {}, {}, true);
+                            CastCustomSpell(pCaster->ToUnit(), 12559, 0.2f * currentAbsorb, {}, {}, true);
                         else if (i->GetId() == 13043) // Improved Fire Ward 2
-                            CastCustomSpell(pCaster->ToUnit(), 12559, 0.35 * currentAbsorb, {}, {}, true);
+                            CastCustomSpell(pCaster->ToUnit(), 12559, 0.35f * currentAbsorb, {}, {}, true);
             }
 #endif
         }
@@ -5309,7 +5309,7 @@ bool Unit::IsSpellCrit(Unit const* pVictim, SpellEntry const* spellProto, SpellS
                         continue;
 #if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_10_2
                     // 1.11.0 - Mage talent Shatter was changed to affect all spells, previously limited to Frost spells.
-                    const SpellEntry* modSpellProto = i->GetSpellProto();
+                    SpellEntry const* modSpellProto = i->GetSpellProto();
                     if (modSpellProto->EffectItemType[0] && !spellProto->IsFitToFamily(SpellFamily(modSpellProto->SpellFamilyName), modSpellProto->EffectItemType[0]))
                         continue;
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
- Mage talent Shatter was changed to affect all spells, previously limited to Frost spells.
- Improved Frost Ward was changed to Frost Warding. Old effect - 50% of the damage absorbed by your Frost Ward is added to your mana.
- Improved Fire Ward was changed. Old effect - Causes your Fire Ward to reflect 20%/35% of the Fire damage absorbed back to the caster.

Tested 1.10 and 1.12

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
On 1.10 client:
- Check that Shatter only affects Frost spells.
- Check that Improved Fire Ward does % absorbed damage to attacker. 20% at rank 1, 35% at rank 2.
- Check that Improved Frost Ward converts 50% of absorbed damage to your mana.
- Newer clients behave as before.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
