### PR TITLE
Fix Detect Magic to have one debuff per caster.

### DIFF
--- a/sql/migrations/20240504222324_world.sql
+++ b/sql/migrations/20240504222324_world.sql
@@ -10,8 +10,7 @@ INSERT INTO `migrations` VALUES ('20240504222324');
 
 
 -- Fix Detect Magic to have one debuff per caster
-INSERT INTO `spell_mod` (`Id`, `procChance`, `procFlags`, `procCharges`, `DurationIndex`, `Category`, `CastingTimeIndex`, `StackAmount`, `SpellIconID`, `activeIconID`, `manaCost`, `Attributes`, `AttributesEx`, `AttributesEx2`, `AttributesEx3`, `AttributesEx4`, `Custom`, `InterruptFlags`, `AuraInterruptFlags`, `ChannelInterruptFlags`, `Dispel`, `Stances`, `StancesNot`, `SpellVisual`, `ManaCostPercentage`, `StartRecoveryCategory`, `StartRecoveryTime`, `MaxAffectedTargets`, `MaxTargetLevel`, `DmgClass`, `rangeIndex`, `RecoveryTime`, `CategoryRecoveryTime`, `SpellFamilyName`, `SpellFamilyFlags`, `Mechanic`, `EquippedItemClass`, `Comment`) VALUES 
-(2855, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 4096, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, 'Detect Magic: one debuff per caster');
+UPDATE `spell_template` SET `customFlags`=4096 WHERE `entry`=2855;
 
 
 -- End of migration.

--- a/sql/migrations/20240504222324_world.sql
+++ b/sql/migrations/20240504222324_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20240504222324');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20240504222324');
+-- Add your query below.
+
+
+-- Fix Detect Magic to have one debuff per caster
+INSERT INTO `spell_mod` (`Id`, `procChance`, `procFlags`, `procCharges`, `DurationIndex`, `Category`, `CastingTimeIndex`, `StackAmount`, `SpellIconID`, `activeIconID`, `manaCost`, `Attributes`, `AttributesEx`, `AttributesEx2`, `AttributesEx3`, `AttributesEx4`, `Custom`, `InterruptFlags`, `AuraInterruptFlags`, `ChannelInterruptFlags`, `Dispel`, `Stances`, `StancesNot`, `SpellVisual`, `ManaCostPercentage`, `StartRecoveryCategory`, `StartRecoveryTime`, `MaxAffectedTargets`, `MaxTargetLevel`, `DmgClass`, `rangeIndex`, `RecoveryTime`, `CategoryRecoveryTime`, `SpellFamilyName`, `SpellFamilyFlags`, `Mechanic`, `EquippedItemClass`, `Comment`) VALUES 
+(2855, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 4096, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, 'Detect Magic: one debuff per caster');
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes Detect Magic to have one debuff per caster. 
Currently only one debuff is applied, no matter how many casters apply Detect Magic. It should be possible to apply multiple Detect Magic on a target. One for every mage.

I used SPELL_CUSTOM_SEPARATE_AURA_PER_CASTER to fix the spell, as there are no alternatives from what I've seen.
Image from vmangos with this PR applied:
![Wow_THk8dpsYsI](https://github.com/vmangos/core/assets/6137576/4a97ddd3-deb2-465f-ad7f-13d53631812f)

### Proof
<!-- Link resources as proof -->
https://youtu.be/9IMfIkC0dxg?t=40
Video from vanilla with Shazzrah having 3 Detect Magic debuffs on him

https://youtu.be/xchHtS9AG38?t=3m3s
Video from vanilla with Shazzrah having 2 Detect Magic debuffs on him

https://youtu.be/HWx1o7ECjI8?t=18m38s
Video from vanilla with a Rogue having 2 Detect Magic debuffs on him

Image from classic with two mages applying detect magic on a mob:
![WowClassicT_kigMHTqEUw](https://user-images.githubusercontent.com/6137576/189505302-229305d5-74ad-4fd2-8d95-3535ab16303d.png)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #1620

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
