### PR TITLE
implement Elapsed Time compensation to Attack Timer adjustements and DW adjustment

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -362,13 +362,13 @@ void Unit::DelayAutoAttacks()
 
 void Unit::FirstAttackDelay()
 {
-    if (isAttackReady(BASE_ATTACK))
+    if (IsAttackReady(BASE_ATTACK))
         SetAttackTimer(BASE_ATTACK, 0); // Erase saved update timer diff from the swing timer
-    if (HaveOffhandWeapon() // Doing an attack command sets offhand timer equal to half its swing speed.
+    if (HaveOffhandWeapon()) // Doing an attack command sets offhand timer equal to half its swing speed.
     {
-        uint32 halfattack = GetAttackTime(OFF_ATTACK) * m_modAttackSpeedPct[OFF_ATTACK] * 0.5
-        if GetAttackTimer(OFF_ATTACK) < halfattack
-            SetAttackTimer(OFF_ATTACK, halfattack)
+        int32 halfattack = int32(GetAttackTime(OFF_ATTACK) * m_modAttackSpeedPct[OFF_ATTACK] * 0.5);
+        if (GetAttackTimer(OFF_ATTACK) < halfattack)
+            SetAttackTimer(OFF_ATTACK, halfattack);
     }
 }
 

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -388,7 +388,7 @@ bool Unit::UpdateMeleeAttackingState()
                     SetAttackTimer(OFF_ATTACK, ATTACK_DISPLAY_DELAY);
                 openerAttack = false;
             }
-            if (HaveOffhandWeapon() && IsAttackReady(OFF_ATTACK))
+            else if (HaveOffhandWeapon() && IsAttackReady(OFF_ATTACK))
             {
                 // do attack
                 AttackerStateUpdate(pVictim, OFF_ATTACK);

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -146,6 +146,7 @@ Unit::Unit()
         m_createResistance = 0;
 
     m_attacking = nullptr;
+    m_openerAttack = true;
     m_modSpellHitChance = 0.0f;
     m_baseSpellCritChance = 5;
 
@@ -297,11 +298,11 @@ void Unit::Update(uint32 update_diff, uint32 p_time)
 
     if (int32 off_att = GetAttackTimer(OFF_ATTACK))
         if (off_att > 0)
-        SetAttackTimer(OFF_ATTACK, off_att - update_diff);
+            SetAttackTimer(OFF_ATTACK, off_att - update_diff);
 
     if (int32 ranged_att = GetAttackTimer(RANGED_ATTACK))
         if (ranged_att > 0)
-        SetAttackTimer(RANGED_ATTACK, ranged_att - update_diff);
+            SetAttackTimer(RANGED_ATTACK, ranged_att - update_diff);
 
     if (IsAlive())
         ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, GetHealth() < GetMaxHealth() * 0.20f);
@@ -383,17 +384,16 @@ bool Unit::UpdateMeleeAttackingState()
             if (IsAttackReady(BASE_ATTACK))
             {
                 AttackerStateUpdate(pVictim, BASE_ATTACK);
-                ResetAttackTimer(BASE_ATTACK, !openerAttack);
-                if (openerAttack && HaveOffhandWeapon() && GetAttackTimer(OFF_ATTACK) < ATTACK_DISPLAY_DELAY)
+                ResetAttackTimer(BASE_ATTACK, !m_openerAttack);
+                if (m_openerAttack && HaveOffhandWeapon() && GetAttackTimer(OFF_ATTACK) < ATTACK_DISPLAY_DELAY)
                     SetAttackTimer(OFF_ATTACK, ATTACK_DISPLAY_DELAY);
-                openerAttack = false;
+                m_openerAttack = false;
             }
             else if (HaveOffhandWeapon() && IsAttackReady(OFF_ATTACK))
             {
-                // do attack
                 AttackerStateUpdate(pVictim, OFF_ATTACK);
-                ResetAttackTimer(OFF_ATTACK, !openerAttack);
-                openerAttack = false;
+                ResetAttackTimer(OFF_ATTACK, !m_openerAttack);
+                m_openerAttack = false;
             }
             break;
         }
@@ -4638,7 +4638,7 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
 
     if (meleeAttack)
     {
-        openerAttack = true;
+        m_openerAttack = true;
         SendMeleeAttackStart(victim);
     }
     return true;

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -389,7 +389,7 @@ bool Unit::UpdateMeleeAttackingState()
                     SetAttackTimer(OFF_ATTACK, ATTACK_DISPLAY_DELAY);
                 m_openerAttack = false;
             }
-            else if (HaveOffhandWeapon() && IsAttackReady(OFF_ATTACK))
+            if (HaveOffhandWeapon() && IsAttackReady(OFF_ATTACK))
             {
                 AttackerStateUpdate(pVictim, OFF_ATTACK);
                 ResetAttackTimer(OFF_ATTACK, !m_openerAttack);
@@ -472,7 +472,10 @@ void Unit::SendMovementPacket(uint16 opcode, bool includingSelf)
 
 void Unit::ResetAttackTimer(WeaponAttackType type, bool compensateDiff/*= false*/)
 {
-    m_attackTimer[type] = uint32(GetAttackTime(type) * m_modAttackSpeedPct[type]) + ((compensateDiff) ? std::min(m_attackTimer[type], 0) : 0);
+    if (compensateDiff && m_attackTimer[type] < 0)
+        m_attackTimer[type] += int32(GetAttackTime(type) * m_modAttackSpeedPct[type]);
+    else
+        m_attackTimer[type] = int32(GetAttackTime(type) * m_modAttackSpeedPct[type]);
 }
 
 void Unit::RemoveSpellsCausingAura(AuraType auraType, AuraRemoveMode mode)

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -908,9 +908,10 @@ class Unit : public SpellCaster
         HostileRefManager m_HostileRefManager; // Manage all Units that are threatened by us
         std::vector<ObjectGuid> m_tauntGuids;
     protected:
-        uint32 m_attackTimer[MAX_ATTACK];
+        int32 m_attackTimer[MAX_ATTACK];
         AttackerSet m_attackers;
         Unit* m_attacking;
+        bool openerAttack; // The unit's first attack against an enemy.
         uint32 m_reactiveTimer[MAX_REACTIVE];
         ObjectGuid m_reactiveTarget[MAX_REACTIVE];
         typedef std::map<ObjectGuid /*attackerGuid*/, uint32 /*damage*/ > DamageTakenHistoryMap;
@@ -922,19 +923,20 @@ class Unit : public SpellCaster
          * @param type The type of weapon that we want to update the time for
          * @param time the remaining time until we can attack with the WeaponAttackType again
          */
-        void SetAttackTimer(WeaponAttackType type, uint32 time) { m_attackTimer[type] = time; }
+        void SetAttackTimer(WeaponAttackType type, int32 time) { m_attackTimer[type] = time; }
         /**
          * Resets the attack timer to the base value decided by Unit::m_modAttackSpeedPct and
          * Unit::GetAttackTime
          * @param type The weapon attack type to reset the attack timer for.
+         * @param compensateDiff Deduct the diff in update tick from the reseted timer.
          */
-        void ResetAttackTimer(WeaponAttackType type = BASE_ATTACK);
+        void ResetAttackTimer(WeaponAttackType type = BASE_ATTACK, bool compensateDiff = false);
         /**
          * Get's the remaining time until we can do an attack
          * @param type The weapon type to check the remaining time for
          * @return The remaining time until we can attack with this weapon type.
          */
-        uint32 GetAttackTimer(WeaponAttackType type) const { return m_attackTimer[type]; }
+        int32 GetAttackTimer(WeaponAttackType type) const { return m_attackTimer[type]; }
         /**
          * Checks whether the unit can do an attack. Does this by checking the attacktimer for the
          * WeaponAttackType, can probably be thought of as a cooldown for each swing/shot

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -911,7 +911,7 @@ class Unit : public SpellCaster
         int32 m_attackTimer[MAX_ATTACK];
         AttackerSet m_attackers;
         Unit* m_attacking;
-        bool openerAttack; // The unit's first attack against an enemy.
+        bool m_openerAttack; // The unit's first attack against an enemy.
         uint32 m_reactiveTimer[MAX_REACTIVE];
         ObjectGuid m_reactiveTarget[MAX_REACTIVE];
         typedef std::map<ObjectGuid /*attackerGuid*/, uint32 /*damage*/ > DamageTakenHistoryMap;

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -911,7 +911,6 @@ class Unit : public SpellCaster
         int32 m_attackTimer[MAX_ATTACK];
         AttackerSet m_attackers;
         Unit* m_attacking;
-        bool m_openerAttack; // The unit's first attack against an enemy.
         uint32 m_reactiveTimer[MAX_REACTIVE];
         ObjectGuid m_reactiveTarget[MAX_REACTIVE];
         typedef std::map<ObjectGuid /*attackerGuid*/, uint32 /*damage*/ > DamageTakenHistoryMap;
@@ -962,6 +961,11 @@ class Unit : public SpellCaster
          * Called from UpdateMeleeAttackingState if attack can't happen now.
          */
         void DelayAutoAttacks();
+        /**
+         * When a starts autoattacking. Erases the saved update diff on its swing timer
+         * and delays the offhand attack to half its attack speed
+         */
+        void FirstAttackDelay();
         /**
          * Checks that need to be done before an auto attack swing happens.
          * Target's faction is only checked for players since its done elsewhere


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
- Starting attack state on a mob right now resets your swing timer to full. This PR makes it delay by 200ms instead.
- Right now any attack while DW locks the unit from making an attack with the other weapon for 200ms. This PR removes that delay.
- Right now swing timers take longer than they should based on server tick rate. The longer the elapsed time between updates, the more lost swings will accumulate over time. This PR makes elapsed time "flow" into the upcoming swing reducing its remaining timer by as much as the swing before it was delayed.

### Proof
<!-- Link resources as proof -->
https://discord.com/channels/484741332850573317/1155578838353449141/1190423674512216194
The thread includes:

- [sheet](https://docs.google.com/spreadsheets/d/1zY2cR9HyyDcp638rGiInmxv6yMoxYddsrlGZB2wnQ4E/edit#gid=143165760) showing mainhand and offhand swings happen within as little as 017ms between each other. That proves that hits of another weapon extending the timer of the other weapon is incorrect.

- [vanilla video](https://www.youtube.com/watch?v=Tu-u-AeXpFk) showing a rogue using his opener attacks instantly with the MH, the OH attack follows in very short time, NOT a full reset which would have been 1.7 secs considering Warblade of the Hakkari swing speed. Restarting autoattacks after gouge works the same as opening from stealth: If a DW unit starts attacking a mob while both its weapons are ready, it will always swing with the MH immediately, and with the OH a short while later.

- these fight club posts [discussion1](https://discord.com/channels/383596811517952002/582317222547030021/602883081040429057) and [discussion2](https://discord.com/channels/383596811517952002/582317222547030021/605393891595780116) and [discussion3](https://discord.com/channels/383596811517952002/582317222547030021/782390729363685416) assert the existence of a delay between first MH and first OH swing, its variation from 200ms to 600ms can most likely be explained by batching.

- The non existence of some system to compensate a unit's swing timer for long update times seems highly unlikely because that would make swing speed in practice slower than it should based on the server's tick rate and that would be most apparent in lengthy fights by seeing units do less total swings than one predicts they would do by fight length (secs)/attack speed (swing per sec)= total swings
-  Generally looking at combat logs and sniff parses I haven't seen that happen. Most likely what happens is an attack could be ready at t=0, but it's not until t=100ms that a game update happens and the unit attacks. In Vmangos the next swing happens at 100ms+attackspeed, but in classic it happens at 0+attackspeed

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->

https://github.com/vmangos/core/assets/111737968/1a5fb8bd-73f1-422a-a86c-c8a0d694a3e7
First attack on a mob is always mainhand, followed by offhand in 200ms. After that, if I walk out of melee range and walk back in, the two will be synced (they still won't happen concurrently in one game update, but the offhand will get compensated on each swing for the delay that happened to it on the previous one)

https://github.com/vmangos/core/assets/111737968/0780fd01-c008-4183-b21a-4d956daf9d41
After the PR ranged autoattacks work fine. They also are affected by the compensation in lost time from long updates.


To debug the swing timers, I wrote this into the ResetAttackTimer function:
```
void Unit::ResetAttackTimer(WeaponAttackType type, bool compensateDiff/*= false*/)
{
    m_attackTimer[type] = uint32(GetAttackTime(type) * m_modAttackSpeedPct[type]) + ((compensateDiff) ? std::min(m_attackTimer[type], 0) : 0);
	Player* pPlayer = ToPlayer();
	if (pPlayer)
    {
        ChatHandler(pPlayer).PSendSysMessage("%i swing. MH %i / OH %i / Ranged %i", type, GetAttackTimer(BASE_ATTACK), GetAttackTimer(OFF_ATTACK), GetAttackTimer(RANGED_ATTACK));
    }
}
```


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
