### PR TITLE
very minor refactor of Creature::HasSpell

### DIFF
--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -3053,8 +3053,7 @@ bool Creature::IsInEvadeMode() const
 
 bool Creature::HasSpell(uint32 spellId) const
 {
-    uint8 i;
-    for (i = 0; i < CREATURE_MAX_SPELLS; ++i)
+    for (uint8 i = 0; i < CREATURE_MAX_SPELLS; ++i)
         if (spellId == m_spells[i])
             return true;
     return false;

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -3056,8 +3056,8 @@ bool Creature::HasSpell(uint32 spellId) const
     uint8 i;
     for (i = 0; i < CREATURE_MAX_SPELLS; ++i)
         if (spellId == m_spells[i])
-            break;
-    return i < CREATURE_MAX_SPELLS;                         // break before end of iteration of known spells
+            return true;
+    return false;
 }
 
 void Creature::LockOutSpells(SpellSchoolMask schoolMask, uint32 duration)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Latest GCC and Clang already optimizes this with -O3 - MSVC doesn't (with -O3)

MSVC Example 
![image](https://github.com/vmangos/core/assets/2223066/02271f60-6897-465d-b77a-f5a09e1d1b7e)

It also simplifies the code and makes it more readable.

minor note for optimization nerds.. The following snippet is often more faster on gcc/clang - but comes with its own set of drawbacks..
   return (spellId == m_spells[0] ||spellId == m_spells[1] || spellId == m_spells[2] ||spellId == m_spells[3]  );

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
