### PR TITLE
Add partybot pull command.

### DIFF
--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -99,6 +99,7 @@ ChatCommand * ChatHandler::getCommandTable()
         { "setrole",    SEC_ADMINISTRATOR,      false, &ChatHandler::HandlePartyBotSetRoleCommand,     "", nullptr },
         { "attackstart",SEC_ADMINISTRATOR,      false, &ChatHandler::HandlePartyBotAttackStartCommand, "", nullptr },
         { "attackstop", SEC_ADMINISTRATOR,      false, &ChatHandler::HandlePartyBotAttackStopCommand,  "", nullptr },
+        { "pull",       SEC_ADMINISTRATOR,      false, &ChatHandler::HandlePartyBotPullCommand,        "", nullptr },
         { "aoe",        SEC_ADMINISTRATOR,      false, &ChatHandler::HandlePartyBotAoECommand,         "", nullptr },
         { "ccmark",     SEC_ADMINISTRATOR,      false, &ChatHandler::HandlePartyBotControlMarkCommand, "", nullptr },
         { "focusmark",  SEC_ADMINISTRATOR,      false, &ChatHandler::HandlePartyBotFocusMarkCommand,   "", nullptr },

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -273,6 +273,7 @@ class ChatHandler
         bool HandlePartyBotSetRoleCommand(char * args);
         bool HandlePartyBotAttackStartCommand(char * args);
         bool HandlePartyBotAttackStopCommand(char * args);
+        bool HandlePartyBotPullCommand(char * args);
         bool HandlePartyBotAoECommand(char * args);
         bool HandlePartyBotControlMarkCommand(char * args);
         bool HandlePartyBotFocusMarkCommand(char * args);


### PR DESCRIPTION
## 🍰 Pullrequest
This adds a `.partybot pull` command which instructs all tanks in the group to attack a targeted mob and pauses all DPS in the group (for 10 seconds by default, but the duration can also be specified).

Usage (when targeting a mob to be pulled):

```sh
.partybot pull [duration] # duration in milliseconds that the DPS should be paused for; optional, default is 10000 milliseconds
```

The duration has to be specified in milliseconds so it's consistent with [the `.partybot pause` command](https://github.com/vmangos/core/blob/ae1a317374dbf020693ae396f135a42436ef8a3f/src/game/PlayerBots/PlayerBotMgr.cpp#L1551-L1629), but it's a quick change if seconds are preferable here (imo, seconds would be precise enough and simpler to use, but I didn't want to deviate from the established syntax).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Closes #1794

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- `.partybot add tank`
- `.partybot add dps`
- `.partybot add healer`
- Target a mob
- `.partybot pull`
- Observe the tank attacking the target and the DPS getting paused for 10 seconds; the healer should not be paused and start healing the tank
- Target another mob after the first one dies
- `.partybot pull 5000`
- Observe the tank attacking the target and the DPS getting paused for 5 seconds (since we override the default 10 seconds); like before, the healer should not be paused

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] None