### PR TITLE
Limit maximum number of file descriptors of mangosd/realmd processes

### DIFF
--- a/src/framework/Network/MangosSocketMgrImpl.h
+++ b/src/framework/Network/MangosSocketMgrImpl.h
@@ -17,6 +17,7 @@
 
 #include <set>
 #include <atomic>
+#include <algorithm>
 
 #include "Log.h"
 #include "Common.h"
@@ -76,7 +77,7 @@ public:
 
 #if defined (ACE_HAS_EVENT_POLL) || defined (ACE_HAS_DEV_POLL)
 
-        imp = new ACE_Dev_Poll_Reactor();
+        imp = new ACE_Dev_Poll_Reactor(std::min(1024, ACE::max_handles()));
 
         imp->max_notify_iterations(128);
         imp->restart(1);

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -53,6 +53,8 @@
 #include <ace/Dev_Poll_Reactor.h>
 #include <signal.h>
 
+#include <algorithm>
+
 #ifdef WIN32
 #include "ServiceWin32.h"
 extern int m_ServiceStatus;
@@ -100,7 +102,7 @@ void remoteAccess()
 {
     #if defined (ACE_HAS_EVENT_POLL) || defined (ACE_HAS_DEV_POLL)
 
-    ACE_Dev_Poll_Reactor imp;
+    ACE_Dev_Poll_Reactor imp (std::min(1024, ACE::max_handles()));
 
     imp.max_notify_iterations (128);
     imp.restart (1);

--- a/src/realmd/Main.cpp
+++ b/src/realmd/Main.cpp
@@ -37,6 +37,8 @@
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 
+#include <algorithm>
+
 #include <ace/Get_Opt.h>
 #include <ace/Dev_Poll_Reactor.h>
 #include <ace/TP_Reactor.h>
@@ -226,7 +228,7 @@ extern int main(int argc, char **argv)
 #endif
 
 #if defined (ACE_HAS_EVENT_POLL) || defined (ACE_HAS_DEV_POLL)
-    ACE_Reactor::instance(new ACE_Reactor(new ACE_Dev_Poll_Reactor(ACE::max_handles(), 1), 1), true);
+    ACE_Reactor::instance(new ACE_Reactor(new ACE_Dev_Poll_Reactor(std::min(1024, ACE::max_handles()), 1), 1), true);
 #else
     ACE_Reactor::instance(new ACE_Reactor(new ACE_TP_Reactor(), true), true);
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest

Both mangosd and realmd use (in certain configurations) ACE_Dev_Poll_Reactor from the ACE library, which allocated memory for every potential open file descriptor. Depending on the operating systems setting for maximum file descriptors per process this can lead to gigabytes of storage allocated.

We restrict the number of maximum file descriptors of our processes to at most 1024 (ACE handles adjusting the limit for the process), as this is a common setting that should be sufficient.

### Proof

You can observe this behaviour by changing the file descriptor limit with `ulimit -n`.

### Issues

This is related to my issue described in the comments of https://github.com/vmangos/core/issues/2561, which eventually turned out to be unrelated to the originally reported problem.

### How2Test

Run `ulimit -n 1073741816` (number taken from the environment I encountered the problem in), start mangosd/realmd and observe gigabytes of memory being allocated (before this patch is applied).

### Todo / Checklist

- [X] None
