### PR TITLE
Update migration scripts to use UTC.

### DIFF
--- a/sql/make_migration.bat
+++ b/sql/make_migration.bat
@@ -1,4 +1,3 @@
-
 @ECHO Off
 SETLOCAL ENABLEDELAYEDEXPANSION
 
@@ -8,26 +7,26 @@ REM Get the UTC date-time string to use
 CALL :GetFormattedCurrentUTCDate UTC
 ECHO "Formatted UTC Date time : %UTC%"
 
-SET "output=%UTC%_world.sql"
+SET "output=migrations\%UTC%_world.sql"
 
-ECHO DROP PROCEDURE IF EXISTS add_migration;>> migrations/%output%
-ECHO delimiter ??>> migrations/%output%
-ECHO CREATE PROCEDURE `add_migration`()>> migrations/%output%
-ECHO BEGIN>> migrations/%output%
-ECHO DECLARE v INT DEFAULT 1;>> migrations/%output%
-ECHO SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='%UTC%');>> migrations/%output%
-ECHO IF v=0 THEN>> migrations/%output%
-ECHO INSERT INTO `migrations` VALUES ('%UTC%');>> migrations/%output%
-ECHO -- Add your query below.>> migrations/%output%
-ECHO.>> migrations/%output%
-ECHO.>> migrations/%output%
-ECHO.>> migrations/%output%
-ECHO -- End of migration.>> migrations/%output%
-ECHO END IF;>> migrations/%output%
-ECHO END??>> migrations/%output%
-ECHO delimiter ; >> migrations/%output%
-ECHO CALL add_migration();>> migrations/%output%
-ECHO DROP PROCEDURE IF EXISTS add_migration;>> migrations/%output%
+ECHO DROP PROCEDURE IF EXISTS add_migration;>> %output%
+ECHO DELIMITER ??>> %output%
+ECHO CREATE PROCEDURE `add_migration`()>> %output%
+ECHO BEGIN>> %output%
+ECHO DECLARE v INT DEFAULT 1;>> %output%
+ECHO SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='%UTC%');>> %output%
+ECHO IF v = 0 THEN>> %output%
+ECHO INSERT INTO `migrations` VALUES ('%UTC%');>> %output%
+ECHO -- Add your query below.>> %output%
+ECHO.>> %output%
+ECHO.>> %output%
+ECHO.>> %output%
+ECHO -- End of migration.>> %output%
+ECHO END IF;>> %output%
+ECHO END??>> %output%
+ECHO DELIMITER ;>> %output%
+ECHO CALL add_migration();>> %output%
+ECHO DROP PROCEDURE IF EXISTS add_migration;>> %output%
 
 REM End of the script Body
 :EndOfScriptBody

--- a/sql/make_migration.py
+++ b/sql/make_migration.py
@@ -1,26 +1,32 @@
-#Script for making new sql migrations 
-#Python3
-
 import os
 import time
 
-#Variable Declaration
+DATE = time.strftime('%Y%m%d%H%M%S', time.gmtime()) # UTC DATE
+FPATH = f"migrations/{DATE}_world.sql"
 
-debug = 0 #Debug
+sql_content = f"""DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='{DATE}');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('{DATE}');
+-- Add your query below.
 
-DATE = time.strftime('%Y%m%d%H%M%S') #DATE
-FPATH= os.path.join("migrations",DATE + "_world.sql") #File path
-
-if (debug == 1):
-    print (DATE)
-    print (FPATH)
 
 
-print("Creating new migration")
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;
+"""
 
-with open(FPATH,"w") as file:
-    if (os.path.isfile(FPATH)):
-        file.write("DROP PROCEDURE IF EXISTS add_migration;\r\ndelimiter ??\r\nCREATE PROCEDURE \`add_migration\`()\r\nBEGIN\r\nDECLARE v INT DEFAULT 1;\r\nSET v = (SELECT COUNT(*) FROM \`migrations\` WHERE \`id\`='$DATE');\r\nIF v=0 THEN\r\nINSERT INTO \`migrations\` VALUES ('$DATE');\r\n-- Add your query below.\r\n\r\n\r\n\r\n-- End of migration.\r\nEND IF;\r\nEND??\r\ndelimiter ; \r\nCALL add_migration();\r\nDROP PROCEDURE IF EXISTS add_migration;")
-        print(FPATH,"created")
-    else:
-        print ("FAILED to create file")
+try:
+    with open(FPATH, 'w') as output_file:
+        output_file.write(sql_content)
+    print(f"File created: {FPATH}")
+except Exception as e:
+    print(f"Failed to create file: {e}")


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
The bash and python migration script didn't use UTC, only the windows batch script did. This PR fixes that.

Touch_migration.sh 
- didn't use UTC date:
![mintty_ShfFaphUyh](https://github.com/vmangos/core/assets/6137576/cde019e1-9da4-4821-8941-0b6379cde079)
![mintty_cONdTAsWHN](https://github.com/vmangos/core/assets/6137576/62127897-ce39-48ba-90cb-705d3095b633)
https://man7.org/linux/man-pages/man1/date.1.html
- cleaned up and improved readability

make_migration.py
- fixed broken format:
![EmEditor_ykpLKb3PgP](https://github.com/vmangos/core/assets/6137576/a854bcb0-b18e-4e49-942e-b02a85d23c89)
- didn't use UTC
https://docs.python.org/3/library/time.html#time.strftime
https://docs.python.org/3/library/time.html#time.gmtime
- cleaned up and improved readability

make_migration.bat
- very minor changes


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
