### PR TITLE
Removed strict range check in dungeons

### DIFF
--- a/src/game/Movement/TargetedMovementGenerator.cpp
+++ b/src/game/Movement/TargetedMovementGenerator.cpp
@@ -161,15 +161,6 @@ void TargetedMovementGeneratorMedium<T, D>::_setTargetLocation(T &owner)
     if (!m_bReachable && !!(pathType & PATHFIND_INCOMPLETE) && owner.HasUnitState(UNIT_STAT_ALLOW_INCOMPLETE_PATH))
         m_bReachable = true;
 
-    // Enforce stricter checking inside dungeons
-    if (m_bReachable && owner.GetMap() && owner.GetMap()->IsDungeon())
-    {
-        // Check dest coords to ensure reachability
-        G3D::Vector3 dest = path.getActualEndPosition();
-        if (!owner.CanReachWithMeleeAutoAttackAtPosition(i_target.getTarget(), dest[0], dest[1], dest[2]))
-            m_bReachable = false;
-    }
-
     m_bRecalculateTravel = false;
     if (this->GetMovementGeneratorType() == CHASE_MOTION_TYPE && !transport && owner.HasDistanceCasterMovement())
         if (path.UpdateForCaster(i_target.getTarget(), owner.GetMinChaseDistance(i_target.getTarget())))


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This range check is not only excessively strict and breaks with extrapolation, it's also redundant as GetRandomAttackPoint makes that check already before extrapolation happens.

- extrapolation happens [here](https://github.com/balakethelock/core/blob/7ad28135e076052501bf40831108383a115089ae/src/game/Objects/Unit.cpp#L2969)
- called by [this](https://github.com/balakethelock/core/blob/7ad28135e076052501bf40831108383a115089ae/src/game/Objects/Unit.cpp#L10249)
- that is in turn called by [this](https://github.com/balakethelock/core/blob/7ad28135e076052501bf40831108383a115089ae/src/game/Movement/TargetedMovementGenerator.cpp#L90). if it returned false, that means the target was unreachable regardless of extrapolation so making the check again is unnecessary.

Another thing to do is to do yet another extrapolation calculation for the dungeon-only range check but I think that's ultimately just spending server resources for no benefit.

### Proof
<!-- Link resources as proof -->
https://www.youtube.com/watch?v=j19wdNo2gXY

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->


### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
