### PR TITLE
Wait for database availability in workflows.

### DIFF
--- a/.github/workflows/db_check.yml
+++ b/.github/workflows/db_check.yml
@@ -25,11 +25,12 @@ jobs:
         sudo docker pull mysql
         sudo docker run --name mysqldb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:5.6 --max_allowed_packet=128M
         sudo docker start mysqldb
+        until nc -z localhost 3306 ; do sleep 5 ; echo "Waiting for database availability..." ; done
 
-    
+
     - name: Checkout update sql
       uses: actions/checkout@v2
-      
+
     - name: Checkout base sql
       run: |
         cd ${{github.workspace}}
@@ -66,11 +67,11 @@ jobs:
         docker exec mysqldb sh -c 'exec mysqldump -u root -proot realmd' > ${{github.workspace}}/dbexport/db_dump/logon.sql
         docker exec mysqldb sh -c 'exec mysqldump -u root -proot logs' > ${{github.workspace}}/dbexport/db_dump/logs.sql
         docker exec mysqldb sh -c 'exec mysqldump -u root -proot characters' > ${{github.workspace}}/dbexport/db_dump/characters.sql
-        
-        
+
+
         # cd db_dump
         # mkdir update_check_only_do_not_import
-        # cp ${{github.workspace}}/sql/migrations/world_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/world_db_updates.sql 
+        # cp ${{github.workspace}}/sql/migrations/world_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/world_db_updates.sql
         # cp ${{github.workspace}}/sql/migrations/logon_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/logon_db_updates.sql
         # cp ${{github.workspace}}/sql/migrations/logs_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/logs_db_updates.sql
         # cp ${{github.workspace}}/sql/migrations/characters_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/characters_db_updates.sql
@@ -81,7 +82,7 @@ jobs:
         docker exec mysqldb sh -c 'exec mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS characters2 DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"'
         docker exec mysqldb sh -c 'exec mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS mangos2 DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"'
         docker exec mysqldb sh -c 'exec mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS logs2 DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"'
-        
+
     - name: Import data back in to verify the dump data
       run: |
         docker exec -i mysqldb sh -c 'exec mysql -u root -proot realmd2' < ${{github.workspace}}/dbexport/db_dump/logon.sql

--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -26,11 +26,12 @@ jobs:
         sudo docker pull mysql
         sudo docker run --name mysqldb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:5.6 --max_allowed_packet=128M
         sudo docker start mysqldb
+        until nc -z localhost 3306 ; do sleep 5 ; echo "Waiting for database availability..." ; done
 
-    
+
     - name: Checkout update sql
       uses: actions/checkout@v2
-      
+
     - name: Checkout base sql
       run: |
         cd ${{github.workspace}}
@@ -67,11 +68,11 @@ jobs:
         docker exec mysqldb sh -c 'exec mysqldump -u root -proot realmd' > ${{github.workspace}}/dbexport/db_dump/logon.sql
         docker exec mysqldb sh -c 'exec mysqldump -u root -proot logs' > ${{github.workspace}}/dbexport/db_dump/logs.sql
         docker exec mysqldb sh -c 'exec mysqldump -u root -proot characters' > ${{github.workspace}}/dbexport/db_dump/characters.sql
-        
-        
+
+
         # cd db_dump
         # mkdir update_check_only_do_not_import
-        # cp ${{github.workspace}}/sql/migrations/world_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/world_db_updates.sql 
+        # cp ${{github.workspace}}/sql/migrations/world_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/world_db_updates.sql
         # cp ${{github.workspace}}/sql/migrations/logon_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/logon_db_updates.sql
         # cp ${{github.workspace}}/sql/migrations/logs_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/logs_db_updates.sql
         # cp ${{github.workspace}}/sql/migrations/characters_db_updates.sql ${{github.workspace}}/dbexport/db_dump/update_check_only_do_not_import/characters_db_updates.sql
@@ -97,7 +98,7 @@ jobs:
         docker exec mysqldb sh -c 'exec mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS characters2 DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"'
         docker exec mysqldb sh -c 'exec mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS mangos2 DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"'
         docker exec mysqldb sh -c 'exec mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS logs2 DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"'
-        
+
     - name: Import data back in to verify the dump data
       run: |
         docker exec -i mysqldb sh -c 'exec mysql -u root -proot realmd2' < ${{github.workspace}}/dbexport/db_dump/logon.sql
@@ -108,13 +109,13 @@ jobs:
     - name: Set sha short outputs
       id: vars
       run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      
+
     - name: Archive files
       run: |
         cd ${{github.workspace}}/dbexport
         7z a -tzip db-${{steps.vars.outputs.sha_short}}.zip db_dump
         7z a -tzip db-sqlite-${{steps.vars.outputs.sha_short}}.zip sqlite_dump
-          
+
     - name: Archive SQL artifact
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
## 🍰 Pullrequest
This ensures that the MySQL database is available during the GitHub workflows before trying to access it. This (hopefully) prevents failing workflows like [this one](https://github.com/vmangos/core/actions/runs/7877314892/job/21493225639).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
