### PR TITLE
CI: Determine date using dedicated action.

### DIFF
--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -143,7 +143,9 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      uses: Kaven-Universe/github-action-current-date-time@v1
+      with:
+        format: "YYYY-MM-DD"
 
     - name: Upload snapshot
       uses: "crowbarmaster/GH-Automatic-Releases@latest"
@@ -151,5 +153,5 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "db_latest"
         prerelease: true
-        title: "Development DB Dump(${{ steps.date.outputs.date }})"
+        title: "Development DB Dump(${{ steps.date.outputs.time }})"
         files: all_snapshots

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -146,7 +146,9 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      uses: Kaven-Universe/github-action-current-date-time@v1
+      with:
+        format: "YYYY-MM-DD"
 
     - name: Upload snapshot
       uses: "crowbarmaster/GH-Automatic-Releases@latest"
@@ -154,5 +156,5 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "Development Build(${{ steps.date.outputs.date }})"
+        title: "Development Build(${{ steps.date.outputs.time }})"
         files: all_snapshots


### PR DESCRIPTION
## 🍰 Pullrequest
In #2524 I already replaced the deprecated `set-output` commands; however, I only now realized that the _Windows Development Release_ workflow is using PowerShell which requires a different syntax, meaning the date is now missing from the release title:
<img width="573" alt="image" src="https://github.com/vmangos/core/assets/80664890/0e2ebb66-7aab-4d7f-90aa-c1f99b2f49cc">

This PR makes it so that a [dedicated action](https://github.com/Kaven-Universe/github-action-current-date-time) for determining the date is used instead (which I think is preferable to having two different commands to determine the date based on what shell is used).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
