### PR TITLE
Partybot rework of the pause command, more flexible.

### DIFF
--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1670,12 +1670,11 @@ bool ChatHandler::HandlePartyBotPullCommand(char* args)
     }
 
     uint32 duration;
-    char* arg = ExtractArg(&args);
 
-    if (isNumeric(arg))
-        duration = atoi(arg) * IN_MILLISECONDS; // in sec
-    else
-        duration = 10 * IN_MILLISECONDS;
+    if (!ExtractUInt32(&args, duration))
+        duration = 10;
+
+    duration = duration * IN_MILLISECONDS;
 
     for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
     {

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1670,7 +1670,11 @@ bool ChatHandler::HandlePartyBotPullCommand(char* args)
     }
 
     uint32 duration;
-    if (!ExtractUInt32(&args, duration))
+    char* arg = ExtractArg(&args);
+
+    if (isNumeric(arg))
+        duration = atoi(arg) * IN_MILLISECONDS; // in sec
+    else
         duration = 10 * IN_MILLISECONDS;
 
     for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1622,16 +1622,12 @@ bool ChatHandler::HandlePartyBotPauseHelper(char* args, bool pause)
             if (success)
             {
                 if (pause)
-                {
                     PSendSysMessage("Partybots %s paused for %u seconds.", option.c_str(), (duration / IN_MILLISECONDS));
-                }
                 else
-                    SendSysMessage("All party bots unpaused.");
+                    PSendSysMessage("Partybots %s unpaused.", option.c_str());
             }
             else
-            {
                 SendSysMessage("No party bots in group.");
-            }
         }
         else
         {

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1551,7 +1551,7 @@ bool HandlePartyBotPauseApplyHelper(Player* pTarget, uint32 duration)
 bool ChatHandler::HandlePartyBotPauseHelper(char* args, bool pause)
 {
     std::string option = "all"; // all, tank, dps, healer
-    uint32 duration = 5 * MINUTE * IN_MILLISECONDS; // in sec
+    uint32 duration = 0;
 
     while (char* arg = ExtractArg(&args))
     {
@@ -1559,9 +1559,14 @@ bool ChatHandler::HandlePartyBotPauseHelper(char* args, bool pause)
             continue;
 
         if (pause && isNumeric(arg))
-            duration = atoi(arg) * IN_MILLISECONDS;
+            duration = atoi(arg) * IN_MILLISECONDS; // in sec
         else
             option = arg;
+    }
+
+    if (pause && !duration)
+    {
+        duration = 5 * MINUTE * IN_MILLISECONDS;
     }
 
     if (duration > 5 * HOUR * IN_MILLISECONDS)


### PR DESCRIPTION
Added options for roles.
The approach to specifying time has been changed, not in milliseconds but in seconds. It's more convenient for a person.
The maximum pause time cannot be more than 5 hours.

Test:
.partybot pause 5 (default all)
.partybot pause 5 tank
.partybot pause 5 dps
.partybot pause 5 healer
.partybot pause 5 all

unpause to
.partybot unpause (default all)
.partybot unpause tank
.partybot unpause dps
.partybot unpause healer
.partybot unpause all
