### PR TITLE
Prevent BattleBot addition messages from spamming all players in world.

### DIFF
--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -589,12 +589,12 @@ void PlayerBotMgr::AddBattleBot(BattleGroundQueueTypeId queueType, Team botTeam,
 
     if (botTeam == ALLIANCE)
     {
-        sWorld.SendWorldText(LANG_ALLIANCE_BATTLEBOT_ADDED, botLevel, queueType);
+        sWorld.SendWorldTextToBGAndQueue(LANG_ALLIANCE_BATTLEBOT_ADDED, botLevel, queueType, botLevel, queueType);
         sLog.Out(LOG_BG, LOG_LVL_BASIC, "[PlayerBotMgr] Adding level %u alliance battlebot to bg queue %u.", botLevel, queueType);
     }
     else
     {
-        sWorld.SendWorldText(LANG_HORDE_BATTLEBOT_ADDED, botLevel, queueType);
+        sWorld.SendWorldTextToBGAndQueue(LANG_HORDE_BATTLEBOT_ADDED, botLevel, queueType, botLevel, queueType);
         sLog.Out(LOG_BG, LOG_LVL_BASIC, "[PlayerBotMgr] Adding level %u horde battlebot to bg queue %u.", botLevel, queueType);
     }
 }

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2245,8 +2245,11 @@ void World::SendWorldText(int32 string_id, ...)
 }
 
 // Send a System Message to all players in the same battleground or queue (except self if mentioned)
-void World::SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel, BattleGroundQueueTypeId queueType, ...)
+void World::SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel, uint32 queueType, ...)
 {
+    BattleGroundTypeId bgTypeId = BattleGroundMgr::BgTemplateId(static_cast<BattleGroundQueueTypeId>(queueType));
+    BattleGroundBracketId queuedPlayerBracket = Player::GetBattleGroundBracketIdFromLevel(bgTypeId, queuedPlayerLevel);
+
     va_list ap;
     va_start(ap, string_id);
 
@@ -2260,19 +2263,18 @@ void World::SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel,
             if (player && player->IsInWorld())
             {
                 // Always announce it to all GMs.
-                if (player->GetSession()->GetSecurity() > SEC_PLAYER)
+                if (session->GetSecurity() > SEC_PLAYER)
                 {
                     wt_do(player);
                     continue;
                 }
 
-                BattleGroundTypeId bgTypeId = BattleGroundMgr::BgTemplateId(queueType);
                 // If player is queued or already inside a BG matching the BG type.
                 if ((player->InBattleGroundQueue() && player->GetQueuedBattleground() == queueType) ||
                     (player->InBattleGround() && player->GetBattleGroundTypeId() == bgTypeId))
                 {
                     // If player bracket matches the queued player bracket.
-                    if (player->GetBattleGroundBracketIdFromLevel(bgTypeId) == Player::GetBattleGroundBracketIdFromLevel(bgTypeId, queuedPlayerLevel))
+                    if (player->GetBattleGroundBracketIdFromLevel(bgTypeId) == queuedPlayerBracket)
                         wt_do(player);
                 }
 

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2260,7 +2260,7 @@ void World::SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel,
             if (player && player->IsInWorld())
             {
                 // Always announce it to all GMs.
-                if (player->IsGameMaster())
+                if (player->GetSession()->GetSecurity() > SEC_PLAYER)
                 {
                     wt_do(player);
                     continue;

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2259,6 +2259,13 @@ void World::SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel,
             Player* player = session->GetPlayer();
             if (player && player->IsInWorld())
             {
+                // Always announce it to all GMs.
+                if (player->IsGameMaster())
+                {
+                    wt_do(player);
+                    continue;
+                }
+
                 BattleGroundTypeId bgTypeId = BattleGroundMgr::BgTemplateId(queueType);
                 // If player is queued or already inside a BG matching the BG type.
                 if ((player->InBattleGroundQueue() && player->GetQueuedBattleground() == queueType) ||

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2244,6 +2244,38 @@ void World::SendWorldText(int32 string_id, ...)
     va_end(ap);
 }
 
+// Send a System Message to all players in the same battleground or queue (except self if mentioned)
+void World::SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel, BattleGroundQueueTypeId queueType, ...)
+{
+    va_list ap;
+    va_start(ap, string_id);
+
+    MaNGOS::WorldWorldTextBuilder wt_builder(string_id, &ap);
+    MaNGOS::LocalizedPacketListDo<MaNGOS::WorldWorldTextBuilder> wt_do(wt_builder);
+    for (const auto& itr : m_sessions)
+    {
+        if (WorldSession* session = itr.second)
+        {
+            Player* player = session->GetPlayer();
+            if (player && player->IsInWorld())
+            {
+                BattleGroundTypeId bgTypeId = BattleGroundMgr::BgTemplateId(queueType);
+                // If player is queued or already inside a BG matching the BG type.
+                if ((player->InBattleGroundQueue() && player->GetQueuedBattleground() == queueType) ||
+                    (player->InBattleGround() && player->GetBattleGroundTypeId() == bgTypeId))
+                {
+                    // If player bracket matches the queued player bracket.
+                    if (player->GetBattleGroundBracketIdFromLevel(bgTypeId) == Player::GetBattleGroundBracketIdFromLevel(bgTypeId, queuedPlayerLevel))
+                        wt_do(player);
+                }
+
+            }
+        }
+    }
+
+    va_end(ap);
+}
+
 void World::SendBroadcastTextToWorld(uint32 textId)
 {
     MaNGOS::WorldBroadcastTextBuilder wt_builder(textId);

--- a/src/game/World.h
+++ b/src/game/World.h
@@ -43,7 +43,6 @@
 #include <memory>
 #include <unordered_map>
 #include <thread>
-#include <BattleGroundDefines.h>
 
 class Object;
 class WorldSession;
@@ -808,7 +807,7 @@ class World
         void LoadConfigSettings(bool reload = false);
 
         void SendWorldText(int32 string_id, ...);
-        void SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel, BattleGroundQueueTypeId queueType, ...);
+        void SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel, uint32 queueType, ...);
         void SendBroadcastTextToWorld(uint32 textId);
 
         // Only for GMs with ticket notification ON

--- a/src/game/World.h
+++ b/src/game/World.h
@@ -43,6 +43,7 @@
 #include <memory>
 #include <unordered_map>
 #include <thread>
+#include <BattleGroundDefines.h>
 
 class Object;
 class WorldSession;
@@ -807,6 +808,7 @@ class World
         void LoadConfigSettings(bool reload = false);
 
         void SendWorldText(int32 string_id, ...);
+        void SendWorldTextToBGAndQueue(int32 string_id, uint32 queuedPlayerLevel, BattleGroundQueueTypeId queueType, ...);
         void SendBroadcastTextToWorld(uint32 textId);
 
         // Only for GMs with ticket notification ON


### PR DESCRIPTION
## 🍰 Pullrequest
At this moment the message of adding a BattleBot will spam all players in world; with this change only players who are queued or inside the relevant BG will get notified.