### PR TITLE
Fix #2561: close() instead of freopen() to stop readline leaks

### DIFF
--- a/src/shared/PosixDaemon.cpp
+++ b/src/shared/PosixDaemon.cpp
@@ -55,8 +55,13 @@ void startDaemon(uint32_t timeout)
     signal(SIGTERM, daemonSignal);
     signal(SIGALRM, daemonSignal);
 
+    // Fork the process
     sid = pid = fork();
 
+    // An error occurred
+    // pid > 0 == parent
+    // pid == 0 == child
+    // do the real termination of the parent via a call in master.cpp Master::run()
     if (pid < 0)
     {
         exit(EXIT_FAILURE);
@@ -71,6 +76,7 @@ void startDaemon(uint32_t timeout)
 
     umask(0);
 
+    // child process becomes the session leader
     sid = setsid();
 
     if (sid < 0)
@@ -83,12 +89,10 @@ void startDaemon(uint32_t timeout)
         exit(EXIT_FAILURE);
     }
 
-    if (!freopen("/dev/null", "rt", stdin))
-        exit(EXIT_FAILURE);
-    if (!freopen("/dev/null", "wt", stdout))
-        exit(EXIT_FAILURE);
-    if (!freopen("/dev/null", "wt", stderr))
-        exit(EXIT_FAILURE);
+    close(STDIN_FILENO);
+    close(STDOUT_FILENO);
+    close(STDERR_FILENO);
+
 }
 
 void stopDaemon()


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Direct fix for #2561, use `close` instead of `freopen` to `/dev/null`

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2561 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
