### PR TITLE
Fix rp walk caused by overlapping CC

### DIFF
--- a/src/game/Movement/spline/MoveSplineInit.cpp
+++ b/src/game/Movement/spline/MoveSplineInit.cpp
@@ -207,10 +207,6 @@ int32 MoveSplineInit::Launch()
     if (args.velocity > 4 * realSpeedRun && !args.flags.done)
         mvtData.SetUnitSpeed(SMSG_SPLINE_SET_RUN_SPEED, unit.GetObjectGuid(), realSpeedRun);
 
-    // Restore correct walk mode for players
-    if (unit.GetTypeId() == TYPEID_PLAYER && (moveFlags & MOVEFLAG_WALK_MODE) != (oldMoveFlags & MOVEFLAG_WALK_MODE))
-        mvtData.SetSplineOpcode(oldMoveFlags & MOVEFLAG_WALK_MODE ? SMSG_SPLINE_MOVE_SET_WALK_MODE : SMSG_SPLINE_MOVE_SET_RUN_MODE, unit.GetObjectGuid());
-
     if (compress)
     {
         WorldPacket data2;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fixes an unintended behavior of restoring walk/run mode on players, that occurs when different splines with run/walk mode overlaps.

### Proof
<!-- Link resources as proof -->
I have no sources to prove this is blizzlike behavior. 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/TeamEverlook/Everlook-BugTracker/issues/327
- fixes https://github.com/TeamEverlook/Everlook-BugTracker/issues/136
- 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
This is 100% replicable on 1.14 with HP
 - sheep player (Walk)
 - fear player before sheep CC runs out (Run)
 - watch player being in walkmode 

https://www.youtube.com/watch?v=03vU7YC4m84&feature=youtu.be

Lots of ppl claim it also happens on 1.12 - I have found no way to reproduce it. But from looking at the code i would say its possible, as we are sending the data to the client 😅 

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
