### PR TITLE
Fix build failing due to misnamed OutTime() and OutTimestamp() calls.

### DIFF
--- a/src/game/Anticheat/WardenAnticheat/Warden.cpp
+++ b/src/game/Anticheat/WardenAnticheat/Warden.cpp
@@ -15,10 +15,10 @@
  */
 
 /*
- * 
+ *
  * This code was written by namreeb (legal@namreeb.org) and is released with
  * permission as part of vmangos (https://github.com/vmangos/core)
- * 
+ *
  */
 
 #include "WardenModule.hpp"
@@ -62,7 +62,7 @@ void Log::OutWarden(Warden const* warden, LogLevel logLevel, char const* format,
         SetColor(stdout, g_logColors[logLevel]);
 
         if (m_includeTime)
-            outTime(stdout);
+            OutTime(stdout);
 
         // Append tag to console warden messages.
         printf("[Warden] (Name %s, Id %u, IP %s) ", warden->GetAccountName(), warden->GetAccountId(), warden->GetSessionIP());
@@ -80,7 +80,7 @@ void Log::OutWarden(Warden const* warden, LogLevel logLevel, char const* format,
 
     if (logFiles[LOG_ANTICHEAT] && m_fileLevel >= logLevel)
     {
-        outTimestamp(logFiles[LOG_ANTICHEAT]);
+        OutTimestamp(logFiles[LOG_ANTICHEAT]);
         fprintf(logFiles[LOG_ANTICHEAT], "[Warden] (Name %s, Id %u, IP %s) ", warden->GetAccountName(), warden->GetAccountId(), warden->GetSessionIP());
 
         va_list ap;
@@ -341,7 +341,7 @@ void Warden::ReadScanResults(ByteBuffer& buff)
     {
         sLog.OutWarden(this, LOG_LVL_DEBUG, "Checking result for %s", s->comment.c_str());
 
-        // checks return true when they have discovered a hack 
+        // checks return true when they have discovered a hack
         if (s->Check(this, buff))
         {
             // if this scan requires being in the world and they are not in the world (meaning they left
@@ -652,7 +652,7 @@ void Warden::Update()
 {
     {
         std::vector<WorldPacket> packetQueue;
-    
+
         {
             std::lock_guard<std::mutex> lock(m_packetQueueMutex);
             std::swap(packetQueue, m_packetQueue);


### PR DESCRIPTION
## 🍰 Pullrequest
The build currently fails with the latest commit (89e918e814580087820677aea04a2c2c39fbe226) due to calls to `Log::OutTime()` and `Log::OutTimestamp()` being misnamed in `src/game/Anticheat/WardenAnticheat/Warden.cpp`:

```
[ 60%] Building CXX object src/game/CMakeFiles/game.dir/Anticheat/WardenAnticheat/Warden.cpp.o
/core/src/game/Anticheat/WardenAnticheat/Warden.cpp: In member function 'void Log::OutWarden(const Warden*, LogLevel, const char*, ...)':
/core/src/game/Anticheat/WardenAnticheat/Warden.cpp:65:13: error: 'outTime' was not declared in this scope; did you mean 'OutTime'?
   65 |             outTime(stdout);
      |             ^~~~~~~
      |             OutTime
/core/src/game/Anticheat/WardenAnticheat/Warden.cpp:83:9: error: 'outTimestamp' was not declared in this scope; did you mean 'OutTimestamp'?
   83 |         outTimestamp(logFiles[LOG_ANTICHEAT]);
      |         ^~~~~~~~~~~~
      |         OutTimestamp
[ 60%] Building CXX object src/game/CMakeFiles/game.dir/Anticheat/WardenAnticheat/WardenMac.cpp.o
[ 60%] Building CXX object src/game/CMakeFiles/game.dir/Anticheat/WardenAnticheat/WardenModule.cpp.o
```

This fixes those calls.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
