### PR TITLE
Set build_min in spell_affect for some Shaman talents that were changed in 1.11.

### DIFF
--- a/sql/migrations/20231126103923_world.sql
+++ b/sql/migrations/20231126103923_world.sql
@@ -1,0 +1,28 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20231126103923');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20231126103923');
+-- Add your query below.
+
+-- Concussion; 16106 already set to 5464
+UPDATE `spell_affect` SET `build_min`='5464' WHERE `entry` IN (16035, 16105, 16107, 16108) AND `effectId`=0;
+
+-- Convection
+UPDATE `spell_affect` SET `build_min`='5464' WHERE `entry` IN (16039, 16109, 16110, 16111, 16112) AND `effectId`=0;
+
+-- Healing Focus/Improved Lesser Healing Wave
+UPDATE `spell_affect` SET `build_min`='5464' WHERE `entry` IN (16181, 16230, 16232, 16233, 16234) AND `effectId`=0;
+
+-- Restorative Totems/Improved Mana Spring Totem
+UPDATE `spell_affect` SET `build_min`='5464' WHERE `entry` IN (16187, 16205, 16206, 16207, 16208) AND `effectId`=0;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Addressing the changes in 1.11:
- Talents Concussion and Convection were changed to also affect Lightning Bolt and Chain Lightning.
- Improved Lesser Healing Wave renamed to Healing Focus and made to affect all healing spells.
- Improved Mana Spring Totem renamed to Restorative Totems and made to also affect Healing Stream Totems.

Tested 1.10 and 1.12
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
On 1.10 client:
- Concussion should not affect Lightning Bolt and Chain Lightning.
- Convection should not affect Lightning Bolt and Chain Lightning.
- Improved Lesser Healing Wave should not affect Chain Heal and Healing Wave.
- Improved Mana Spring Totem should not increase healing of Healing Stream Totems.
- Newer clients work as before.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
