### PR TITLE
Fix nesting of free().

### DIFF
--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -123,9 +123,7 @@ void CliRunnable::operator()()
                 s_canReadLine = false;
                 sWorld.QueueCliCommand(new CliCommandHolder(0, SEC_CONSOLE, nullptr, command.c_str(), &utf8print, &commandFinished));
             }
+            free(command_str);
         }
-        #ifndef WIN32
-        free(command_str);
-        #endif
     }
 }


### PR DESCRIPTION
## 🍰 Pullrequest
This fixes the GCC/Clang build error:
```
/home/runner/work/core/core/src/mangosd/CliRunnable.cpp: In member function ‘void CliRunnable::operator()()’:
/home/runner/work/core/core/src/mangosd/CliRunnable.cpp:128:14: error: ‘command_str’ was not declared in this scope
  128 |         free(command_str);
      |              ^~~~~~~~~~~
[ 99%] Building CXX object src/mangosd/CMakeFiles/mangosd.dir/MaNGOSsoap.cpp.o
make[2]: *** [src/mangosd/CMakeFiles/mangosd.dir/build.make:76: src/mangosd/CMakeFiles/mangosd.dir/CliRunnable.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:556: src/mangosd/CMakeFiles/mangosd.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

The new `if (s_canReadLine)` introduced in https://github.com/vmangos/core/commit/79c5f503df39cd92eccc399443f8502eb8f9c248 probably caused the auto-merge to fuck up the nesting.

The PR also makes it so `free()` is used on Windows as well; when #2572 was opened, readline support didn't exist on Windows, but now it does (so the `free()` needs to happen there as well).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
