### PR TITLE
CI: Update actions.

### DIFF
--- a/.github/workflows/db_check.yml
+++ b/.github/workflows/db_check.yml
@@ -29,7 +29,7 @@ jobs:
 
 
     - name: Checkout update sql
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Checkout base sql
       run: |

--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -30,7 +30,7 @@ jobs:
 
 
     - name: Checkout update sql
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Checkout base sql
       run: |
@@ -108,7 +108,7 @@ jobs:
 
     - name: Set sha short outputs
       id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Archive files
       run: |
@@ -117,32 +117,32 @@ jobs:
         7z a -tzip db-sqlite-${{steps.vars.outputs.sha_short}}.zip sqlite_dump
 
     - name: Archive SQL artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: snapshot-db-dump
           path: "${{github.workspace}}/dbexport/db-${{steps.vars.outputs.sha_short}}.zip"
 
     - name: Archive SQLite artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: snapshot-db-sqlite-dump
           path: "${{github.workspace}}/dbexport/db-sqlite-${{steps.vars.outputs.sha_short}}.zip"
 
     - name: Download artifact snapshot-db-dump
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: snapshot-db-dump
         path: all_snapshots
 
     - name: Download artifact snapshot-db-sqlite-dump
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: snapshot-db-sqlite-dump
         path: all_snapshots
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Upload snapshot
       uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -14,14 +14,14 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - 'CONTRIBUTING.md'
-   
+
 jobs:
   build:
     runs-on: windows-2019
-    
+
     steps:
     #git checkout
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: windows dependencies
       #Sets versions for ACE/TBB
@@ -29,7 +29,7 @@ jobs:
         ACE_VERSION: 6.5.11
         ACE_VERSION2: 6_5_11
         TBB_VERSION: 2020.3
-      
+
       run: |
         #directory variables
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers
@@ -89,7 +89,7 @@ jobs:
 
           7z a -tzip ${{env.ARCHIVE_FILENAME}} Release
     - name: Archive this artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: snapshot-devbuild
           path: "${{github.workspace}}/bin/${{env.ARCHIVE_FILENAME}}"
@@ -132,20 +132,20 @@ jobs:
 
           7z a -tzip ${{env.ARCHIVE_FILENAME}} Release
     - name: Archive this artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: snapshot-devbuild
           path: "${{github.workspace}}/bin/${{env.ARCHIVE_FILENAME}}"
 
     - name: Download artifact snapshot-Release
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: snapshot-devbuild
         path: all_snapshots
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Upload snapshot
       uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
 
     #git checkout
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     #before install dependencies
     - name: ubuntu dependencies


### PR DESCRIPTION
## 🍰 Pullrequest
This updates the used actions to their latest versions. ~~This is especially important for the artifact actions, as older versions will [no longer work after June 30th 2024](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).~~ __EDIT:__ I might have misread and the _removal_ only affects GitHub Connect for now; regardless, they are getting deprecated and will likely also be removed here (non-enterprise) at some point, so it's good to get the update out of the way.

In addition, I've replaced the `set-output` according to [this article](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) as that will also be removed at some point in the future.

The PR also gets rid of some of the Node.js deprecations notices (marvinpinto/action-automatic-releases will have to be updated to get rid of the rest of them, or we switch to a different action for that step).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
