### PR TITLE
[PB] Rework dispel logic.

### DIFF
--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -2253,7 +2253,14 @@ Player* CombatBotBaseAI::SelectBuffTarget(SpellEntry const* pSpellEntry) const
 
 Player* CombatBotBaseAI::SelectDispelTarget(SpellEntry const* pSpellEntry) const
 {
+    if (IsValidDispelTarget(me, pSpellEntry))
+    {
+        return me;
+    }
+
+    std::vector<Player*> pMembersHaveDebuff;
     Group* pGroup = me->GetGroup();
+    
     if (pGroup)
     {
         for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
@@ -2265,9 +2272,14 @@ Player* CombatBotBaseAI::SelectDispelTarget(SpellEntry const* pSpellEntry) const
                     IsValidDispelTarget(pMember, pSpellEntry) &&
                     me->IsWithinLOSInMap(pMember) &&
                     me->IsWithinDist(pMember, 30.0f))
-                    return pMember;
+                    pMembersHaveDebuff.push_back(pMember);
             }
         }
+    }
+
+    if (!pMembersHaveDebuff.empty())
+    {
+        return pMembersHaveDebuff[rand() % pMembersHaveDebuff.size()];
     }
 
     return nullptr;


### PR DESCRIPTION
## 🍰 Pullrequest
1. We take it off ourselves.
2. Select a random target for dispel.

### Proof
The fix is trying to remove this. 
1. The bot will dispel itself. (if we have a lot of magicians in the raid, then it removes a lot of targets at once)
2. The bot will select a random target from the list. (this should solve the queue issue)

### Issues
Now there is a problem, if there is more than 1 bot in the group with the ability to remove the debuff, then they interfere with each other. It looks like this. 
1. They choose the same goal.
2. Remove the debuff. (the first one who managed, the rest hang)