### PR TITLE
PB usegobject command object selection is integrated.

### DIFF
--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1476,6 +1476,8 @@ bool HandlePartyBotUseGObjectHelper(Player* pTarget, GameObject* pGo)
 
 bool ChatHandler::HandlePartyBotUseGObjectCommand(char* args)
 {
+    HandleGameObjectSelectCommand(args);
+
     Player* pPlayer = GetSession()->GetPlayer();
     Player* pTarget = GetSelectedPlayer();
 


### PR DESCRIPTION
Before, you need to use two commands, the first to select an object, the second to tell the bots to use it.
Now this select functionality is integrated into the usage command.