### PR TITLE
Auto detect MariaDB dependencies

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -17,7 +17,7 @@ if( UNIX )
     "preferred path to MySQL (mysql_config)"
   )
 
-  find_program(MYSQL_CONFIG mysql_config
+  find_program(MYSQL_CONFIG NAMES mysql_config mariadb_config
     ${MYSQL_CONFIG_PREFER_PATH}
     /usr/local/mysql/bin/
     /usr/local/bin/


### PR DESCRIPTION
Look for mariadb equivalent of mysql_config

## 🍰 Pullrequest
Also look for the MariaDB version of the binary that provides the same function. On debian the binary is called `mariadb_config`. This shouldn't break exisiting workflows even when both `mysql_config` and `mariadb_config` is there.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Install Debian stable
- Install package `libmariadb-dev`
- Compile as normal

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
