### PR TITLE
Linux daemon issue

### DIFF
--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -145,5 +145,8 @@ void CliRunnable::operator()()
             }
             sWorld.QueueCliCommand(new CliCommandHolder(0, SEC_CONSOLE, nullptr, command.c_str(), &utf8print, &commandFinished));
         }
+        #ifndef WIN32
+        free(command_str);
+        #endif
     }
 }

--- a/src/mangosd/Main.cpp
+++ b/src/mangosd/Main.cpp
@@ -216,7 +216,7 @@ extern int main(int argc, char **argv)
 
     // and run the 'Master'
     // TODO: Why do we need this 'Master'? Can't all of this be in the Main as for Realmd?
-    return sMaster.Run();
+    return sMaster.Run(serviceDaemonMode);
 
     // at sMaster return function exist with codes
     // 0 - normal shutdown

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -153,7 +153,7 @@ Master::~Master()
 }
 
 // Main function
-int Master::Run()
+int Master::Run(char serviceDaemonMode = '\0')
 {
     // worldd PID file creation
     std::string pidfile = sConfig.GetStringDefault("PidFile", "");
@@ -210,7 +210,7 @@ int Master::Run()
 #ifdef WIN32
     if (sConfig.GetBoolDefault("Console.Enable", true) && (m_ServiceStatus == -1)/* need disable console in service mode*/)
 #else
-    if (sConfig.GetBoolDefault("Console.Enable", true))
+    if (sConfig.GetBoolDefault("Console.Enable", true) && !serviceDaemonMode)
 #endif
     {
         // Launch CliRunnable thread

--- a/src/mangosd/Master.h
+++ b/src/mangosd/Master.h
@@ -35,7 +35,7 @@ class Master
     public:
         Master();
         ~Master();
-        int Run();
+        int Run(char serviceDaemonMode);
         static volatile uint32  m_masterLoopCounter;
         static volatile bool    m_handleSigvSignals;
         static void SigvSignalHandler();

--- a/src/shared/PosixDaemon.cpp
+++ b/src/shared/PosixDaemon.cpp
@@ -84,15 +84,9 @@ void startDaemon(uint32_t timeout)
         exit(EXIT_FAILURE);
     }
 
-    if ((chdir("/")) < 0)
-    {
-        exit(EXIT_FAILURE);
-    }
-
     close(STDIN_FILENO);
     close(STDOUT_FILENO);
     close(STDERR_FILENO);
-
 }
 
 void stopDaemon()


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
In an attempt to fix the memory leak & process going nuts when launched in `daemon` mode with the changes I made in https://github.com/vmangos/core/pull/2527, simply don't launch the CLI when running in this mode. Rationale is that you can't even use the CLI easily if launched like this.

There's also a change around paths and what your relative path is in `daemon` mode, making it *more consistent* with non daemon mode.

Also a small memory leak fix for the linux mangosd CLI.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2561 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
