### PR TITLE
Remove scripts for patches where content is not available.

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -424,6 +424,22 @@ set (game_SRCS
 
 )
 
+# Retrieve the value of SUPPORTED_CLIENT_BUILD from the CMake cache
+set(SUPPORTED_CLIENT_BUILD "${SUPPORTED_CLIENT_BUILD}" CACHE STRING "Client version the core will support")
+
+# Extract major patch
+string(REGEX MATCH "1_([0-9]+)_" PATCH_NUMBER "${SUPPORTED_CLIENT_BUILD}")
+
+set(PATCH_NUMBER ${CMAKE_MATCH_1})
+
+# Remove Arathi Basin script if the client build is below patch 1.7
+if(${PATCH_NUMBER} LESS 7)
+    list(REMOVE_ITEM game_SRCS
+    Battlegrounds/BattleGroundAB.h
+    Battlegrounds/BattleGroundAB.cpp
+)
+endif()
+
 if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   list(APPEND game_SRCS
       pchdef.cpp

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -1157,7 +1157,7 @@ ChatCommand * ChatHandler::getCommandTable()
         { "remove",             SEC_BASIC_ADMIN,    false, &ChatHandler::HandleGoldRemoval,               "", nullptr },
         { nullptr,              0,                  false, nullptr,                                       "", nullptr }
     };
-
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
     static ChatCommand warEffortCommandTable[] =
     {
         { "info",           SEC_DEVELOPER,    true,  &ChatHandler::HandleWarEffortInfoCommand,         "", nullptr },
@@ -1167,7 +1167,7 @@ ChatCommand * ChatHandler::getCommandTable()
         { "setresource",    SEC_DEVELOPER,    true,  &ChatHandler::HandleWarEffortSetResource,         "", nullptr },
         { nullptr,          0,                false, nullptr,                                          "", nullptr }
     };
-
+#endif
     static ChatCommand commandTable[] =
     {
         { "account",        SEC_PLAYER,         true, nullptr,                                         "", accountCommandTable  },
@@ -1298,7 +1298,9 @@ ChatCommand * ChatHandler::getCommandTable()
         { "spamer",         SEC_MODERATOR,      true, nullptr,                                         "", spamerCommandTable },
         { "antispam",       SEC_TICKETMASTER,   true, nullptr,                                         "", AntiSpamCommandTable },
         { "gold",           SEC_BASIC_ADMIN,    true, nullptr,                                         "", goldCommandTable },
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
         { "wareffort",      SEC_DEVELOPER,      true, nullptr,                                         "", warEffortCommandTable },
+#endif
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };
 

--- a/src/game/HardcodedEvents.cpp
+++ b/src/game/HardcodedEvents.cpp
@@ -155,6 +155,7 @@ void ElementalInvasion::ResetThings()
     }
 }
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_8_4
 /*
 * Dragons of Nightmare
 */
@@ -318,7 +319,9 @@ void DragonsOfNightmare::PermutateDragons()
     sObjectMgr.SetSavedVariable(VAR_PERM_3, permutation[2], true);
     sObjectMgr.SetSavedVariable(VAR_PERM_4, permutation[3], true);
 }
+#endif
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
 /*
 * Darkmoon Faire
 */
@@ -382,7 +385,9 @@ DarkmoonState DarkmoonFaire::GetDarkmoonState()
 
     return DARKMOON_NONE;
 }
+#endif
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_8_4
 /*
  * Fireworks Show
  */
@@ -489,6 +494,12 @@ bool ToastingGoblets::ShouldEnable() const
 
     return timeinfo->tm_min >= 10 && timeinfo->tm_min <= 20;
 }
+#endif
+
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_11_2
+/*
+* Scourge Invasion
+*/
 
 ScourgeInvasionEvent::ScourgeInvasionEvent()
     :WorldEvent(GAME_EVENT_SCOURGE_INVASION),
@@ -1251,7 +1262,9 @@ void ScourgeInvasionEvent::UpdateWorldState()
         pl->SendUpdateWorldState(WS_SI_WINTERSPRING_REMAINING, REMAINING_WINTERSPRING);
     }
 }
+#endif
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
 /*
 world_event_wareffort
 The Gates of Ahn'Qiraj War Effort. Automatic transition from collection through
@@ -1668,19 +1681,27 @@ void WarEffortEvent::UpdateHiveColossusEvents()
             sGameEventMgr.StartEvent(event, true);
     }
 }
-
 /*
 *
 */
+#endif
 
 void GameEventMgr::LoadHardcodedEvents(HardcodedEventList& eventList)
 {
     auto invasion = new ElementalInvasion();
-    auto nightmare = new DragonsOfNightmare();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_2
     auto darkmoon = new DarkmoonFaire();
+    eventList = { invasion, darkmoon };
+#elif SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_8_4
+    auto nightmare = new DragonsOfNightmare();
     auto fireworks = new FireworksShow();
     auto goblets = new ToastingGoblets();
-    auto scourge_invasion = new ScourgeInvasionEvent();
+    eventList = { invasion, nightmare, darkmoon, fireworks, goblets };
+#elif SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
     auto war_effort = new WarEffortEvent();
-    eventList = { invasion, nightmare, darkmoon, fireworks, goblets, scourge_invasion, war_effort };
+    eventList = { invasion, nightmare, darkmoon, fireworks, goblets, war_effort };
+#else
+    auto scourge_invasion = new ScourgeInvasionEvent();
+    eventList = { invasion, nightmare, darkmoon, fireworks, goblets, war_effort, scourge_invasion };
+#endif
 }

--- a/src/game/HardcodedEvents.cpp
+++ b/src/game/HardcodedEvents.cpp
@@ -1688,20 +1688,23 @@ void WarEffortEvent::UpdateHiveColossusEvents()
 
 void GameEventMgr::LoadHardcodedEvents(HardcodedEventList& eventList)
 {
-    auto invasion = new ElementalInvasion();
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_2
-    auto darkmoon = new DarkmoonFaire();
-    eventList = { invasion, darkmoon };
-#elif SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_8_4
-    auto nightmare = new DragonsOfNightmare();
-    auto fireworks = new FireworksShow();
-    auto goblets = new ToastingGoblets();
-    eventList = { invasion, nightmare, darkmoon, fireworks, goblets };
-#elif SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
-    auto war_effort = new WarEffortEvent();
-    eventList = { invasion, nightmare, darkmoon, fireworks, goblets, war_effort };
-#else
-    auto scourge_invasion = new ScourgeInvasionEvent();
-    eventList = { invasion, nightmare, darkmoon, fireworks, goblets, war_effort, scourge_invasion };
+    eventList.emplace_back(new ElementalInvasion());
+
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+    eventList.emplace_back(new DarkmoonFaire());
+#endif
+
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_8_4
+    eventList.emplace_back(new DragonsOfNightmare());
+    eventList.emplace_back(new FireworksShow());
+    eventList.emplace_back(new ToastingGoblets());
+#endif
+
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
+    eventList.emplace_back(new WarEffortEvent());
+#endif
+
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_11_2
+    eventList.emplace_back(new ScourgeInvasionEvent());
 #endif
 }

--- a/src/game/HardcodedEvents.h
+++ b/src/game/HardcodedEvents.h
@@ -298,6 +298,8 @@ enum WarEffortEnums
     WAR_EFFORT_REGAL_REWARD                 = 0x04
 };
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
+
 struct WarEffortEvent : WorldEvent
 {
     WarEffortEvent();
@@ -324,3 +326,4 @@ private:
     void DisableAndStopEvent(uint16 event_id);
     void UpdateHiveColossusEvents();
 };
+#endif

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -8715,12 +8715,13 @@ void Player::SendInitWorldStates(uint32 zoneid) const
             break;
     }
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
     // Ahn'Qiraj War Effort
     if (sGameEventMgr.IsActiveEvent(EVENT_WAR_EFFORT))
     {
         count += BuildWarEffortWorldStates(data);
     }
-
+#endif
     data << uint32(0) << uint32(0);     // [-ZERO] Add terminator to prevent repeating audio bug.
     data.put<uint16>(count_pos, count); // set actual world state amount
     GetSession()->SendPacket(&data);

--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -877,7 +877,6 @@ enum HolidayIds
     HOLIDAY_BREWFEST                 = 372,
     HOLIDAY_DARKMOON_FAIRE_ELWYNN    = 374,
     HOLIDAY_DARKMOON_FAIRE_THUNDER   = 375,
-    HOLIDAY_DARKMOON_FAIRE_SHATTRATH = 376,
 };
 
 // Values based on QuestSort.dbc

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -293,7 +293,7 @@ if(${PATCH_NUMBER} LESS 11)
 )
 endif()
 
-# Remove Ahn'Qiraj scripts if the client build is below patch 1.9
+# Remove Ahn'Qiraj and Omen scripts if the client build is below patch 1.9
 if(${PATCH_NUMBER} LESS 9)
     list(REMOVE_ITEM SCRIPTS_SRCS
     kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
@@ -317,6 +317,10 @@ if(${PATCH_NUMBER} LESS 9)
     kalimdor/silithus/temple_of_ahnqiraj/boss_viscidus.cpp
     kalimdor/silithus/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
     kalimdor/silithus/temple_of_ahnqiraj/mob_anubisath_sentinel.cpp
+    world/world_event_wareffort.cpp
+    world/world_event_wareffort.h
+    kalimdor/moonglade/boss_omen.h
+    kalimdor/moonglade/boss_omen.cpp
     )
 endif()
 

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -260,6 +260,118 @@ set (SCRIPTS_SRCS
 
 )
 
+# Retrieve the value of SUPPORTED_CLIENT_BUILD from the CMake cache
+set(SUPPORTED_CLIENT_BUILD "${SUPPORTED_CLIENT_BUILD}" CACHE STRING "Client version the core will support")
+
+# Extract major patch
+string(REGEX MATCH "1_([0-9]+)_" PATCH_NUMBER "${SUPPORTED_CLIENT_BUILD}")
+
+set(PATCH_NUMBER ${CMAKE_MATCH_1})
+
+# Remove Naxxramas scripts if the client build is below patch 1.11
+if(${PATCH_NUMBER} LESS 11)
+    list(REMOVE_ITEM SCRIPTS_SRCS
+    eastern_kingdoms/eastern_plaguelands/naxxramas/naxxramas.h
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_anubrekhan.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_faerlina.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_four_horsemen.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_gluth.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_gothik.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_grobbulus.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_heigan.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_loatheb.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_maexxna.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_noth.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_patchwerk.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_razuvious.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_sapphiron.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/boss_thaddius.cpp
+    eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
+    world/scourge_invasion.cpp
+    world/scourge_invasion.h
+)
+endif()
+
+# Remove Ahn'Qiraj scripts if the client build is below patch 1.9
+if(${PATCH_NUMBER} LESS 9)
+    list(REMOVE_ITEM SCRIPTS_SRCS
+    kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
+    kalimdor/silithus/temple_of_ahnqiraj/temple_of_ahnqiraj.h
+    kalimdor/silithus/ruins_of_ahnqiraj/boss_ayamiss.cpp
+    kalimdor/silithus/ruins_of_ahnqiraj/boss_buru.cpp
+    kalimdor/silithus/ruins_of_ahnqiraj/boss_kurinnaxx.cpp
+    kalimdor/silithus/ruins_of_ahnqiraj/boss_moam.cpp
+    kalimdor/silithus/ruins_of_ahnqiraj/boss_ossirian.cpp
+    kalimdor/silithus/ruins_of_ahnqiraj/instance_ruins_of_ahnqiraj.cpp
+    kalimdor/silithus/ruins_of_ahnqiraj/npc_sandstalker.cpp
+    kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_bug_trio.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_cthun.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_fankriss.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_huhuran.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_ouro.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_sartura.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_twinemperors.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/boss_viscidus.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
+    kalimdor/silithus/temple_of_ahnqiraj/mob_anubisath_sentinel.cpp
+    )
+endif()
+
+# Remove Dragons of Nightmare scripts if the client build is below patch 1.8
+if(${PATCH_NUMBER} LESS 8)
+    list(REMOVE_ITEM SCRIPTS_SRCS
+    world/dragons_of_nightmare/boss_dragon_of_nightmare.h
+    world/dragons_of_nightmare/boss_dragon_of_nightmare.cpp
+    world/dragons_of_nightmare/boss_emeriss.cpp
+    world/dragons_of_nightmare/boss_lethon.cpp
+    world/dragons_of_nightmare/boss_taerar.cpp
+    world/dragons_of_nightmare/boss_ysondre.cpp
+    )
+endif()
+
+# Remove Zul'Gurub scripts if the client build is below patch 1.7
+if(${PATCH_NUMBER} LESS 7)
+    list(REMOVE_ITEM SCRIPTS_SRCS
+    eastern_kingdoms/stranglethorn_vale/zulgurub/zulgurub.h
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_arlokk.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_gahzranka.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_grilek.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_hakkar.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_hazzarah.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_jeklik.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_jindo.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_mandokir.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_marli.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_renataki.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_thekal.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_venoxis.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/boss_wushoolay.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/instance_zulgurub.cpp
+    eastern_kingdoms/stranglethorn_vale/zulgurub/zulgurub_trash.cpp
+    )
+endif()
+
+# Remove Blackwing scripts if the client build is below patch 1.6
+if(${PATCH_NUMBER} LESS 6)
+    list(REMOVE_ITEM SCRIPTS_SRCS
+    eastern_kingdoms/burning_steppes/blackwing_lair/blackwing_lair.h
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_broodlord_lashlayer.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_chromaggus.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_ebonroc.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_firemaw.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_flamegor.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_razorgore.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/boss_victor_nefarius.cpp
+    eastern_kingdoms/burning_steppes/blackwing_lair/instance_blackwing_lair.cpp
+    )
+endif()
+
+
 if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   list(APPEND SCRIPTS_SRCS
         PrecompiledHeaders/scriptPCH.cpp

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -371,7 +371,6 @@ if(${PATCH_NUMBER} LESS 6)
     )
 endif()
 
-
 if((${CMAKE_VERSION} VERSION_LESS "3.16") OR USE_PCH_OLD)
   list(APPEND SCRIPTS_SRCS
         PrecompiledHeaders/scriptPCH.cpp

--- a/src/scripts/ScriptLoader.cpp
+++ b/src/scripts/ScriptLoader.cpp
@@ -168,7 +168,6 @@ void AddSC_boss_venoxis();
 void AddSC_instance_zulgurub();
 void AddSC_zg_trash();
 #endif
-void AddSC_boss_omen();
 
 //void AddSC_alterac_mountains();
 void AddSC_arathi_highlands();
@@ -223,6 +222,7 @@ void AddSC_boss_skeram();
 void AddSC_boss_twinemperors();
 void AddSC_mob_anubisath_sentinel();
 void AddSC_instance_temple_of_ahnqiraj();
+void AddSC_boss_omen();
 #endif
 void AddSC_instance_wailing_caverns();               //Wailing caverns
 void AddSC_wailing_caverns();
@@ -248,7 +248,9 @@ void AddSC_the_barrens();
 void AddSC_thousand_needles();
 void AddSC_ungoro_crater();
 void AddSC_winterspring();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
 void AddSC_war_effort();
+#endif
 
 void AddSC_npc_j_eevee();                            // J'Eevee, the Imp in a Jar
 
@@ -292,7 +294,9 @@ void AddScripts()
     AddSC_scourge_invasion();
 #endif
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
     AddSC_war_effort();
+#endif
 
     //eastern kingdoms
     AddSC_blackrock_depths();                               //blackrock_depths
@@ -417,7 +421,6 @@ void AddScripts()
     AddSC_instance_zulgurub();
     AddSC_zg_trash();
 #endif
-    AddSC_boss_omen();
 
     //AddSC_alterac_mountains();
     AddSC_arathi_highlands();
@@ -472,6 +475,7 @@ void AddScripts()
     AddSC_boss_twinemperors();
     AddSC_mob_anubisath_sentinel();
     AddSC_instance_temple_of_ahnqiraj();
+    AddSC_boss_omen();
 #endif
     AddSC_wailing_caverns();                               //Wailing caverns
     AddSC_instance_wailing_caverns();

--- a/src/scripts/ScriptLoader.cpp
+++ b/src/scripts/ScriptLoader.cpp
@@ -32,12 +32,16 @@ void AddSC_npc_king_gordok();
 
 //world
 void AddSC_areatrigger_scripts();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_8_4
 void AddSC_dragons_of_nightmare();
+#endif
 void AddSC_go_scripts();
 void AddSC_event_fireworks();
 void AddSC_npcs_special();
 void AddSC_Totems();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_11_2
 void AddSC_scourge_invasion();
+#endif
 
 //eastern kingdoms
 void AddSC_instance_blackrock_spire();
@@ -59,6 +63,7 @@ void AddSC_boss_overlordwyrmthalak();
 void AddSC_boss_shadowvosh();
 void AddSC_boss_thebeast();
 void AddSC_boss_warmastervoone();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
 void AddSC_boss_razorgore();                         //blackwing_lair
 void AddSC_boss_vael();
 void AddSC_boss_broodlord();
@@ -69,6 +74,7 @@ void AddSC_boss_chromaggus();
 void AddSC_boss_nefarian();
 void AddSC_boss_victor_nefarius();
 void AddSC_instance_blackwing_lair();
+#endif
 
 void AddSC_deadmines();                              //deadmines
 void AddSC_instance_deadmines();
@@ -90,6 +96,7 @@ void AddSC_boss_majordomo();
 void AddSC_boss_ragnaros();
 void AddSC_instance_molten_core();
 void AddSC_molten_core();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_11_2
 void AddSC_boss_anubrekhan();                        //naxxramas
 void AddSC_boss_four_horsemen();
 void AddSC_boss_faerlina();
@@ -106,6 +113,7 @@ void AddSC_boss_thaddius();
 void AddSC_boss_razuvious();
 void AddSC_boss_sapphiron();
 void AddSC_instance_naxxramas();
+#endif
 void AddSC_boss_arcanist_doan();                     //scarlet_monastery
 //void AddSC_boss_azshir_the_sleepless();
 void AddSC_boss_herod();
@@ -143,6 +151,7 @@ void AddSC_boss_ironaya();                           //uldaman
 void AddSC_instance_uldaman();                       //uldaman
 void AddSC_uldaman();                                //uldaman
 void AddSC_boss_archaedas();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_7_1
 void AddSC_boss_arlokk();                            //zulgurub
 void AddSC_boss_gahzranka();
 //void AddSC_boss_grilek();
@@ -152,13 +161,13 @@ void AddSC_boss_jeklik();
 void AddSC_boss_jindo();
 void AddSC_boss_mandokir();
 void AddSC_boss_marli();
-void AddSC_boss_ouro();
 void AddSC_boss_renataki();
 void AddSC_boss_thekal();
 void AddSC_boss_venoxis();
 //void AddSC_boss_wushoolay();
 void AddSC_instance_zulgurub();
 void AddSC_zg_trash();
+#endif
 void AddSC_boss_omen();
 
 //void AddSC_alterac_mountains();
@@ -195,6 +204,7 @@ void AddSC_razorfen_downs();
 void AddSC_razorfen_kraul();                         //razorfen_kraul
 void AddSC_instance_razorfen_kraul();
 void AddSC_instance_razorfen_downs();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
 void AddSC_boss_ayamiss();                           //ruins_of_ahnqiraj
 void AddSC_boss_buru();
 void AddSC_boss_kurinnaxx();
@@ -207,11 +217,13 @@ void AddSC_boss_viscidus();
 void AddSC_boss_fankriss();
 void AddSC_boss_huhuran();
 void AddSC_bug_trio();
+void AddSC_boss_ouro();
 void AddSC_boss_sartura();
 void AddSC_boss_skeram();
 void AddSC_boss_twinemperors();
 void AddSC_mob_anubisath_sentinel();
 void AddSC_instance_temple_of_ahnqiraj();
+#endif
 void AddSC_instance_wailing_caverns();               //Wailing caverns
 void AddSC_wailing_caverns();
 void AddSC_zulfarrak();                              //zulfarrak
@@ -269,12 +281,16 @@ void AddScripts()
 
     //world
     AddSC_areatrigger_scripts();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_8_4
     AddSC_dragons_of_nightmare();
+#endif
     AddSC_go_scripts();
     AddSC_event_fireworks();
     AddSC_npcs_special();
     AddSC_Totems();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_11_2
     AddSC_scourge_invasion();
+#endif
 
     AddSC_war_effort();
 
@@ -299,6 +315,7 @@ void AddScripts()
     AddSC_boss_warmastervoone();
 
     AddSC_instance_blackrock_spire();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     AddSC_boss_razorgore();                                 //blackwing_lair
     AddSC_boss_vael();
     AddSC_boss_broodlord();
@@ -309,6 +326,7 @@ void AddScripts()
     AddSC_boss_nefarian();
     AddSC_boss_victor_nefarius();
     AddSC_instance_blackwing_lair();
+#endif
     AddSC_deadmines();                                      //deadmines
     AddSC_instance_deadmines();
     AddSC_boss_mr_smite();
@@ -327,6 +345,7 @@ void AddScripts()
     AddSC_boss_ragnaros();
     AddSC_instance_molten_core();
     AddSC_molten_core();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_11_2
     AddSC_boss_anubrekhan();                                //naxxramas
     AddSC_boss_four_horsemen();
     AddSC_boss_faerlina();
@@ -343,6 +362,7 @@ void AddScripts()
     AddSC_boss_razuvious();
     AddSC_boss_sapphiron();
     AddSC_instance_naxxramas();
+#endif
     AddSC_boss_arcanist_doan();                             //scarlet_monastery
     //AddSC_boss_azshir_the_sleepless();
     AddSC_boss_herod();
@@ -380,6 +400,7 @@ void AddScripts()
     AddSC_boss_ironaya();                                   //uldaman
     AddSC_uldaman();
     AddSC_boss_archaedas();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_7_1
     AddSC_boss_arlokk();                                    //zulgurub
     AddSC_boss_gahzranka();
     //AddSC_boss_grilek();
@@ -389,14 +410,15 @@ void AddScripts()
     AddSC_boss_jindo();
     AddSC_boss_mandokir();
     AddSC_boss_marli();
-    AddSC_boss_ouro();
     AddSC_boss_renataki();
     AddSC_boss_thekal();
     AddSC_boss_venoxis();
     //AddSC_boss_wushoolay();
     AddSC_instance_zulgurub();
     AddSC_zg_trash();
+#endif
     AddSC_boss_omen();
+
 
     //AddSC_alterac_mountains();
     AddSC_arathi_highlands();
@@ -432,6 +454,7 @@ void AddScripts()
     AddSC_razorfen_kraul();                                 //razorfen_kraul
     AddSC_instance_razorfen_downs();
     AddSC_instance_razorfen_kraul();
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
     AddSC_boss_ayamiss();                                   //ruins_of_ahnqiraj
     AddSC_boss_buru();
     AddSC_boss_kurinnaxx();
@@ -444,11 +467,13 @@ void AddScripts()
     AddSC_boss_fankriss();
     AddSC_boss_huhuran();
     AddSC_bug_trio();
+    AddSC_boss_ouro();
     AddSC_boss_sartura();
     AddSC_boss_skeram();
     AddSC_boss_twinemperors();
     AddSC_mob_anubisath_sentinel();
     AddSC_instance_temple_of_ahnqiraj();
+#endif
     AddSC_wailing_caverns();                               //Wailing caverns
     AddSC_instance_wailing_caverns();
     AddSC_zulfarrak();                                      //zulfarrak

--- a/src/scripts/ScriptLoader.cpp
+++ b/src/scripts/ScriptLoader.cpp
@@ -419,7 +419,6 @@ void AddScripts()
 #endif
     AddSC_boss_omen();
 
-
     //AddSC_alterac_mountains();
     AddSC_arathi_highlands();
     AddSC_blasted_lands();

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -546,6 +546,7 @@ CreatureAI* GetAI_npc_doctor(Creature* pCreature)
     return new npc_doctorAI(pCreature);
 }
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
 /*######
 ## npc_tonk_mine
 ######*/
@@ -685,6 +686,7 @@ CreatureAI* GetAI_npc_steam_tonk(Creature* pCreature)
 {
     return new npc_steam_tonkAI(pCreature);
 }
+#endif
 
 /*
  * Rat of the depths
@@ -1130,6 +1132,7 @@ CreatureAI* GetAI_npc_the_cleaner(Creature* pCreature)
     return new npc_the_cleanerAI(pCreature);
 }
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
 /*
  * Fireworks
  */
@@ -1350,6 +1353,7 @@ CreatureAI* GetAI_npc_pats_firework_guy(Creature* creature)
 {
     return new npc_pats_firework_guyAI(creature);
 }
+#endif
 
 /*
  * Summon possessed mobs
@@ -1387,6 +1391,7 @@ CreatureAI* GetAI_npc_summon_possessed(Creature* pCreature)
     return new npc_summon_possessedAI(pCreature);
 }
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_7_1
 /*
  * Riggle Bassbait (Stranglethorn Vale Fishing Extravaganza)
  */
@@ -1491,6 +1496,7 @@ bool QuestRewarded_npc_riggle_bassbait(Player* pPlayer, Creature* pCreature, Que
 
     return true;
 }
+#endif
 
 /*
  * Target Dummy
@@ -2091,6 +2097,7 @@ CreatureAI* GetAI_npc_explosive_sheep(Creature* pCreature)
     return new npc_explosive_sheepAI(pCreature);
 }
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
 enum
 {
     EVENT_LOVE_IS_IN_THE_AIR                                    = 8,
@@ -2317,6 +2324,7 @@ bool QuestRewarded_npc_kwee_peddlefeet(Player* pPlayer, Creature* pCreature, Que
 
     return true;
 }
+#endif
 
 enum
 {
@@ -2406,6 +2414,7 @@ void AddSC_npcs_special()
     newscript->pQuestAcceptNPC = &QuestAccept_npc_doctor;
     newscript->RegisterSelf();
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     newscript = new Script;
     newscript->Name = "npc_tonk_mine";
     newscript->GetAI = &GetAI_npc_tonk_mine;
@@ -2420,6 +2429,7 @@ void AddSC_npcs_special()
     newscript->Name = "npc_steam_tonk";
     newscript->GetAI = &GetAI_npc_steam_tonk;
     newscript->RegisterSelf();
+#endif
 
     newscript = new Script;
     newscript->Name = "rat_des_profondeurs";
@@ -2456,10 +2466,12 @@ void AddSC_npcs_special()
     newscript->GetAI = &GetAI_npc_the_cleaner;
     newscript->RegisterSelf();
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
     newscript = new Script;
     newscript->Name = "npc_pats_firework_guy";
     newscript->GetAI = &GetAI_npc_pats_firework_guy;
     newscript->RegisterSelf();
+#endif
     /*
     newscript = new Script;
     newscript->Name = "npc_firestarter_regular";
@@ -2472,11 +2484,13 @@ void AddSC_npcs_special()
     newscript->GetAI = &GetAI_npc_summon_possessed;
     newscript->RegisterSelf();
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_7_1
     newscript = new Script;
     newscript->Name = "npc_riggle_bassbait";
     newscript->GetAI = &GetAI_npc_riggle_bassbait;
     newscript->pQuestRewardedNPC = &QuestRewarded_npc_riggle_bassbait;
     newscript->RegisterSelf();
+#endif
 
     newscript = new Script;
     newscript->Name = "npc_target_dummy";
@@ -2508,12 +2522,14 @@ void AddSC_npcs_special()
     newscript->GetAI = &GetAI_npc_explosive_sheep;
     newscript->RegisterSelf();
 
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_9_4
     newscript = new Script;
     newscript->Name = "npc_kwee_peddlefeet";
     newscript->GetAI = &GetAI_npc_kwee_peddlefeet;
     newscript->pGossipHello = &GossipHello_npc_kwee_peddlefeet;
     newscript->pQuestRewardedNPC = &QuestRewarded_npc_kwee_peddlefeet;
     newscript->RegisterSelf();
+#endif
 
     newscript = new Script;
     newscript->Name = "npc_oozeling_jubjub";


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR stops compiler from building scripts where the content is not available. For patch 1.12.1, this PR does nothing.
As this removes plenty of script files when building for lower patch, the file size difference between patch 1.12.1 mangosd and patch 1.6.1 mangosd is 495 kb.

Full 1.12.1 build on a 5800x:
![devenv_2qwWuLwgt1](https://github.com/vmangos/core/assets/6137576/5541808b-249b-491a-a3b2-10331b05d475)
Full 1.6.1 build on a 5800x:
![devenv_2w1O8Ib6ab](https://github.com/vmangos/core/assets/6137576/3ae93886-022f-4368-b9a5-4a7cf7ba60b4)


If below patch 1.11, Naxxramas and Scourge Invasion will not build.
If below patch 1.9, AQ, War Effort and Omen will not build.
If below patch 1.8, Dragons of Nightmare will not build.
If below patch 1.7, AB and ZG will not build.
If below patch 1.6, BWL will not build.

All patches build successfully. No server crashes from my testing in game.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] Attempt to remove War Effort when building for lower patch.
