### PR TITLE
Fix missing headers in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,7 @@ CMakeSettings.json
 /out/
 
 # CLion files
-cmake-build-debug
-cmake-build-release
+cmake-build-*
 
 #
 # Top-level generic files

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -30,6 +30,7 @@
 #include "Util.h"
 #include "Group.h"
 #include "SpellAuraDefines.h"
+#include "Map.h"
 
 int PetAI::Permissible(Creature const* creature)
 {

--- a/src/game/AI/ScriptedFollowerAI.cpp
+++ b/src/game/AI/ScriptedFollowerAI.cpp
@@ -13,6 +13,7 @@ EndScriptData */
 #include "Chat.h"
 #include "Player.h"
 #include "Group.h"
+#include "Map.h"
 
 float const MAX_PLAYER_DISTANCE = 100.0f;
 


### PR DESCRIPTION
## 🍰 Pullrequest

This PR fixes some missing build headers and also includes `cmake-build-*` to .gitignore.

I am using CLion and depending on which build environment I am using the suffix changes.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
