### PR TITLE
Use concurrent.futures and improve user feedback in mmap_extract.py.

### DIFF
--- a/contrib/mmap/mmap_extract.py
+++ b/contrib/mmap/mmap_extract.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """
-This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information
+Copyright (C) 2013-2017  CMaNGOS  https://github.com/cmangos
+Copyright (C) 2024-present  VMaNGOS  https://github.com/vmangos
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -18,25 +19,28 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+import concurrent.futures
+import functools
+import os
 import pathlib
+import platform
 import struct
 import subprocess
 import sys
-import threading
-import time
-import typing
-from collections import deque
-from multiprocessing import cpu_count
+import typing as T
 
 # https://github.com/vmangos/core/blob/5e142e104c8033cd0505cf8e060f37e263f503fe/src/game/vmap/ModelInstance.h#L40
-MOD_HAS_BOUND = 1 << 2
+MOD_HAS_BOUND_FLAG = 1 << 2
 # mapID, tileX, tileY, Flags, adtID, ID, Pos, Rot, Scale, Bound_lo, Bound_hi, name
 INTRO_STRUCT_FORMAT = "<IIIIHI3f3ff"
+INTRO_STRUCT_SIZE = struct.calcsize(INTRO_STRUCT_FORMAT)
 BOUND_STRUCT_FORMAT = "<3f3f"
-NAME_STRUCT_FORMAT = "<I"
+BOUND_STRUCT_SIZE = struct.calcsize(BOUND_STRUCT_FORMAT)
+NAME_LENGTH_STRUCT_FORMAT = "<I"
+NAME_LENGTH_STRUCT_SIZE = struct.calcsize(NAME_LENGTH_STRUCT_FORMAT)
 
 
-class Spawn(typing.NamedTuple):
+class Spawn(T.NamedTuple):
     map_id: int
     tile_x: int
     tile_y: int
@@ -46,52 +50,28 @@ class Spawn(typing.NamedTuple):
     pos: tuple[float, float, float]
     rot: tuple[float, float, float]
     scale: tuple[float, float, float]
-    bound_low: typing.Optional[tuple[float, float, float]]
-    bound_high: typing.Optional[tuple[float, float, float]]
-    name_len: int
+    bound_low: tuple[float, float, float] | None
+    bound_high: tuple[float, float, float] | None
     name: bytes
 
 
 # https://github.com/vmangos/core/blob/5e142e104c8033cd0505cf8e060f37e263f503fe/src/game/vmap/TileAssembler.cpp#L206-L243
 # https://github.com/vmangos/core/blob/5e142e104c8033cd0505cf8e060f37e263f503fe/src/game/vmap/ModelInstance.cpp#L182-L226
-def read_spawn(file):
-    intro_data = file.read(struct.calcsize(INTRO_STRUCT_FORMAT))
-    (
-        map_id,
-        tile_x,
-        tile_y,
-        flags,
-        adt_id,
-        id_,
-        pos_x,
-        pos_y,
-        pos_z,
-        rot_x,
-        rot_y,
-        rot_z,
-        scale,
-    ) = struct.unpack(INTRO_STRUCT_FORMAT, intro_data)
-    if flags & MOD_HAS_BOUND:
-        bound_data = file.read(struct.calcsize(BOUND_STRUCT_FORMAT))
-        (
-            bound_low_x,
-            bound_low_y,
-            bound_low_z,
-            bound_high_x,
-            bound_high_y,
-            bound_high_z,
-        ) = struct.unpack(BOUND_STRUCT_FORMAT, bound_data)
+def read_spawn(file: T.BinaryIO) -> Spawn:
+    (map_id, tile_x, tile_y, flags, adt_id, id_, pos_x, pos_y, pos_z, rot_x, rot_y, rot_z, scale) = struct.unpack(
+        INTRO_STRUCT_FORMAT, file.read(INTRO_STRUCT_SIZE)
+    )
+    if flags & MOD_HAS_BOUND_FLAG:
+        (bound_low_x, bound_low_y, bound_low_z, bound_high_x, bound_high_y, bound_high_z) = struct.unpack(
+            BOUND_STRUCT_FORMAT, file.read(BOUND_STRUCT_SIZE)
+        )
         bound_low = bound_low_x, bound_low_y, bound_low_z
         bound_high = bound_high_x, bound_high_y, bound_high_z
     else:
         bound_low, bound_high = None, None
 
-    name_len_data = file.read(struct.calcsize(NAME_STRUCT_FORMAT))
-    name_len = struct.unpack(NAME_STRUCT_FORMAT, name_len_data)[0]
-    assert name_len <= 500
-    name_data = file.read(name_len)
-    name = struct.unpack(f"{name_len}s", name_data)[0]
-
+    name_length = struct.unpack(NAME_LENGTH_STRUCT_FORMAT, file.read(NAME_LENGTH_STRUCT_SIZE))[0]
+    name = struct.unpack(f"{name_length}s", file.read(name_length))[0]
     return Spawn(
         map_id,
         tile_x,
@@ -104,67 +84,82 @@ def read_spawn(file):
         scale,
         bound_low,
         bound_high,
-        name_len,
         name,
     )
 
 
-class WorkerThread(threading.Thread):
-    def __init__(self, map_id):
-        super().__init__()
-        self.map_id = map_id
-
-    def run(self):
-        name = f"Worker for map {self.map_id}"
-        print("++", name)
-
-        # The MoveMapGen executable is expected to be in the same directory as this script
-        move_map_gen_dir = pathlib.Path(__file__).parent
-        if sys.platform == "win32":
-            startup_info = subprocess.STARTUPINFO()
-            startup_info.dwFlags |= 0x00000001
-            startup_info.wShowWindow = 7
-            creation_flags = subprocess.CREATE_NEW_CONSOLE
-            bin_path = move_map_gen_dir / "MoveMapGen.exe"
-        else:
-            startup_info = None
-            creation_flags = 0
-            bin_path = move_map_gen_dir / "MoveMapGen"
-
-        subprocess.call(
-            (bin_path, str(self.map_id), "--silent", *sys.argv[1:]),
-            startupinfo=startup_info,
-            creationflags=creation_flags,
-        )
-        print("--", name)
+class SubprocessConfig(T.NamedTuple):
+    executable: pathlib.Path
+    # Quote the type-hint because subprocess.STARTUPINFO isn't defined when running on Linux
+    startupinfo: "subprocess.STARTUPINFO | None"  # type: ignore
+    creation_flags: int
 
 
-if __name__ == "__main__":
+@functools.cache
+def get_subprocess_config() -> SubprocessConfig:
+    script_directory = pathlib.Path(__file__).parent
+    if platform.system() == "Windows":
+        startup_info = subprocess.STARTUPINFO()  # type: ignore
+        startup_info.dwFlags |= 0x00000001
+        startup_info.wShowWindow = 7
+        creation_flags = subprocess.CREATE_NEW_CONSOLE  # type: ignore
+        executable = script_directory / "MoveMapGen.exe"
+    else:
+        startup_info = None
+        creation_flags = 0
+        executable = script_directory / "MoveMapGen"
+
+    return SubprocessConfig(executable, startup_info, creation_flags)
+
+
+def run_move_map_gen(map_id: int) -> None:
+    config = get_subprocess_config()
+    subprocess.check_call(
+        (config.executable, str(map_id), "--silent", *sys.argv[1:]),
+        startupinfo=config.startupinfo,
+        creationflags=config.creation_flags,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def main() -> None:
     # Read map IDs from dir_bin
-    map_ids = set()
-    with (pathlib.Path("Buildings") / "dir_bin").open("rb") as file:
+    map_ids: set[int] = set()
+    current_working_directory = pathlib.Path.cwd()
+
+    dir_bin_path = current_working_directory / "Buildings" / "dir_bin"
+    with dir_bin_path.open("rb") as file:
         while True:
             try:
                 spawn = read_spawn(file)
             except struct.error:
-                # EOF
+                # EOF reached
                 break
+            map_ids.add(spawn.map_id)
 
-            if spawn.map_id not in map_ids:
-                map_ids.add(spawn.map_id)
+    max_workers = os.cpu_count() or 1
+    print(f"Using {max_workers} worker(s) for map processing")
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers)
+
+    # Create mmaps directory beforehand to avoid a race condition in MoveMapGen
+    mmaps_directory = current_working_directory / "mmaps"
+    mmaps_directory.mkdir(exist_ok=True)
 
     # Process maps
-    max_workers = max(
-        cpu_count() - 0, 1 # You can reduce the load by putting 1 instead of 0 if you need to free 1 core/cpu
-    )
-    print(
-        "I will always maintain",
-        max_workers,
-        "MoveMapGen tasks running in background.\n",
-    )
-    map_queue = deque(map_ids)
-    while map_queue:
-        if threading.active_count() <= max_workers:
-            WorkerThread(map_queue.popleft()).start()
+    future_to_map_id = {pool.submit(run_move_map_gen, map_id): map_id for map_id in sorted(map_ids)}
+    total = len(future_to_map_id)
+    num_errors = 0
+    for number, future in enumerate(concurrent.futures.as_completed(future_to_map_id), start=1):
+        map_id = future_to_map_id[future]
+        exception = future.exception()
+        if exception:
+            num_errors += 1
+        print(f"({number}/{total}) Map #{map_id}:", exception or "Processed successfully")
 
-        time.sleep(0.1)
+    pool.shutdown()
+    print(f"Finished processing all maps ({total}) with {num_errors} error(s)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🍰 Pullrequest
This is a continuation of #2541 and improves the code of [mmap_extract.py](https://github.com/vmangos/core/blob/2a615b20721c32eb320d5d71171b95054187c37c/contrib/mmap/mmap_extract.py) further. It uses [`concurrent.futures`](https://docs.python.org/3/library/concurrent.futures.html) for the subprocesses instead of the previous thread-based parallelism, which is more efficient than the thread-keepalive check that existed beforehand and also allows us to easily check whether the function raised any exception (i.e. the `MoveMapGen` executable returned a non-zero exit code), which is hard when subclassing `threading.Thread`. It also determines the platform-specific configuration for running the `MoveMapGen` executable only once and then caches it, instead of running the same logic in every new thread.

The output of the `MoveMapGen` executable is now swallowed and instead the user is presented with a simple overview that makes it easier to follow and see which maps have finished processing and if there were any errors. This should be more appropriate in non-debug scenarios where all the user cares about is the end result instead of seeing the progress of each individual tile. It looks like this:

```
Using 8 worker(s) for map processing
(1/43) Map #34: Processed successfully
(2/43) Map #35: Processed successfully
(3/43) Map #13: Processed successfully
(4/43) Map #29: Processed successfully
(5/43) Map #42: Processed successfully
(6/43) Map #44: Processed successfully
(7/43) Map #43: Processed successfully
(8/43) Map #33: Processed successfully
(9/43) Map #70: Processed successfully
(10/43) Map #48: Processed successfully
(11/43) Map #36: Processed successfully
(12/43) Map #30: Processed successfully
(13/43) Map #37: Processed successfully
(14/43) Map #90: Processed successfully
(15/43) Map #129: Processed successfully
(16/43) Map #109: Processed successfully
(17/43) Map #189: Processed successfully
(18/43) Map #249: Processed successfully
(19/43) Map #229: Processed successfully
(20/43) Map #209: Processed successfully
(21/43) Map #230: Processed successfully
(22/43) Map #289: Processed successfully
(23/43) Map #47: Processed successfully
(24/43) Map #349: Processed successfully
(25/43) Map #269: Processed successfully
(26/43) Map #309: Processed successfully
(27/43) Map #389: Processed successfully
(28/43) Map #409: Processed successfully
(29/43) Map #449: Processed successfully
(30/43) Map #450: Processed successfully
(31/43) Map #369: Processed successfully
(32/43) Map #489: Processed successfully
(33/43) Map #169: Processed successfully
(34/43) Map #529: Processed successfully
(35/43) Map #451: Processed successfully
(36/43) Map #329: Processed successfully
(37/43) Map #429: Processed successfully
(38/43) Map #469: Processed successfully
(39/43) Map #509: Processed successfully
(40/43) Map #533: Processed successfully
(41/43) Map #531: Processed successfully
(42/43) Map #0: Processed successfully
(43/43) Map #1: Processed successfully
Finished processing all maps (43) with 0 error(s)
```

Finally, I've decided to look up the [initial CMaNGOS commit that introduced the script](https://github.com/cmangos/mangos-classic/commit/4130ec99d8f278ce2f313ee293acf963abed7a8d) and adjusted the copyright notice accordingly. If that's not desirable I can remove it, of course, but it would be a lot more accurate compared to the current situation (where VMaNGOS isn't even mentioned).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1. Put `mmap_extract.py` next to `MoveMapGen`
2. Change the current working directory to the directory the data is in (= the directory `Buildings`, `maps` etc. is in)
3. Run `mmap_extract.py` (from the data directory)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
