### PR TITLE
Fix incorrectly named outdoor PvP config options.

### DIFF
--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -24,7 +24,7 @@ ConfVersion=2010100901
 #
 #	   HonorDir
 #		     Folder to store HCR files. These are logs of weekly honor calculation.
-#		     By default logs are stored in the current directory of the running program.	                    
+#		     By default logs are stored in the current directory of the running program.
 #
 #    LoginDatabase.Info
 #    WorldDatabase.Info
@@ -387,7 +387,7 @@ Anticrash.Rearm.Timer = 60000
 #    PvP.DishonorableKills
 #        Whether to give dishonorable kills to players who kill civilians.
 #        Default: 1
-#  
+#
 #    PvP.CityProtector
 #        Whether to assign City Protector titles on honor update or not.
 #        Default: 0
@@ -960,7 +960,7 @@ PerformanceLog.SlowPacketBroadcast      = 0
 #                 1 (allowed)
 #
 #    Group.OfflineLeaderDelay
-#        A grace period for an offline group leader to reconnect before tranfering leadership to the next suitable member of the group (in secs) 
+#        A grace period for an offline group leader to reconnect before tranfering leadership to the next suitable member of the group (in secs)
 #        Default: 300 (5 minutes)
 #                   0 (Do not transfer group leadership)
 #
@@ -1410,7 +1410,7 @@ GuidReserveSize.GameObject = 1000
 #        Minimum level to /yell in chat
 #        Default: 0
 #
-#    YellRange.LinearScale.MaxLevel 
+#    YellRange.LinearScale.MaxLevel
 #    YellRange.QuadraticScale.MaxLevel
 #        Limit yell range based on level
 #        Default: 0
@@ -2676,15 +2676,20 @@ Alterac.InitMaxPlayers = 0
 ###################################################################################################################
 # OUTDOOR PVP CONFIG
 #
-#    OutdoorPvp.SIEnabled               #Enable Silithus Outdoor pvp
-#    OutdoorPvp.EPEnabled               #Enable Eastern Plaguelands Outdoor pvp
+#    OutdoorPvP.SI.Enable
+#        Enable Silithus Outdoor PvP
+#        Default: 1 (enable)
+#                 0 (disable)
+#
+#    OutdoorPvP.EP.Enable
+#        Enable Eastern Plaguelands Outdoor PvP
 #        Default: 1 (enable)
 #                 0 (disable)
 #
 ###################################################################################################################
 
-OutdoorPvp.SIEnabled = 1
-OutdoorPvp.EPEnabled = 1
+OutdoorPvP.SI.Enable = 1
+OutdoorPvP.EP.Enable = 1
 
 ###################################################################################################################
 # MEETING STONE LFG CONFIG


### PR DESCRIPTION
## 🍰 Pullrequest
This fixes the incorrectly named outdoor PvP config options in the example configuration; their names were changed in the config file in https://github.com/vmangos/core/commit/dce57fee270eb7a08a609ecb4a6e69d85b0ee27a, but not in the code that reads them.

I chose to use the names from the code so people who might have already figured out that the names were wrong and adjusted their config file accordingly won't have to change them once again.

### Proof
<!-- Link resources as proof -->
- See https://github.com/vmangos/core/issues/2259#issuecomment-2066359257 for more details

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
