### PR TITLE
Add missing enchants to GM island enchant vendors

### DIFF
--- a/src/scripts/custom/custom_creatures.cpp
+++ b/src/scripts/custom/custom_creatures.cpp
@@ -561,21 +561,31 @@ enum Enchants
     WEP2H_SUPERIOR_IMPACT = 20,
     WEP2H_AGILITY,
     WEP_CRUSADER,
+    WEP_LIFESTEAL,
+    WEP_FIERY,
+    WEP_ICY,
+    WEP_DEMONSLAYING,
     WEP1H_AGILITY,
     WEP_SPELLPOWER,
     WEP_HEAL,
+    WEP2H_INT,
+    WEP2H_SPIRIT,
     OFFHAND_SPIRIT,
     OFFHAND_STAM,
     OFFHAND_FROSTRES,
+    OFFHAND_SHIELDSPIKE,
     CHEST_STATS,
+    CHEST_HEALTH,
     CLOAK_DODGE,
     CLOAK_SUB,
     CLOAK_ARMOR,
     CLOAK_AGILITY,
+    CLOAK_GREATER_RES,
     BRACER_STAM,
     BRACER_STR,
     BRACER_HEAL,
     BRACER_INT,
+    BRACER_MP5,
     GLOVES_AGI,
     GLOVES_FIRE,
     GLOVES_FROST,
@@ -630,18 +640,21 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
         {
         case EQUIPMENT_SLOT_CHEST:
             player->ADD_GOSSIP_ITEM(5, "Greater Stats",      GOSSIP_SENDER_MAIN, CHEST_STATS);
+            player->ADD_GOSSIP_ITEM(5, "Greater Health",     GOSSIP_SENDER_MAIN, CHEST_HEALTH);
             break;
         case EQUIPMENT_SLOT_BACK:
             player->ADD_GOSSIP_ITEM(5, "Agility",            GOSSIP_SENDER_MAIN, CLOAK_AGILITY);
             player->ADD_GOSSIP_ITEM(5, "Armor",              GOSSIP_SENDER_MAIN, CLOAK_ARMOR);
             player->ADD_GOSSIP_ITEM(5, "Dodge",              GOSSIP_SENDER_MAIN, CLOAK_DODGE);
             player->ADD_GOSSIP_ITEM(5, "Subtlety",           GOSSIP_SENDER_MAIN, CLOAK_SUB);
+            player->ADD_GOSSIP_ITEM(5, "Greater Resistance", GOSSIP_SENDER_MAIN, CLOAK_GREATER_RES);
         break;
         case EQUIPMENT_SLOT_WRISTS:
             player->ADD_GOSSIP_ITEM(5, "Stamina",            GOSSIP_SENDER_MAIN, BRACER_STAM);
             player->ADD_GOSSIP_ITEM(5, "Strength",           GOSSIP_SENDER_MAIN, BRACER_STR);
             player->ADD_GOSSIP_ITEM(5, "Healing",            GOSSIP_SENDER_MAIN, BRACER_HEAL);
             player->ADD_GOSSIP_ITEM(5, "Intellect",          GOSSIP_SENDER_MAIN, BRACER_INT);
+            player->ADD_GOSSIP_ITEM(5, "MP5",                GOSSIP_SENDER_MAIN, BRACER_MP5);
             break;
         case EQUIPMENT_SLOT_HANDS:
             player->ADD_GOSSIP_ITEM(5, "Agility",            GOSSIP_SENDER_MAIN, GLOVES_AGI);
@@ -659,13 +672,20 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
             player->ADD_GOSSIP_ITEM(5, "Crusader",           GOSSIP_SENDER_MAIN, WEP_CRUSADER);
             player->ADD_GOSSIP_ITEM(5, "1H Agility",         GOSSIP_SENDER_MAIN, WEP1H_AGILITY);
             player->ADD_GOSSIP_ITEM(5, "2H Agility",         GOSSIP_SENDER_MAIN, WEP2H_AGILITY);
+            player->ADD_GOSSIP_ITEM(5, "2H INT",             GOSSIP_SENDER_MAIN, WEP2H_INT);
+            player->ADD_GOSSIP_ITEM(5, "2H Spirit",          GOSSIP_SENDER_MAIN, WEP2H_SPIRIT);
             player->ADD_GOSSIP_ITEM(5, "Spellpower",         GOSSIP_SENDER_MAIN, WEP_SPELLPOWER);
             player->ADD_GOSSIP_ITEM(5, "Healing",            GOSSIP_SENDER_MAIN, WEP_HEAL);
+            player->ADD_GOSSIP_ITEM(5, "Lifesteal",          GOSSIP_SENDER_MAIN, WEP_LIFESTEAL);
+            player->ADD_GOSSIP_ITEM(5, "Fiery",              GOSSIP_SENDER_MAIN, WEP_FIERY);
+            player->ADD_GOSSIP_ITEM(5, "Icy",                GOSSIP_SENDER_MAIN, WEP_ICY);
+            player->ADD_GOSSIP_ITEM(5, "Demonslaying",       GOSSIP_SENDER_MAIN, WEP_DEMONSLAYING);
             break;
         case EQUIPMENT_SLOT_OFFHAND:
             player->ADD_GOSSIP_ITEM(5, "Spirit",             GOSSIP_SENDER_MAIN, OFFHAND_SPIRIT);
             player->ADD_GOSSIP_ITEM(5, "Stamina",            GOSSIP_SENDER_MAIN, OFFHAND_STAM);
             player->ADD_GOSSIP_ITEM(5, "Frost Resistance",   GOSSIP_SENDER_MAIN, OFFHAND_FROSTRES);
+            player->ADD_GOSSIP_ITEM(5, "Shield Spike",       GOSSIP_SENDER_MAIN, OFFHAND_SHIELDSPIKE);
             break;
         }
         player->SEND_GOSSIP_MENU(DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
@@ -678,8 +698,10 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
         {
             case WEP2H_SUPERIOR_IMPACT:
             case WEP2H_AGILITY:
+            case WEP2H_INT:
+            case WEP2H_SPIRIT:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-                if (item && (action == WEP2H_AGILITY || action == WEP2H_SUPERIOR_IMPACT))
+                if (item && (action == WEP2H_AGILITY || action == WEP2H_SUPERIOR_IMPACT || action == WEP2H_INT || action == WEP2H_SPIRIT))
                 {
                     if (item->GetProto()->SubClass != ITEM_SUBCLASS_WEAPON_AXE2 && item->GetProto()->SubClass != ITEM_SUBCLASS_WEAPON_MACE2
                         && item->GetProto()->SubClass != ITEM_SUBCLASS_WEAPON_SWORD2 && item->GetProto()->SubClass != ITEM_SUBCLASS_WEAPON_POLEARM
@@ -694,6 +716,10 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
                     id = 1896;
                 else if (action == WEP2H_AGILITY)
                     id = 2646;
+                else if (action == WEP2H_INT)
+                    id = 2568;
+                else if (action == WEP2H_SPIRIT)
+                    id = 2567;
                 break;
 
             case WEP_CRUSADER:
@@ -712,10 +738,27 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
                 id = 2505;
                 break;
+            case WEP_LIFESTEAL:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+                id = 1898;
+                break;
+            case WEP_ICY:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+                id = 1894;
+                break;
+            case WEP_FIERY:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+                id = 803;
+                break;
+            case WEP_DEMONSLAYING:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+                id = 912;
+                break;
 
             case OFFHAND_SPIRIT:
             case OFFHAND_STAM:
             case OFFHAND_FROSTRES:
+            case OFFHAND_SHIELDSPIKE:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
                 if (item && item->GetProto()->SubClass != ITEM_SUBCLASS_ARMOR_SHIELD)
                 {
@@ -729,10 +772,16 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
                     id = 926;
                 else if (action == OFFHAND_STAM)
                     id = 929;
+                else if (action == OFFHAND_SHIELDSPIKE)
+                    id = 1704;
                 break;
             case CHEST_STATS:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_CHEST);
                 id = 1891;
+                break;
+            case CHEST_HEALTH:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_CHEST);
+                id = 1892;
                 break;
             case CLOAK_DODGE:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_BACK);
@@ -750,6 +799,10 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_BACK);
                 id = 849;
                 break;
+            case CLOAK_GREATER_RES:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_BACK);
+                id = 1888;
+                break;
             case BRACER_STAM:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_WRISTS);
                 id = 1886;
@@ -765,6 +818,10 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
             case BRACER_INT:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_WRISTS);
                 id = 1883;
+                break;
+            case BRACER_MP5:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_WRISTS);
+                id = 2565;
                 break;
             case GLOVES_AGI:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_HANDS);


### PR DESCRIPTION
## 🍰 Pullrequest
Adds missing enchants to enchant vendor on GM island
Mainhand: Lifesteal, Fiery, Icy, Demonslaying, 2H INT, 2H Spirit
Offhand: Thorium Shield Spike
Body: Major Health(+100)
Bracer: MP5
Back: Greater Resistance


### Issues
- None

### How2Test
.tele gm

### Todo / Checklist

