### PR TITLE
Disable quest Horns of Nez'ra.

### DIFF
--- a/sql/migrations/20240329131510_world.sql
+++ b/sql/migrations/20240329131510_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20240329131510');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20240329131510');
+-- Add your query below.
+
+-- Set QUEST_METHOD_DISABLED flag for 2358 Horns of Nez'ra
+UPDATE `quest_template` SET `Method`=1 WHERE `entry`=2358 AND `patch`=0;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
This disables the quest [Horns of Nez'ra](https://classicdb.ch/?quest=2358) which apparently doesn't exist in Classic or Vanilla.

### Proof
<!-- Link resources as proof -->
- https://github.com/Questie/Questie/issues/921 (contains a screenshot from a Blizzard support ticket)
- The quest also [got removed from the Wowhead Classic page](https://www.wowhead.com/classic/quest=2358)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- closes #2512

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
