### PR TITLE
Spawn AQ gong pre patch 1.9.

### DIFF
--- a/sql/migrations/20240402183826_world.sql
+++ b/sql/migrations/20240402183826_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20240402183826');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20240402183826');
+-- Add your query below.
+
+
+-- Spawn old Ahn Qiraj Gong pre 1.9
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES 
+(66333, 177223, 1, -8067.78, 1568.16, 8.03422, 1.26537, 0, 0, 0, 0, 900, 900, 100, 1, 1, 150, 0, 6);
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Prior to patch 1.9.0 the gong had a different name, used a different entry and had a different spawn.
This PR spawns the old gong using sniffed data from pre patch 1.9.0.

I set the visibility_mod to 150, equal to the post 1.9 gong that vmangos currently has.
It can be increased to 350, to match the gate as the old gong is much more visible in pre 1.9 than the new gong added in post 1.9 is.

From pre patch 1.3.0:
![04](https://github.com/vmangos/core/assets/6137576/5a101512-37f5-478d-a260-2f7b5d55ec92)
![05](https://github.com/vmangos/core/assets/6137576/58fc0e32-57a2-45e4-8964-82b8757876fd)
From vmangos with this PR applied:
![WoW_sw3FLQl2Uc](https://github.com/vmangos/core/assets/6137576/84d3b9eb-f844-412b-af2c-ee4c07a0ad05)


### Proof
<!-- Link resources as proof -->
- gameobjects1_12.sql from WoWD-DB. Sniffed on vanilla sometime between patch 1.7.x and 1.8.x.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
