### PR TITLE
[RealmMerge] Fix building on linux with gcc/g++

### DIFF
--- a/contrib/RealmMerge/CMakeLists.txt
+++ b/contrib/RealmMerge/CMakeLists.txt
@@ -33,8 +33,8 @@ add_executable(RealmMerge RealmMerge.cpp)
 SET_TARGET_PROPERTIES (RealmMerge PROPERTIES FOLDER Tools)
 target_link_libraries(RealmMerge 
                     ${ACE_LIBRARIES}
-                    framework
                     shared
+                    framework
 )
 
 if(WIN32)


### PR DESCRIPTION
Fix for `g++ (Debian 10.2.1-6) 10.2.1 20210110`

## 🍰 Pullrequest
Linker error when trying to build on Debian Linux, just an oredering issue :)

### Proof
<!-- Link resources as proof -->
```
[ 28%] Linking CXX executable RealmMerge
/usr/bin/ld: ../../src/shared/libshared.a(Log.cpp.o): in function `MaNGOS::ObjectLifeTime<Config>::ScheduleCall(void (*)())':
/home/imranh/vmangos/core/src/framework/Policies/ObjectLifeTime.h:41: undefined reference to `MaNGOS::at_exit(void (*)())'
/usr/bin/ld: ../../src/shared/libshared.a(Log.cpp.o): in function `MaNGOS::ObjectLifeTime<Log>::ScheduleCall(void (*)())':
/home/imranh/vmangos/core/src/framework/Policies/ObjectLifeTime.h:41: undefined reference to `MaNGOS::at_exit(void (*)())'
/usr/bin/ld: ../../src/shared/libshared.a(DatabaseMysql.cpp.o): in function `MaNGOS::ObjectLifeTime<Log>::ScheduleCall(void (*)())':
/home/imranh/vmangos/core/src/framework/Policies/ObjectLifeTime.h:41: undefined reference to `MaNGOS::at_exit(void (*)())'
collect2: error: ld returned 1 exit status
make[2]: *** [contrib/RealmMerge/CMakeFiles/RealmMerge.dir/build.make:110: contrib/RealmMerge/RealmMerge] Error 1
make[1]: *** [CMakeFiles/Makefile2:1021: contrib/RealmMerge/CMakeFiles/RealmMerge.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Try building using Debian and gcc

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
