### PR TITLE
CI: Replace automatic release action with maintained version.

### DIFF
--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -146,7 +146,7 @@ jobs:
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Upload snapshot
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: "crowbarmaster/GH-Automatic-Releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "db_latest"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -149,7 +149,7 @@ jobs:
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Upload snapshot
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: "crowbarmaster/GH-Automatic-Releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"


### PR DESCRIPTION
## 🍰 Pullrequest
This replaces [marvinpinto/action-automatic-releases](https://github.com/marvinpinto/action-automatic-releases) with a [maintained fork](https://github.com/crowbarmaster/GH-Automatic-Releases) of it since the original hasn't been updated since 2022 and will stop working once GitHub no longer allows the usage of Node.js 12 and 16 (which are already deprecated) in actions.

This is a simple drop-in replacement and should require no further changes.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
