### PR TITLE
Add waypoints to Witherheart the Stalker.

### DIFF
--- a/sql/migrations/20231126234757_world.sql
+++ b/sql/migrations/20231126234757_world.sql
@@ -1,0 +1,42 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20231126234757');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20231126234757');
+-- Add your query below.
+
+
+-- Pathing for Witherheart the Stalker Entry: 8218
+SET @NPC := 85478;
+UPDATE `creature` SET `wander_distance`=0,`movement_type`=2,`position_x`=-399.90463,`position_y`=-2810.7239,`position_z`=78.00985 WHERE `guid`=@NPC;
+DELETE FROM `creature_movement` WHERE `id`=@NPC;
+INSERT INTO `creature_movement` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`waittime`,`wander_distance`,`script_id`) VALUES
+(@NPC,1,-399.90463,-2810.7239,78.00985,100,0,0,0),
+(@NPC,2,-411.23264,-2833.3965,79.34615,100,0,0,0),
+(@NPC,3,-419.67285,-2866.848,81.6237,100,0,0,0),
+(@NPC,4,-433.39053,-2891.0513,85.470924,100,0,0,0),
+(@NPC,5,-440.9833,-2912.3506,88.50849,100,0,0,0),
+(@NPC,6,-431.72278,-2919.4988,87.758095,100,0,0,0),
+(@NPC,7,-410.9552,-2911.8176,80.65067,100,0,0,0),
+(@NPC,8,-398.36133,-2915.043,79.20992,100,0,0,0),
+(@NPC,9,-368.3346,-2925.7651,75.58492,100,0,0,0),
+(@NPC,10,-333.24603,-2914.1536,77.88582,100,0,0,0),
+(@NPC,11,-312.31683,-2894.8928,79.29725,100,0,0,0),
+(@NPC,12,-316.2032,-2867.8672,80.33094,100,0,0,0),
+(@NPC,13,-343.85233,-2834.53,75.73404,100,0,0,0),
+(@NPC,14,-331.66537,-2820.3848,79.355644,100,0,0,0),
+(@NPC,15,-345.9131,-2799.4731,80.685,100,0,0,0),
+(@NPC,16,-368.80045,-2797.7434,76.87515,100,0,0,0),
+(@NPC,17,-390.4299,-2788.0408,77.2648,100,0,0,0);
+-- 0x204CB0000008068000000D00003DC2AA .go xyz -399.90463 -2810.7239 78.00985
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds waypoints to Witherheart the Stalker. Previously incorrectly had random movement.
It should path around in stealth in a circle around the area.

### Proof
<!-- Link resources as proof -->
- Sniffed on classic WotLK PTR.
- Confirmed to have exact same waypoints on classic era PTR.

Image from classic WotLK PTR waypoints sniff:
![WoW_GGK2xCD95n](https://github.com/vmangos/core/assets/6137576/2e8967af-28e4-4718-9869-420da6a8ffef)
Image from classic era PTR:
![WowClassicT_AXzhkDpxx6](https://github.com/vmangos/core/assets/6137576/82ebf337-ff30-4353-a0d2-30f0ae035bab)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
