### PR TITLE
fix BG area trigger message displaying wrong team as requirement

### DIFF
--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -760,7 +760,7 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
         if ((pPlayer->GetLevel() < bg->GetMinLevel() || pPlayer->GetLevel() > bg->GetMaxLevel()) ||
             (pPlayer->GetTeam() != pBgEntrance->team))
         {
-            SendAreaTriggerMessage("You must be in the %s and at least %u%s level to enter.", pPlayer->GetTeam() == ALLIANCE ? "Alliance" : "Horde", bg->GetMinLevel(), bg->GetMinLevel() % 2 ? "st" : "th");
+            SendAreaTriggerMessage("You must be in the %s and at least %u%s level to enter.", pPlayer->GetTeam() == ALLIANCE ? "Horde" : "Alliance", bg->GetMinLevel(), bg->GetMinLevel() % 2 ? "st" : "th");
             return;
         }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Wrong area trigger message when accessing BG portal of opposing faction

### Proof
![Screenshot_20240318_105705](https://github.com/vmangos/core/assets/10067406/f8f6e35d-5a1c-42d6-9299-2f196efff5e1)


### How2Test
Go to a BG portal as opposing faction
