### PR TITLE
Remove statue type from totems

### DIFF
--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -753,7 +753,7 @@ int32 SpellCaster::DealHeal(Unit* pVictim, uint32 addhealth, SpellEntry const* s
 
     SpellCaster* pHealer = this;
 
-    if (IsCreature() && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
+    if (IsCreature() && ((Creature*)this)->IsTotem())
         pHealer = pUnit->GetOwner();
 
     if (IsPlayer() || pVictim->IsPlayer())
@@ -1180,8 +1180,8 @@ float SpellCaster::SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellP
 {
     Unit* pUnit = ToUnit();
 
-    // For totems get healing bonus from owner (statue isn't totem in fact)
-    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
+    // For totems get healing bonus from owner
+    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem())
         if (Unit* owner = pUnit->GetOwner())
             return owner->SpellHealingBonusDone(pVictim, spellProto, effectIndex, healamount, damagetype, stack, spell);
 
@@ -1296,8 +1296,8 @@ float SpellCaster::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellPr
 
     Unit* pUnit = ToUnit();
 
-    // For totems get damage bonus from owner (statue isn't totem in fact)
-    if (pUnit && GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
+    // For totems get damage bonus from owner
+    if (pUnit && GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem())
     {
         if (Unit* owner = pUnit->GetOwner())
             return owner->SpellDamageBonusDone(pVictim, spellProto, effectIndex, pdamage, damagetype, stack, spell);

--- a/src/game/Objects/Totem.cpp
+++ b/src/game/Objects/Totem.cpp
@@ -82,8 +82,8 @@ void Totem::Update(uint32 update_diff, uint32 time)
         UnSummon();                                         // remove self
         return;
     }
-    else
-        m_duration -= update_diff;
+
+    m_duration -= update_diff;
 }
 
 void Totem::Summon(Unit* owner)
@@ -100,16 +100,9 @@ void Totem::Summon(Unit* owner)
     if (!GetSpell())
         return;
 
-    switch (m_type)
+    if (m_type==TOTEM_PASSIVE)
     {
-        case TOTEM_PASSIVE:
-            CastSpell(this, GetSpell(), true);
-            break;
-        case TOTEM_STATUE:
-            CastSpell(GetOwner(), GetSpell(), true);
-            break;
-        default:
-            break;
+        CastSpell(this, GetSpell(), true);
     }
 }
 
@@ -177,8 +170,6 @@ void Totem::SetTypeBySummonSpell(SpellEntry const* spellProto)
         if (totemSpell->GetCastTime(this))
             m_type = TOTEM_ACTIVE;
     }
-    if (spellProto->SpellIconID == 2056)
-        m_type = TOTEM_STATUE;                              //Jewelery statue
 }
 
 bool Totem::IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex index, bool castOnSelf) const

--- a/src/game/Objects/Totem.h
+++ b/src/game/Objects/Totem.h
@@ -28,7 +28,6 @@ enum TotemType
 {
     TOTEM_PASSIVE    = 0,
     TOTEM_ACTIVE     = 1,
-    TOTEM_STATUE     = 2
 };
 
 class Totem : public Creature

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -3887,13 +3887,8 @@ void Unit::DeleteAuraHolder(SpellAuraHolder* holder)
 
 void Unit::RemoveSpellAuraHolder(SpellAuraHolder* holder, AuraRemoveMode mode)
 {
-    // Statue unsummoned at holder remove
-    Totem* statue = nullptr;
     SpellCaster* caster = holder->GetRealCaster();
     bool isChanneled = holder->IsChanneled(); // cache for after the holder is deleted
-    if (isChanneled && caster)
-        if (caster->IsCreature() && ((Creature*)caster)->IsTotem() && ((Totem*)caster)->GetTotemType() == TOTEM_STATUE)
-            statue = ((Totem*)caster);
 
     if (m_spellAuraHoldersUpdateIterator != m_spellAuraHolders.end() && m_spellAuraHoldersUpdateIterator->second == holder)
         ++m_spellAuraHoldersUpdateIterator;
@@ -3926,9 +3921,6 @@ void Unit::RemoveSpellAuraHolder(SpellAuraHolder* holder, AuraRemoveMode mode)
 
     if (mode != AURA_REMOVE_BY_DELETE)
         holder->HandleSpellSpecificBoosts(false);
-
-    if (statue)
-        statue->UnSummon();
 
     uint32 auraSpellId = holder->GetId();
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Statues were introduced with jewelcrafting in TBC - and TOTEM_STATUE is being assigned based on a spelliconid that doesn't exist in vanilla clients. Thereby a totem will never be TOTEM_STATUE with vanilla DBCs.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
