### PR TITLE
CI: Merge artifacts together to fix not being able to use the same name.

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Archive this artefact
       uses: actions/upload-artifact@v4
       with:
-          name: snapshot-devbuild
+          name: snapshot-devbuild-without-anticheat
           path: "${{github.workspace}}/bin/${{env.ARCHIVE_FILENAME}}"
 
     #build with anticheat and install
@@ -134,13 +134,14 @@ jobs:
     - name: Archive this artefact
       uses: actions/upload-artifact@v4
       with:
-          name: snapshot-devbuild
+          name: snapshot-devbuild-with-anticheat
           path: "${{github.workspace}}/bin/${{env.ARCHIVE_FILENAME}}"
 
     - name: Download artifact snapshot-Release
       uses: actions/download-artifact@v4
       with:
-        name: snapshot-devbuild
+        pattern: snapshot-devbuild-*
+        merge-multiple: true
         path: all_snapshots
 
     - name: Get current date


### PR DESCRIPTION
## 🍰 Pullrequest
I had an oversight in #2524; with actions/upload-artifact@v4 it's apparently no longer possible to automatically merge artifacts together using the same name, which is why [this run](https://github.com/vmangos/core/actions/runs/8050741348/job/21987028834) failed.

I missed that mistake because I thought the run in my fork failed due to a different issue that wouldn't affect the main repository here.

This should hopefully fix that (according to [this migration guide](https://github.com/actions/download-artifact/blob/v4/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact)), but if not, a quick fix would be reverting #2524 for now.

Sorry for the trouble.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
