### PR TITLE
Partybot in combat target selection AI

### DIFF
--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -960,6 +960,27 @@ void PartyBotAI::UpdateInCombatAI()
             return;
     }
 
+    Unit* pVictim = me->GetVictim();
+
+    // Swap to marked target or party leader's target
+    if (GetRole() != ROLE_HEALER)
+    {
+        if (Player* pLeader = GetPartyLeader())
+        {
+            Unit* newVictim = SelectAttackTarget(pLeader);
+
+            if (newVictim && (newVictim != pVictim))
+            {
+                if (pVictim)
+                    me->AttackStop();
+                else
+                    AttackStart(newVictim);
+
+                return;
+            }
+        }
+    }
+
     switch (me->GetClass())
     {
         case CLASS_PALADIN:


### PR DESCRIPTION
## 🍰 Pullrequest
Original Behavior:
Partybots do not swap to the party leaders target or swap to a marked target after the focusmark in game command is executed while in combat. 

Corrected Behavior:
Partybots properly target a marked target(if focusmark command is executed) or the party leaders target while in combat. Priority is marked(if focusmark command executed) - > Party leaders target(if no mark or command isn't executed).

### Proof
<!-- Link resources as proof -->
- None

### Issues
- fixes #2406

### How2Test

Summon party bots, type .partybot focusmark skull. engage an enemy.  Mark a new enemy with skull, bots will swap to it.
Summon party bots, engage an enemy, swap target(do not mark), partybots will swap to your target


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
