### PR TITLE
Anubisath Defender EventAI adjustements

### DIFF
--- a/sql/migrations/20240120155120_world.sql
+++ b/sql/migrations/20240120155120_world.sql
@@ -1,0 +1,88 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20240120155120');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20240120155120');
+-- Add your query below.
+
+-- Removing unused script actions.
+DELETE FROM `creature_ai_scripts` WHERE `id` IN (1527701, 1527702, 1527703, 1527704, 1527705, 1527706, 1527707, 1527708, 1527709, 1527710, 1527711, 1527712, 1527713, 1527714, 1527715, 1527716, 1527717, 1527718, 1527719, 1527720, 1527721, 1527722, 1527723, 1527724, 1527725, 1527726, 1527727, 1527728, 1527729, 1527730, 1527731, 1527732, 1527733, 1527734, 1527735, 1527736, 1527737, 1527738, 1527739, 1527740, 1527741, 1527742, 1527743, 1527744, 1527745, 1527746, 1527747, 1527748, 1527749, 1527750, 1527751, 1527752, 1527753, 1527754, 1527755, 1527756, 1527757, 1527758, 1527759, 1527760, 1527761, 1527762, 1527763, 1527764, 1527765, 1527786, 1527787, 1527767, 1527768, 1527769, 1527770, 1527771, 1527772);
+
+-- Scripts list for Anubisath Defender
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527701;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527701, 0, 0, 46, 1, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Random Phase between 1 and 4'),
+(1527701, 0, 0, 49, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Combat Pulse');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527702;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527702, 0, 0, 15, 27630, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Drop Obsidian');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527703;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527703, 0, 0, 15, 26555, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527704;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527704, 0, 0, 15, 26555, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Shadow Storm (Phase 3+4)');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527705;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527705, 0, 0, 15, 26556, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Plague (Phase 1+3)');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527706;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527706, 0, 0, 15, 26558, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Meteor (Phase 2+4)');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527717;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527717, 0, 0, 15, 13022, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Fire and Arcane Reflect');
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527727;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527727, 0, 0, 15, 19595, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Shadow and Frost Reflect');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527718;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527718, 0, 0, 15, 25698, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Explode');
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527728;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527728, 0, 0, 15, 8269, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Enrage');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527719;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527719, 0, 0, 10, 15537, 60000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Anubisath Warrior'),
+(1527719, 0, 0, 15, 18476, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Animation');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527729;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527729, 0, 0, 10, 15538, 60000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Anubisath Swarmguard'),
+(1527729, 0, 0, 15, 18476, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Animation');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527710;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527710, 0, 0, 15, 20477, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Teleport Target');
+
+
+-- Events list for Anubisath Defender
+DELETE FROM `creature_ai_events` WHERE `creature_id`=15277;
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527701, 15277, 0, 4, 0, 100, 0, 0, 0, 0, 0, 1527701, 0, 0, 'Anubisath Defender - Aggro pulse and Phase');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527702, 15277, 0, 6, 0, 100, 0, 0, 0, 0, 0, 1527702, 0, 0, 'Anubisath Defender - Drop Obsidian');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527703, 15277, 0, 0, 24, 100, 1, 2500, 6500, 3000, 8000, 1527703, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527704, 15277, 0, 0, 6, 100, 1, 2500, 6500, 3000, 8000, 1527704, 0, 0, 'Anubisath Defender - Cast Shadow Storm (Phase 3+4)');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527705, 15277, 0, 0, 20, 100, 1, 4000, 12000, 4000, 12000, 1527705, 0, 0, 'Anubisath Defender - Cast Plague (Phase 1+3)');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527706, 15277, 0, 0, 10, 100, 1, 4000, 12000, 4000, 12000, 1527706, 0, 0, 'Anubisath Defender - Cast Meteor (Phase 2+4)');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527707, 15277, 0, 4, 0, 100, 2, 0, 0, 0, 0, 1527717, 1527727, 0, 'Anubisath Defender - Cast Spell Reflect');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527708, 15277, 0, 2, 0, 100, 2, 10, 0, 0, 0, 1527718, 1527728, 0, 'Anubisath Defender - Cast Low Hp Spell');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527709, 15277, 0, 0, 0, 100, 3, 10000, 10000, 10000, 10000, 1527719, 1527729, 0, 'Anubisath Defender - Summon Minion');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527710, 15277, 0, 9, 0, 100, 1, 60, 100, 5000, 5000, 1527710, 0, 0, 'Anubisath Defender - Teleport Target');
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20240120155120_world.sql
+++ b/sql/migrations/20240120155120_world.sql
@@ -15,7 +15,8 @@ DELETE FROM `creature_ai_scripts` WHERE `id` IN (1527701, 1527702, 1527703, 1527
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527701;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
 (1527701, 0, 0, 46, 1, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Random Phase between 1 and 4'),
-(1527701, 0, 0, 49, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Combat Pulse');
+(1527701, 0, 1, 15, 26553, 7, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Powers Trigger'),
+(1527701, 0, 2, 49, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Combat Pulse');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527702;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
@@ -23,61 +24,80 @@ INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalo
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527703;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527703, 0, 0, 15, 26554, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)');
+(1527703, 0, 0, 15, 26554, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527704;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527704, 0, 0, 15, 26555, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Shadow Storm (Phase 3+4)');
+(1527704, 0, 0, 15, 26555, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Shadow Storm (Phase 3+4)');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527705;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527705, 0, 0, 15, 26556, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Plague (Phase 1+3)');
+(1527705, 0, 0, 15, 26556, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Plague (Phase 1+3)');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527706;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527706, 0, 0, 15, 26558, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Meteor (Phase 2+4)');
+(1527706, 0, 0, 15, 26558, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Meteor (Phase 2+4)');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527717;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527717, 0, 0, 15, 13022, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Fire and Arcane Reflect');
+(1527717, 0, 0, 15, 13022, 2, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Fire and Arcane Reflect');
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527727;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527727, 0, 0, 15, 19595, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Shadow and Frost Reflect');
+(1527727, 0, 0, 15, 19595, 2, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Shadow and Frost Reflect');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527718;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527718, 0, 0, 15, 25698, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Explode');
+(1527718, 0, 0, 15, 25698, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Explode');
+
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527728;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527728, 0, 0, 15, 8269, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Enrage');
+(1527728, 0, 0, 15, 8269, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Enrage');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527719;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527719, 0, 0, 10, 15537, 60000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Anubisath Warrior'),
-(1527719, 0, 0, 15, 18476, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Animation');
+(1527719, 0, 0, 10, 15537, 60000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Anubisath Warrior');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527729;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527729, 0, 0, 10, 15538, 60000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Anubisath Swarmguard'),
-(1527729, 0, 0, 15, 18476, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Animation');
+(1527729, 0, 0, 10, 15538, 60000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Anubisath Swarmguard');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527710;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
 (1527710, 0, 0, 15, 20477, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Teleport Target');
 
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527711;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527711, 0, 0, 15, 84, 7, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Low Hp Trigger');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527712;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527712, 0, 0, 15, 18476, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Summon Minion Trigger');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527713;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527713, 0, 0, 15, 9173, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Aoe Trigger');
+
+DELETE FROM `creature_ai_scripts` WHERE `id`=1527714;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(1527714, 0, 0, 15, 14291, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Aoe Trigger');
 
 -- Events list for Anubisath Defender
 DELETE FROM `creature_ai_events` WHERE `creature_id`=15277;
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527701, 15277, 0, 4, 0, 100, 0, 0, 0, 0, 0, 1527701, 0, 0, 'Anubisath Defender - Aggro pulse and Phase');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527702, 15277, 0, 6, 0, 100, 0, 0, 0, 0, 0, 1527702, 0, 0, 'Anubisath Defender - Drop Obsidian');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527703, 15277, 0, 0, 24, 100, 1, 2500, 6500, 3000, 8000, 1527703, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527704, 15277, 0, 0, 6, 100, 1, 2500, 6500, 3000, 8000, 1527704, 0, 0, 'Anubisath Defender - Cast Shadow Storm (Phase 3+4)');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527705, 15277, 0, 0, 20, 100, 1, 4000, 12000, 4000, 12000, 1527705, 0, 0, 'Anubisath Defender - Cast Plague (Phase 1+3)');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527706, 15277, 0, 0, 10, 100, 1, 4000, 12000, 4000, 12000, 1527706, 0, 0, 'Anubisath Defender - Cast Meteor (Phase 2+4)');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527707, 15277, 0, 4, 0, 100, 2, 0, 0, 0, 0, 1527717, 1527727, 0, 'Anubisath Defender - Cast Spell Reflect');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527708, 15277, 0, 2, 0, 100, 2, 10, 0, 0, 0, 1527718, 1527728, 0, 'Anubisath Defender - Cast Low Hp Spell');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527709, 15277, 0, 0, 0, 100, 3, 10000, 10000, 10000, 10000, 1527719, 1527729, 0, 'Anubisath Defender - Summon Minion');
-INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES (1527710, 15277, 0, 9, 0, 100, 1, 60, 100, 5000, 5000, 1527710, 0, 0, 'Anubisath Defender - Teleport Target');
+INSERT INTO `creature_ai_events` (`id`, `creature_id`, `condition_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_script`, `action2_script`, `action3_script`, `comment`) VALUES
+(1527701, 15277, 0, 4, 0, 100, 0, 0, 0, 0, 0, 1527701, 0, 0, 'Anubisath Defender - Aggro pulse and Phase'),
+(1527702, 15277, 0, 6, 0, 100, 0, 0, 0, 0, 0, 1527702, 0, 0, 'Anubisath Defender - Drop Obsidian'),
+(1527703, 15277, 0, 8, 24, 100, 1, 9173, 127, 0, 0, 1527703, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)'),
+(1527704, 15277, 0, 8, 6, 100, 1, 9173, 127, 0, 0, 1527704, 0, 0, 'Anubisath Defender - Cast Shadow Storm (Phase 3+4)'),
+(1527705, 15277, 0, 36, 20, 100, 1, 14291, 127, 0, 0, 1527705, 0, 0, 'Anubisath Defender - Cast Plague (Phase 1+3)'),
+(1527706, 15277, 0, 36, 10, 100, 1, 14291, 127, 0, 0, 1527706, 0, 0, 'Anubisath Defender - Cast Meteor (Phase 2+4)'),
+(1527707, 15277, 0, 8, 0, 100, 2, 26553, 127, 0, 0, 1527717, 1527727, 0, 'Anubisath Defender - Cast Spell Reflect'),
+(1527708, 15277, 0, 8, 0, 100, 2, 84, 127, 0, 0, 1527718, 1527728, 0, 'Anubisath Defender - Cast Low Hp Spell'),
+(1527709, 15277, 0, 36, 0, 100, 3, 18476, 127, 0, 0, 1527719, 1527729, 0, 'Anubisath Defender - Summon Minion'),
+(1527710, 15277, 0, 9, 0, 100, 1, 60, 100, 5000, 5000, 1527710, 0, 0, 'Anubisath Defender - Teleport Target'),
+(1527711, 15277, 0, 2, 0, 100, 0, 10, 0, 0, 0, 1527711, 0, 0, 'Anubisath Defender - Cast Low Hp Trigger'),
+(1527712, 15277, 0, 0, 0, 100, 1, 10000, 10000, 10000, 10000, 1527712, 0, 0, 'Anubisath Defender - Summon Minion Trigger'),
+(1527713, 15277, 0, 0, 0, 100, 1, 2500, 6500, 3000, 8000, 1527713, 0, 0, 'Anubisath Defender - Cast Aoe Trigger'),
+(1527714, 15277, 0, 0, 0, 100, 1, 4000, 12000, 4000, 12000, 1527714, 0, 0, 'Anubisath Defender - Cast Targeted Trigger');
 
 
 -- End of migration.

--- a/sql/migrations/20240120155120_world.sql
+++ b/sql/migrations/20240120155120_world.sql
@@ -23,7 +23,7 @@ INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalo
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527703;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
-(1527703, 0, 0, 15, 26555, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)');
+(1527703, 0, 0, 15, 26554, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Anubisath Defender - Cast Thunderclap (Phase 1+2)');
 
 DELETE FROM `creature_ai_scripts` WHERE `id`=1527704;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -2638,7 +2638,7 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
                 case 14297:
                 case 26546:
                 case 26555:
-                    minDist = 20.0f;
+                    minDist = 25.0f;
                     break;
             }
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
- Removes the aggro and social pull Events.
- Adjusted spell timers based on sniff data.
- Simplified the script to only use 4 phases
- Implemented dropping Obsidian Shard on death
- Adjusted the range of Shadow Storm spells to 25 yards. The tooltip says 25 yards, and I haven't seen any evidence from classic discords, raid guides, wiki, videos to suggest that it should be less than that.

### Proof
<!-- Link resources as proof -->
- Proof that aggro & social pull events are not correct to classic:
https://www.youtube.com/watch?v=eWPnt_Lersc&t=1018s
https://www.youtube.com/watch?v=RF1hE_YFx4g&t=901s

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- none

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
