### PR TITLE
Make .namego command teleport to accurate pos

### DIFF
--- a/src/game/Commands/TeleportCommands.cpp
+++ b/src/game/Commands/TeleportCommands.cpp
@@ -262,8 +262,8 @@ bool ChatHandler::HandleGroupgoCommand(char* args)
 
         // before GM
         float x, y, z;
-        pPlayer->GetClosePoint(x, y, z, pl->GetObjectBoundingRadius());
-        pl->TeleportTo(pPlayer->GetMapId(), x, y, z, pl->GetOrientation());
+        pPlayer->GetPosition(x, y, z);
+        pl->TeleportTo(pPlayer->GetMapId(), x, y, z, pPlayer->GetOrientation());
     }
 
     return true;
@@ -1179,8 +1179,8 @@ bool ChatHandler::HandleNamegoCommand(char* args)
 
         // before GM
         float x, y, z;
-        pPlayer->GetClosePoint(x, y, z, pTarget->GetObjectBoundingRadius());
-        pTarget->TeleportTo(pPlayer->GetMapId(), x, y, z, pTarget->GetOrientation(), TELE_TO_NOT_LEAVE_COMBAT);
+        pPlayer->GetPosition(x, y, z);
+        pTarget->TeleportTo(pPlayer->GetMapId(), x, y, z, pPlayer->GetOrientation(), TELE_TO_NOT_LEAVE_COMBAT);
     }
     else
     {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

It was weirdly teleporting to a proximate location based on boundingradius and conserving teleported player orientation. Much more convenient for testing and gm activity to teleport to accurate pos

### Proof
<!-- Link resources as proof -->
Not a bug with the game just simplifying an unnecessarily convoluted gm command

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .namego on 2nd player
- the 2nd player is teleported exactly on top of 1st player and facing the same direction

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
