### PR TITLE
Fix to sylvanas getting stuck in idle motion and not evading outside throne room

### DIFF
--- a/src/game/AI/ScriptedAI.cpp
+++ b/src/game/AI/ScriptedAI.cpp
@@ -238,7 +238,7 @@ bool ScriptedAI::EnterEvadeIfOutOfCombatArea(uint32 const uiDiff)
             break;
         case NPC_SYLVANAS:
         case NPC_VARIMATHRAS:
-            if (m_creature->GetDistance(fX, fY, fZ) < 120.0f)
+            if (fZ < -53.0f)
                 return false;
             break;
         default:

--- a/src/scripts/eastern_kingdoms/undercity/undercity.cpp
+++ b/src/scripts/eastern_kingdoms/undercity/undercity.cpp
@@ -69,6 +69,9 @@ public:
 
     void UpdateAI(uint32 const uiDiff) override
     {
+        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
+            return;
+
         if (m_uiFadedTimer)
         {
             if (m_uiFadedTimer > uiDiff)
@@ -77,11 +80,9 @@ public:
                 return;
             }
             m_uiFadedTimer = 0;
-            m_creature->GetMotionMaster()->Clear();
+            m_creature-> GetMotionMaster()->Clear();
+            m_creature-> GetMotionMaster()->MoveChase(m_creature->GetVictim());
         }
-
-        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
-            return;
 
         if (m_uiSummSkelTimer <= uiDiff)
         {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
- Sylvanas evade check was completely meaningless checking for distance between her and her position, changed to height based check (Her throne room is slightly lower than the hallway leading to it)

- fixed being set to idle motion after fade

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .tele undercity
- pull sylvanas outside of room, correctly resets

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
