### PR TITLE
Pass through arguments in mmap_extract.py.

### DIFF
--- a/contrib/mmap/mmap_extract.py
+++ b/contrib/mmap/mmap_extract.py
@@ -132,7 +132,7 @@ class WorkerThread(threading.Thread):
             bin_path = move_map_gen_dir / "MoveMapGen"
 
         subprocess.call(
-            (bin_path, str(self.map_id), "--silent"),
+            (bin_path, str(self.map_id), "--silent", *sys.argv[1:]),
             startupinfo=startup_info,
             creationflags=creation_flags,
         )
@@ -154,8 +154,14 @@ if __name__ == "__main__":
                 map_ids.add(spawn.map_id)
 
     # Process maps
-    max_workers = max(cpu_count() - 0, 1)  # You can reduce the load by putting 1 instead of 0 if you need to free 1 core/cpu
-    print("I will always maintain", max_workers, "MoveMapGen tasks running in background.\n")
+    max_workers = max(
+        cpu_count() - 0, 1 # You can reduce the load by putting 1 instead of 0 if you need to free 1 core/cpu
+    )
+    print(
+        "I will always maintain",
+        max_workers,
+        "MoveMapGen tasks running in background.\n",
+    )
     map_queue = deque(map_ids)
     while map_queue:
         if threading.active_count() <= max_workers:


### PR DESCRIPTION
## 🍰 Pullrequest
This allows passing through additional arguments such as `--configInputPath` or `--offMeshInput` to `MoveMapGen` when using [mmap_extract.py](https://github.com/vmangos/core/blob/e5ba29cb92a568db2cd99f7893e6cd343334e0e0/contrib/mmap/mmap_extract.py).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1. Put `mmap_extract.py` next to `MoveMapGen`
2. Change the current working directory to the directory the data is in (= the directory `Buildings`, `maps` etc. is in)
3. Run `mmap_extract.py` (from the data directory) with additional arguments, e.g.: `/path/to/mmap_extract.py --configInputPath /path/to/config.json --offMeshInput /path/to/offmesh.txt`

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
