### PR TITLE
[linux] use gnu readline for linux console cli

### DIFF
--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -57,7 +57,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install build-essential cmake cppcheck git libace-dev libiberty-dev libmysql++-dev libssl-dev libtbb-dev make openssl
+        sudo apt-get -qq install build-essential cmake cppcheck git libace-dev libiberty-dev libmysql++-dev libssl-dev libtbb-dev make openssl libreadline-dev
       #windows dependencies
     - name: windows dependencies
       if: matrix.os == 'windows-2019'

--- a/src/mangosd/CMakeLists.txt
+++ b/src/mangosd/CMakeLists.txt
@@ -147,6 +147,7 @@ if(UNIX)
     ${OPENSSL_LIBRARIES}
     ${OPENSSL_EXTRA_LIBRARIES}
     ${ZLIB_LIBRARIES}
+    readline
   )
 endif()
 

--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -29,6 +29,10 @@
 #include "Util.h"
 #include "CliRunnable.h"
 #include "Database/DatabaseEnv.h"
+#ifdef linux
+#include "readline/readline.h"
+#include "readline/history.h"
+#endif
 
 void utf8print(void* /*arg*/, const char* str)
 {
@@ -55,24 +59,28 @@ void utf8print(void* /*arg*/, const char* str)
 
 void commandFinished(void*, bool /*sucess*/)
 {
+#ifdef WIN32
     printf("mangos>");
+#endif
     fflush(stdout);
+    #ifdef linux
+    rl_on_new_line();
+    #endif
 }
 
 // @}
 
 #ifdef linux
-// Non-blocking keypress detector, when return pressed, return 1, else always return 0
-int kb_hit_return()
+int checkStopped()
 {
-    struct timeval tv;
-    fd_set fds;
-    tv.tv_sec = 0;
-    tv.tv_usec = 0;
-    FD_ZERO(&fds);
-    FD_SET(STDIN_FILENO, &fds);
-    select(STDIN_FILENO+1, &fds, nullptr, nullptr, &tv);
-    return FD_ISSET(STDIN_FILENO, &fds);
+    if (World::IsStopped())
+    {
+        rl_clear_message();
+        rl_done = 1;
+        rl_free_line_state();
+        rl_cleanup_after_signal();
+    }
+    return 0;
 }
 #endif
 
@@ -90,75 +98,52 @@ void CliRunnable::operator()()
 
     // print this here the first time
     // later it will be printed after command queue updates
+    #ifdef WIN32
     printf("\nmangos>");
+    #endif
 
     // As long as the World is running (no World::m_stopEvent), get the command line and handle it
     while (!World::IsStopped())
     {
         fflush(stdout);
-        #ifdef linux
-        while (!kb_hit_return() && !World::IsStopped())
-            // With this, we limit CLI to 10commands/second
-            usleep(100);
-        if (World::IsStopped())
-            break;
-        #endif
 
-#ifndef WIN32
-
-        int retval;
-        do
-        {
-            fd_set rfds;
-            struct timeval tv;
-            tv.tv_sec = 1;
-            tv.tv_usec = 0;
-
-            FD_ZERO(&rfds);
-            FD_SET(0, &rfds);
-
-            retval = select(1, &rfds, nullptr, nullptr, &tv);
-        } while (!retval);
-
-        if (retval == -1)
-        {
-            World::StopNow(SHUTDOWN_EXIT_CODE);
-            break;
-        }
-#endif
-
+        #ifdef WIN32
         char *command_str = fgets(commandbuf,sizeof(commandbuf),stdin);
+        #else
+        rl_event_hook = &checkStopped;
+        //TDO: tab completion
+        rl_bind_key ('\t', rl_insert);
+        char *command_str = readline("vmangos>");
+        // don't save empty commands
+        if (command_str && *command_str)
+            add_history(command_str);
+        #endif
         if (command_str != nullptr)
         {
             for(int x=0;command_str[x];x++)
                 if(command_str[x]=='\r'||command_str[x]=='\n')
-            {
-                command_str[x]=0;
-                break;
-            }
-
+                {
+                    command_str[x]=0;
+                    break;
+                }
 
             if(!*command_str)
             {
+                #ifdef WIN32
                 printf("mangos>");
+                #endif
                 continue;
             }
 
             std::string command;
             if(!consoleToUtf8(command_str,command))         // convert from console encoding to utf8
             {
+                #ifdef WIN32
                 printf("mangos>");
+                #endif
                 continue;
             }
-
             sWorld.QueueCliCommand(new CliCommandHolder(0, SEC_CONSOLE, nullptr, command.c_str(), &utf8print, &commandFinished));
         }
-        else if (feof(stdin))
-        {
-            World::StopNow(SHUTDOWN_EXIT_CODE);
-        }
     }
-
-    // End the database thread
-    WorldDatabase.ThreadEnd();                                  // free mySQL thread resources
 }

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -450,9 +450,12 @@ int Master::Run()
         b[3].Event.KeyEvent.wRepeatCount = 1;
         DWORD numb;
         WriteConsoleInput(hStdIn, b, 4, &numb);
-#else
-        fclose(stdin);
 #endif
+        World::StopNow(SHUTDOWN_EXIT_CODE);
+        // End the database thread
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Stopping WorldDatabase thread...");
+        WorldDatabase.ThreadEnd(); // free mySQL thread resources
+
         if (cliThread->joinable())
             cliThread->join();
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Use GNU Readline to do CLI input on Linux. Lets you have a command history and edit commands inline. This also opens up tab completion that can be implemented at some point.

Windows users still get the old way of doing input via fgets reading stdin...

I moved some of the world stopping stuff out of the CLI files too and into the main function that creates and destroys it all.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Compile and build on linux (you'll need the deb/ubuntu package `libreadline-dev`)
- Make sure `Console.Enable` is enabled in mangosd.conf and try some commands! Use the arrow keys on your keyboard :)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->

- [x] Test on windows (i'll need someone else to do the windows building testing please)
