### PR TITLE
CI: Remove unnecessary wget installation.

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,20 +34,16 @@ jobs:
         #directory variables
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers
         export TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb
-        #wget
-        choco install -y wget --version 1.20
         #ACE package download
-        wget http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-$ACE_VERSION2/ACE-$ACE_VERSION.zip
+        curl -LOJ http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-$ACE_VERSION2/ACE-$ACE_VERSION.zip
         unzip ACE-$ACE_VERSION.zip
         rm ACE-$ACE_VERSION.zip
         #configuration of ACE header
         echo "#include \"ace/config-win32.h\"" >> $ACE_ROOT/ace/config.h
         #TBB package download
-        wget https://github.com/oneapi-src/oneTBB/releases/download/v$TBB_VERSION/tbb-$TBB_VERSION-win.zip
+        curl -LOJ https://github.com/oneapi-src/oneTBB/releases/download/v$TBB_VERSION/tbb-$TBB_VERSION-win.zip
         unzip tbb-$TBB_VERSION-win.zip
         rm tbb-$TBB_VERSION-win.zip
-        #openssl
-        #choco install -y openssl --version=1.1.1.500
       #git bash shell
       shell: bash
 

--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -71,20 +71,16 @@ jobs:
         #directory variables
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers
         export TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb
-        #wget
-        choco install -y wget --version 1.20
         #ACE package download
-        wget http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-$ACE_VERSION2/ACE-$ACE_VERSION.zip
+        curl -LOJ http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-$ACE_VERSION2/ACE-$ACE_VERSION.zip
         unzip ACE-$ACE_VERSION.zip
         rm ACE-$ACE_VERSION.zip
         #configuration of ACE header
         echo "#include \"ace/config-win32.h\"" >> $ACE_ROOT/ace/config.h
         #TBB package download
-        wget https://github.com/oneapi-src/oneTBB/releases/download/v$TBB_VERSION/tbb-$TBB_VERSION-win.zip
+        curl -LOJ https://github.com/oneapi-src/oneTBB/releases/download/v$TBB_VERSION/tbb-$TBB_VERSION-win.zip
         unzip tbb-$TBB_VERSION-win.zip
         rm tbb-$TBB_VERSION-win.zip
-        #openssl
-        choco install -y openssl --version=1.1.1.500
       #git bash shell
       shell: bash
 


### PR DESCRIPTION
## 🍰 Pullrequest
~~Chocolatey is currently experiencing an issue that prevents installing packages, at least in GitHub Actions; other projects are also [reporting](https://github.com/numpy/numpy/issues/25980) that problem. In our case that means the Windows CI runs are currently failing because we can't install `wget`.~~
__Edit:__ Looks like the Chocolatey server is operating normally again now but removing a potential source of problems might not be a bad idea still.

This makes it so `curl` is used instead which is available by default and thus we don't need to install anything via Chocolatey.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
