### PR TITLE
CI: Update APT package lists before installing packages.

### DIFF
--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -79,7 +79,8 @@ jobs:
 
     - name: Install SQLite dependencies
       run: |
-        sudo apt install sqlite3 mawk -y
+        sudo apt-get -qq update
+        sudo apt-get -qq install mawk sqlite3
         git clone https://github.com/dumblob/mysql2sqlite
         chmod +x ${{github.workspace}}/mysql2sqlite/mysql2sqlite
 

--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -56,8 +56,8 @@ jobs:
       #ubuntu dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get -qq install libmysql++-dev libace-dev libtbb-dev
-        sudo apt-get -qq install cmake build-essential cppcheck git make libiberty-dev openssl libssl-dev
+        sudo apt-get -qq update
+        sudo apt-get -qq install build-essential cmake cppcheck git libace-dev libiberty-dev libmysql++-dev libssl-dev libtbb-dev make openssl
       #windows dependencies
     - name: windows dependencies
       if: matrix.os == 'windows-2019'


### PR DESCRIPTION
## 🍰 Pullrequest
This should fix failing workflow runs like [this one](https://github.com/vmangos/core/actions/runs/8042515287/job/21963274775).
I've also unified the way APT is used (to always use `apt-get` instead of `apt` since `apt` is still not considered to have a stable CLI).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
