### PR TITLE
Fix maul + swipe clearcasting bug

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7552,10 +7552,13 @@ uint32 Spell::CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spel
 #endif
 
     // Apply cost mod by spell unless delayed
-    if (spell) {
-        if (Player *modOwner = caster->GetSpellModOwner()) {
+    if (spell)
+    {
+        if (Player* modOwner = caster->GetSpellModOwner())
+        {
             // avoid consuming procs during prepare for melee swing spells
-            if(casting || !spellInfo->IsNextMeleeSwingSpell()) {
+            if (casting || !spellInfo->IsNextMeleeSwingSpell())
+            {
                 modOwner->ApplySpellMod(spellInfo->Id, SPELLMOD_COST, powerCost, spell);
             }
         }

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -361,7 +361,7 @@ class Spell
         SpellCastResult CheckCasterAuras() const;
 
         float CalculateDamage(SpellEffectIndex i, Unit* target) { return m_caster->CalculateSpellEffectValue(target, m_spellInfo, i, &m_currentBasePoints[i], this); }
-        static uint32 CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spell* spell = nullptr, Item* castItem = nullptr);
+        static uint32 CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spell* spell = nullptr, Item* castItem = nullptr, bool casting = true);
 
         bool HaveTargetsForEffect(SpellEffectIndex effect) const;
         void Delayed();

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -879,7 +879,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 amount, uint
                         bool notAtMaxStack = igniteAura->GetStackAmount() < 5;
                         
                         bool reapplyIgnite = igniteAura->GetAuraTicks() >= igniteAura->GetAuraMaxTicks();
-
+                        
                         if (!reapplyIgnite)
                         {
                             if (notAtMaxStack)

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -879,6 +879,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 amount, uint
                         bool notAtMaxStack = igniteAura->GetStackAmount() < 5;
                         
                         bool reapplyIgnite = igniteAura->GetAuraTicks() >= igniteAura->GetAuraMaxTicks();
+
                         if (!reapplyIgnite)
                         {
                             if (notAtMaxStack)

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -879,7 +879,6 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 amount, uint
                         bool notAtMaxStack = igniteAura->GetStackAmount() < 5;
                         
                         bool reapplyIgnite = igniteAura->GetAuraTicks() >= igniteAura->GetAuraMaxTicks();
-                        
                         if (!reapplyIgnite)
                         {
                             if (notAtMaxStack)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
I have very limited vmangos experience so I have no idea if this is a smart way to fix this bug or if it will have other side effects.  Just wanted to help out a druid in my guild :)

If you gain clearcasting and then queue maul followed by swipe before maul gets used clearcasting gets consumed and you pay the rage cost for both abilities.  

This seems to be happening because Spell:Prepare for maul is consuming the clearcasting charge:

```
some debug logs I added
ERROR: Spell 9881 current cost 150  (this is Spell::prepare for maul)
ERROR: Checking mod type 108 charges 1 value -100 spellId 16870
ERROR: Spell 9881 new cost 0 (CC got applied but spell not cast yet)
ERROR: ---
ERROR: Spell 9908 current cost 200 (this is Spell::prepare for swipe)
ERROR: Checking mod type 108 charges -1 value -100 spellId 16870
ERROR: mod out of charges
ERROR: Spell 9908 new cost 200
ERROR: ---
ERROR: Spell 9908 current cost 200 (this is Spell::cast for swipe)
ERROR: Checking mod type 108 charges -1 value -100 spellId 16870
ERROR: mod out of charges
ERROR: Spell 9908 new cost 200
ERROR: ---
ERROR: Spell 9881 current cost 150 (this is Spell::cast for maul)
ERROR: Spell 9881 new cost 150 (seems to be when mana actually deducted)
ERROR: ---
```

To fix I made it so that `ApplySpellMod` doesn't get called during `Spell:Prepare` for `IsNextMeleeSwingSpell()` spells.  
Again no idea if this is a smart way to do it or whether there might be other types of delayed spells with similar bugs.


### Proof
<!-- Link resources as proof -->
[maul bug](https://www.youtube.com/watch?v=TNyTor81b6A)
Can see I start with 100 rage and end with 65 (maul 15, swipe 20) and lose clearcasting

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2604

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1.  Use omen of clarity 
2.  switch to bear form
3.  turn on 100% proc cheat + auto to get clearcasting
4.  use maul -> swipe in quick succession right after an auto attack
5.  check that you don't pay the rage cost for swipe and clearcasting is consumed (if you start at 100 rage should end at 85)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
