### PR TITLE
Target furthest player on poison charge

### DIFF
--- a/sql/migrations/20240413233003_world.sql
+++ b/sql/migrations/20240413233003_world.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20240413233003');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20240413233003');
+-- Add your query below.
+
+
+/*
+ - Switch Necro Stalker and Venom Stalker to use script that targets farthest player.
+*/
+UPDATE `creature_template` SET `spell_list_id`=0,`script_name`='poison_charge_stalker_ai' WHERE `entry`=16453 OR `entry`=15976;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
@@ -1760,7 +1760,7 @@ struct mob_poison_charge_stalkerAI : public ScriptedAI
 
 	void Reset() override
 	{
-		m_uiChargeTimer = 0;
+		m_uiChargeTimer = urand(8000, 12000);
 	}
 
     void UpdateAI(uint32 const uiDiff) override


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Venom/Necro stalkers should venom charge the furthest target in LOS similar to surgers.  

### Proof
<!-- Link resources as proof -->
https://us.forums.blizzard.com/en/wow/t/venom-stalkers-venom-charge/808441
https://www.reddit.com/r/classicwow/comments/l0ke38/naxx_trash_guide/
https://youtu.be/lK86U0hXTZU?si=KoHPX_9U4vRF0Mso&t=23

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Engage Venom/Necro Stalkers with multiple people and see if they charge furthest person in LOS.
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
