### PR TITLE
Large PR: Make use of smart-pointers for Database::Query

### DIFF
--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -41,7 +41,6 @@ set(framework_SRCS
   Policies/SingletonImp.h
   Policies/ThreadingModel.h
   Utilities/ByteConverter.h
-  Utilities/Callback.h
   Utilities/EventProcessor.h
   Utilities/EventMap.h
   Utilities/LinkedList.h

--- a/src/game/AI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/CreatureEventAIMgr.cpp
@@ -41,7 +41,7 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Events()
     m_CreatureEventAI_Event_Map.clear();
 
     // Gather event data
-    QueryResult* result = WorldDatabase.Query("SELECT id, creature_id, condition_id, event_type, event_inverse_phase_mask, event_chance, event_flags, "
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT id, creature_id, condition_id, event_type, event_inverse_phase_mask, event_chance, event_flags, "
                           "event_param1, event_param2, event_param3, event_param4, "
                           "action1_script, action2_script, action3_script "
                           "FROM creature_ai_events");
@@ -348,8 +348,6 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Events()
             ++Count;
         }
         while (result->NextRow());
-
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u CreatureEventAI events.", Count);

--- a/src/game/AccountMgr.h
+++ b/src/game/AccountMgr.h
@@ -100,7 +100,7 @@ class AccountMgr
         static bool normalizeString(std::string& utf8str);
         // Nostalrius
         void Update(uint32 diff);
-        void LoadIPBanList(QueryResult* result, bool silent=false);
+        void LoadIPBanList(std::unique_ptr<QueryResult> result, bool silent=false);
         void LoadAccountBanList(bool silent=false);
         void BanIP(std::string const& ip, uint32 unbandate) { m_ipBanned[ip] = unbandate; }
         void UnbanIP(std::string const& ip) { m_ipBanned.erase(ip); }

--- a/src/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -345,7 +345,7 @@ void AuctionHouseMgr::LoadAuctionHouses()
 
 void AuctionHouseMgr::LoadAuctionItems()
 {
-    //                                                     0               1                    2        3           4          5        6               7                     8             9       10                           11
+    //                                                                     0               1                    2        3           4          5        6               7                     8             9       10                           11
     std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `creator_guid`, `gift_creator_guid`, `count`, `duration`, `charges`, `flags`, `enchantments`, `random_property_id`, `durability`, `text`, `item_guid`, `item_instance`.`item_id` FROM `auction` JOIN `item_instance` ON `item_guid` = `guid`");
 
     if (!result)

--- a/src/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -346,7 +346,7 @@ void AuctionHouseMgr::LoadAuctionHouses()
 void AuctionHouseMgr::LoadAuctionItems()
 {
     //                                                     0               1                    2        3           4          5        6               7                     8             9       10                           11
-    QueryResult* result = CharacterDatabase.Query("SELECT `creator_guid`, `gift_creator_guid`, `count`, `duration`, `charges`, `flags`, `enchantments`, `random_property_id`, `durability`, `text`, `item_guid`, `item_instance`.`item_id` FROM `auction` JOIN `item_instance` ON `item_guid` = `guid`");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `creator_guid`, `gift_creator_guid`, `count`, `duration`, `charges`, `flags`, `enchantments`, `random_property_id`, `durability`, `text`, `item_guid`, `item_instance`.`item_id` FROM `auction` JOIN `item_instance` ON `item_guid` = `guid`");
 
     if (!result)
     {
@@ -390,7 +390,6 @@ void AuctionHouseMgr::LoadAuctionItems()
         ++count;
     }
     while (result->NextRow());
-    delete result;
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u auction items", count);
@@ -398,7 +397,7 @@ void AuctionHouseMgr::LoadAuctionItems()
 
 void AuctionHouseMgr::LoadAuctions()
 {
-    QueryResult* result = CharacterDatabase.Query("SELECT COUNT(*) FROM auction");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT COUNT(*) FROM auction");
     if (!result)
     {
         BarGoLink bar(1);
@@ -410,7 +409,6 @@ void AuctionHouseMgr::LoadAuctions()
 
     Field* fields = result->Fetch();
     uint32 AuctionCount = fields[0].GetUInt32();
-    delete result;
 
     if (!AuctionCount)
     {
@@ -494,7 +492,6 @@ void AuctionHouseMgr::LoadAuctions()
 
     }
     while (result->NextRow());
-    delete result;
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u auctions", AuctionCount);

--- a/src/game/AuraRemovalMgr.cpp
+++ b/src/game/AuraRemovalMgr.cpp
@@ -31,7 +31,7 @@ void AuraRemovalManager::LoadFromDB()
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "> Loading table `instance_buff_removal`");
     uint32 count = 0;
-    QueryResult* result = WorldDatabase.Query("SELECT map_id, spell_id, enabled, flags, comment FROM instance_buff_removal");
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT map_id, spell_id, enabled, flags, comment FROM instance_buff_removal");
     if (!result)
     {
         BarGoLink bar(1);
@@ -62,8 +62,6 @@ void AuraRemovalManager::LoadFromDB()
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u entries from instance_buff_removal", count);
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
-
-        delete result;
     }
 }
 

--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -1591,7 +1591,7 @@ void BattleGroundMgr::LoadBattleEventIndexes()
     uint32 count = 0;
 
     std::unique_ptr<QueryResult> result =
-        //                           0         1           2                3                4              5           6
+        //                               0         1           2                3                4              5           6
         WorldDatabase.Query("SELECT data.typ, data.guid1, data.ev1 AS ev1, data.ev2 AS ev2, data.map AS m, data.guid2, description.map, "
                             //                              7                  8                   9
                             "description.event1, description.event2, description.description "

--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -1503,7 +1503,7 @@ void BattleGroundMgr::LoadBattleMastersEntry()
 {
     m_battleMastersMap.clear();                              // need for reload case
 
-    QueryResult* result = WorldDatabase.Query("SELECT `entry`, `bg_template` FROM `battlemaster_entry`");
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT `entry`, `bg_template` FROM `battlemaster_entry`");
 
     uint32 count = 0;
 
@@ -1538,8 +1538,6 @@ void BattleGroundMgr::LoadBattleMastersEntry()
 
     }
     while (result->NextRow());
-
-    delete result;
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u battlemaster entries", count);
@@ -1592,7 +1590,7 @@ void BattleGroundMgr::LoadBattleEventIndexes()
 
     uint32 count = 0;
 
-    QueryResult* result =
+    std::unique_ptr<QueryResult> result =
         //                           0         1           2                3                4              5           6
         WorldDatabase.Query("SELECT data.typ, data.guid1, data.ev1 AS ev1, data.ev2 AS ev2, data.map AS m, data.guid2, description.map, "
                             //                              7                  8                   9
@@ -1692,7 +1690,6 @@ void BattleGroundMgr::LoadBattleEventIndexes()
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u battleground eventindexes", count);
-    delete result;
 }
 
 // Offline BG queue system

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -1363,7 +1363,7 @@ void ChatHandler::LoadRbacPermissions()
         } while (result->NextRow());
     }
 
-    result.reset(LoginDatabase.Query("SELECT `account_id`, `permission_id`, `granted` FROM `rbac_account_permissions`"));
+    result = LoginDatabase.Query("SELECT `account_id`, `permission_id`, `granted` FROM `rbac_account_permissions`");
     if (result)
     {
         do
@@ -1389,7 +1389,7 @@ void ChatHandler::LoadRbacPermissions()
 
     ChatCommand* commandTable = getCommandTable();
 
-    result.reset(LoginDatabase.Query("SELECT `command`, `permission_id` FROM `rbac_command_permissions`"));
+    result = LoginDatabase.Query("SELECT `command`, `permission_id` FROM `rbac_command_permissions`");
     if (result)
     {
         do

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -1079,8 +1079,8 @@ class ChatHandler
         void ShowAllUpdateFieldsHelper(Object const* pTarget);
         void ShowUpdateFieldHelper(Object const* pTarget, uint16 index);
         SkillLineEntry const* FindSkillLineEntryFromProfessionName(char* args, std::string& nameOut);
-        bool LookupPlayerSearchCommand(QueryResult* result, uint32* limit = nullptr);
-        bool HandleBanListHelper(QueryResult* result);
+        bool LookupPlayerSearchCommand(std::unique_ptr<QueryResult> result, uint32* limit = nullptr);
+        bool HandleBanListHelper(std::unique_ptr<QueryResult> result);
         bool HandleBanHelper(BanMode mode, char* args);
         bool HandleBanInfoHelper(uint32 accountid, char const* accountname);
         bool HandleUnBanHelper(BanMode mode, char* args);

--- a/src/game/Chat/MasterPlayer.cpp
+++ b/src/game/Chat/MasterPlayer.cpp
@@ -211,7 +211,7 @@ void MasterPlayer::AddNewMailDeliverTime(time_t deliver_time)
 
 
 // load mailed item which should receive current player
-void MasterPlayer::LoadMailedItems(QueryResult* result)
+void MasterPlayer::LoadMailedItems(std::unique_ptr<QueryResult> result)
 {
     // data needs to be at first place for Item::LoadFromDB
     // 0             1                  2      3         4        5      6             7                   8           9     10       11         12       13
@@ -264,7 +264,7 @@ void MasterPlayer::LoadMailedItems(QueryResult* result)
     while (result->NextRow());
 }
 
-void MasterPlayer::LoadMails(QueryResult* result)
+void MasterPlayer::LoadMails(std::unique_ptr<QueryResult> result)
 {
     m_mail.clear();
     Player* player = GetSession()->GetPlayer();
@@ -362,11 +362,11 @@ void MasterPlayer::removeActionButton(uint8 button)
         buttonItr->second.uState = ACTIONBUTTON_DELETED;    // saved, will deleted at next save
 }
 
-void MasterPlayer::LoadActions(QueryResult* result)
+void MasterPlayer::LoadActions(std::unique_ptr<QueryResult> result)
 {
     m_actionButtons.clear();
 
-    //QueryResult* result = CharacterDatabase.PQuery("SELECT button,action,type FROM character_action WHERE guid = '%u' ORDER BY button",GetGUIDLow());
+    //std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT button,action,type FROM character_action WHERE guid = '%u' ORDER BY button",GetGUIDLow());
 
     if (result)
     {
@@ -438,9 +438,9 @@ void MasterPlayer::SaveActions()
 }
 
 
-void MasterPlayer::LoadSocial(QueryResult* result)
+void MasterPlayer::LoadSocial(std::unique_ptr<QueryResult> result)
 {
-    m_social = sSocialMgr.LoadFromDB(result, GetObjectGuid());
+    m_social = sSocialMgr.LoadFromDB(std::move(result), GetObjectGuid());
     m_social->SetMasterPlayer(this);
 }
 

--- a/src/game/Chat/MasterPlayer.h
+++ b/src/game/Chat/MasterPlayer.h
@@ -48,10 +48,10 @@ public:
     // SOCIAL SYSTEM
     PlayerSocial* GetSocial() const { return m_social; }
     void SetSocial(PlayerSocial* s) { m_social = s; }
-    void LoadSocial(QueryResult* result);
+    void LoadSocial(std::unique_ptr<QueryResult> result);
 
     // ACTIONS SYSTEM
-    void LoadActions(QueryResult* result);
+    void LoadActions(std::unique_ptr<QueryResult> result);
     void SaveActions();
     ActionButtonList& GetActionButtons() { return m_actionButtons; }
     void SendInitialActionButtons() const;
@@ -59,8 +59,8 @@ public:
     void removeActionButton(uint8 button);
 
     // MAIL SYSTEM
-    void LoadMailedItems(QueryResult* result);
-    void LoadMails(QueryResult* result);
+    void LoadMailedItems(std::unique_ptr<QueryResult> result);
+    void LoadMails(std::unique_ptr<QueryResult> result);
     void SaveMails();
     void UpdateNextMailTimeAndUnreads();
     void AddNewMailDeliverTime(time_t deliver_time);

--- a/src/game/Commands/AccountCommands.cpp
+++ b/src/game/Commands/AccountCommands.cpp
@@ -325,7 +325,7 @@ bool ChatHandler::HandleAccountOnlineListCommand(char* args)
 
     // Get the list of accounts ID logged to the realm
     //                                                  0     1           2          3          4
-    QueryResult* result = LoginDatabase.PQuery("SELECT `id`, `username`, `last_ip`, `gmlevel`, `expansion` FROM `account` WHERE `current_realm` = %u LIMIT %u", realmID, limit);
+    std::unique_ptr<QueryResult> result = LoginDatabase.PQuery("SELECT `id`, `username`, `last_ip`, `gmlevel`, `expansion` FROM `account` WHERE `current_realm` = %u LIMIT %u", realmID, limit);
     if (!result)
     {
         SendSysMessage(LANG_ACCOUNT_LIST_EMPTY);
@@ -334,8 +334,8 @@ bool ChatHandler::HandleAccountOnlineListCommand(char* args)
     }
 
     uint32 count = 0;
-    AccountSearchHandler::ShowAccountListHelper(result, *this, count, limit, true);
-    delete result;
+    AccountSearchHandler::ShowAccountListHelper(std::move(result), *this, count, limit, true);
+
     return true;
 }
 
@@ -543,7 +543,7 @@ bool ChatHandler::HandleBanAllIPCommand(char* args)
 
     std::string ip = ipStr;
     LoginDatabase.escape_string(ip);
-    QueryResult* result = LoginDatabase.PQuery("SELECT `id`, `username` FROM `account` WHERE `id` >= %u AND `last_ip` " _LIKE_ " " _CONCAT2_("'%s'", "'%%'"), minId, ip.c_str());
+    std::unique_ptr<QueryResult> result = LoginDatabase.PQuery("SELECT `id`, `username` FROM `account` WHERE `id` >= %u AND `last_ip` " _LIKE_ " " _CONCAT2_("'%s'", "'%%'"), minId, ip.c_str());
     if (!result)
     {
         PSendSysMessage("No account found on IP '%s'", ip.c_str());
@@ -563,7 +563,6 @@ bool ChatHandler::HandleBanAllIPCommand(char* args)
         accountsIdToName[fields[0].GetUInt32()] = fields[1].GetCppString();
     } while (result->NextRow());
 
-    delete result;
     if (result = CharacterDatabase.PQuery("SELECT `account` FROM `characters` WHERE `account` IN (%s) AND `level` > %u GROUP BY `account`", allAccounts.str().c_str(), maxLevel))
     {
         do
@@ -571,7 +570,6 @@ bool ChatHandler::HandleBanAllIPCommand(char* args)
             Field* fields = result->Fetch();
             accountsToBan.erase(fields[0].GetUInt32());
         } while (result->NextRow());
-        delete result;
     }
 
     uint32 bannedCount = 0;
@@ -769,7 +767,7 @@ bool ChatHandler::HandleBanInfoCharacterCommand(char* args)
 
 bool ChatHandler::HandleBanInfoHelper(uint32 accountid, char const* accountname)
 {
-    QueryResult* result = LoginDatabase.PQuery(
+    std::unique_ptr<QueryResult> result = LoginDatabase.PQuery(
     "SELECT FROM_UNIXTIME(`bandate`), `unbandate`-`bandate`, `active`, `unbandate`,`banreason`,`bannedby`,COALESCE(`name`, \"NoRealm\") , `gmlevel` "
     "FROM `account_banned` LEFT JOIN `realmlist` ON `realmlist`.`id` = `realm` "
     "WHERE `account_banned`.`id` = '%u' ORDER BY `bandate` ASC", accountid);
@@ -800,8 +798,7 @@ bool ChatHandler::HandleBanInfoHelper(uint32 accountid, char const* accountname)
                         fields[0].GetString(), bantime.c_str(), active ? GetMangosString(LANG_BANINFO_YES) : GetMangosString(LANG_BANINFO_NO), banreason.c_str(), authorName.c_str());
     }
     while (result->NextRow());
-
-    delete result;
+;
     return true;
 }
 
@@ -820,7 +817,7 @@ bool ChatHandler::HandleBanInfoIPCommand(char* args)
     std::string IP = cIP;
 
     LoginDatabase.escape_string(IP);
-    QueryResult* result = LoginDatabase.PQuery("SELECT `ip`, FROM_UNIXTIME(`bandate`), FROM_UNIXTIME(`unbandate`), `unbandate`-UNIX_TIMESTAMP(), `banreason`,`bannedby`,`unbandate`-`bandate` FROM `ip_banned` WHERE `ip` = '%s'", IP.c_str());
+    std::unique_ptr<QueryResult> result = LoginDatabase.PQuery("SELECT `ip`, FROM_UNIXTIME(`bandate`), FROM_UNIXTIME(`unbandate`), `unbandate`-UNIX_TIMESTAMP(), `banreason`,`bannedby`,`unbandate`-`bandate` FROM `ip_banned` WHERE `ip` = '%s'", IP.c_str());
     if (!result)
     {
         PSendSysMessage(LANG_BANINFO_NOIP);
@@ -832,7 +829,6 @@ bool ChatHandler::HandleBanInfoIPCommand(char* args)
     PSendSysMessage(LANG_BANINFO_IPENTRY,
                     fields[0].GetString(), fields[1].GetString(), permanent ? GetMangosString(LANG_BANINFO_NEVER) : fields[2].GetString(),
                     permanent ? GetMangosString(LANG_BANINFO_INFINITE) : secsToTimeString(fields[3].GetUInt64(), true).c_str(), fields[4].GetString(), fields[5].GetString());
-    delete result;
     return true;
 }
 
@@ -846,14 +842,14 @@ bool ChatHandler::HandleBanListCharacterCommand(char* args)
 
     std::string filter = cFilter;
     CharacterDatabase.escape_string(filter);
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `account` FROM `characters` WHERE `name` " _LIKE_ " " _CONCAT2_("'%s'", "'%%'"), filter.c_str());
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT `account` FROM `characters` WHERE `name` " _LIKE_ " " _CONCAT2_("'%s'", "'%%'"), filter.c_str());
     if (!result)
     {
         PSendSysMessage(LANG_BANLIST_NOCHARACTER);
         return true;
     }
 
-    return HandleBanListHelper(result);
+    return HandleBanListHelper(std::move(result));
 }
 
 bool ChatHandler::HandleBanListAccountCommand(char* args)
@@ -864,7 +860,7 @@ bool ChatHandler::HandleBanListAccountCommand(char* args)
     std::string filter = cFilter ? cFilter : "";
     LoginDatabase.escape_string(filter);
 
-    QueryResult* result;
+    std::unique_ptr<QueryResult> result;
 
     if (filter.empty())
     {
@@ -884,10 +880,10 @@ bool ChatHandler::HandleBanListAccountCommand(char* args)
         return true;
     }
 
-    return HandleBanListHelper(result);
+    return HandleBanListHelper(std::move(result));
 }
 
-bool ChatHandler::HandleBanListHelper(QueryResult* result)
+bool ChatHandler::HandleBanListHelper(std::unique_ptr<QueryResult> result)
 {
     PSendSysMessage(LANG_BANLIST_MATCHINGACCOUNT);
 
@@ -899,12 +895,11 @@ bool ChatHandler::HandleBanListHelper(QueryResult* result)
             Field* fields = result->Fetch();
             uint32 accountid = fields[0].GetUInt32();
 
-            QueryResult* banresult = LoginDatabase.PQuery("SELECT `account`.`username` FROM `account`,`account_banned` WHERE `account_banned`.`id`='%u' AND `account_banned`.`id`=`account`.`id`", accountid);
+            std::unique_ptr<QueryResult> banresult = LoginDatabase.PQuery("SELECT `account`.`username` FROM `account`,`account_banned` WHERE `account_banned`.`id`='%u' AND `account_banned`.`id`=`account`.`id`", accountid);
             if (banresult)
             {
                 Field* fields2 = banresult->Fetch();
                 PSendSysMessage("%s", fields2[0].GetString());
-                delete banresult;
             }
         }
         while (result->NextRow());
@@ -931,7 +926,7 @@ bool ChatHandler::HandleBanListHelper(QueryResult* result)
                 sAccountMgr.GetName(account_id, account_name);
 
             // No SQL injection. id is uint32.
-            QueryResult* banInfo = LoginDatabase.PQuery("SELECT `bandate`,`unbandate`,`bannedby`,`banreason` FROM `account_banned` WHERE `id` = %u ORDER BY `unbandate`", account_id);
+            std::unique_ptr<QueryResult> banInfo = LoginDatabase.PQuery("SELECT `bandate`,`unbandate`,`bannedby`,`banreason` FROM `account_banned` WHERE `id` = %u ORDER BY `unbandate`", account_id);
             if (banInfo)
             {
                 Field* fields2 = banInfo->Fetch();
@@ -957,14 +952,12 @@ bool ChatHandler::HandleBanListHelper(QueryResult* result)
                     }
                 }
                 while (banInfo->NextRow());
-                delete banInfo;
             }
         }
         while (result->NextRow());
         SendSysMessage("===============================================================================");
     }
 
-    delete result;
     return true;
 }
 
@@ -976,7 +969,7 @@ bool ChatHandler::HandleBanListIPCommand(char* args)
     std::string filter = cFilter ? cFilter : "";
     LoginDatabase.escape_string(filter);
 
-    QueryResult* result;
+    std::unique_ptr<QueryResult> result;
 
     if (filter.empty())
     {
@@ -1040,7 +1033,6 @@ bool ChatHandler::HandleBanListIPCommand(char* args)
         SendSysMessage("===============================================================================");
     }
 
-    delete result;
     return true;
 }
 

--- a/src/game/Commands/AccountCommands.cpp
+++ b/src/game/Commands/AccountCommands.cpp
@@ -324,7 +324,7 @@ bool ChatHandler::HandleAccountOnlineListCommand(char* args)
         return false;
 
     // Get the list of accounts ID logged to the realm
-    //                                                  0     1           2          3          4
+    //                                                                  0     1           2          3          4
     std::unique_ptr<QueryResult> result = LoginDatabase.PQuery("SELECT `id`, `username`, `last_ip`, `gmlevel`, `expansion` FROM `account` WHERE `current_realm` = %u LIMIT %u", realmID, limit);
     if (!result)
     {

--- a/src/game/Commands/CharacterCommands.cpp
+++ b/src/game/Commands/CharacterCommands.cpp
@@ -2244,7 +2244,7 @@ bool ChatHandler::HandleCharacterCopySkinCommand(char* args)
         std::string plName(args);
         CharacterDatabase.escape_string(plName); // No SQL injection
 
-        //                                                      0       1       2             3             4              5
+        //                                                                      0       1       2             3             4              5
         std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT `skin`, `face`, `hair_style`, `hair_color`, `facial_hair`, `gender` FROM `characters` WHERE `name`='%s'", plName.c_str());
         if (!result)
         {

--- a/src/game/Commands/CharacterCommands.cpp
+++ b/src/game/Commands/CharacterCommands.cpp
@@ -933,7 +933,7 @@ bool ChatHandler::HandleRemoveRidingCommand(char* args)
     }
     else
     {
-        QueryResult* result = nullptr;
+        std::unique_ptr<QueryResult> result = nullptr;
         if (it->second == 33388) // When removing Apprentice Riding check for Journeyman too. It replaces the first spell.
             result = CharacterDatabase.PQuery("SELECT `spell` FROM `character_spell` WHERE `guid` = %u AND `spell` IN (33388, 33391)", target_guid.GetCounter());
         else
@@ -1350,7 +1350,7 @@ bool ChatHandler::HandleTaxiCheatCommand(char* args)
  */
 bool ChatHandler::GetDeletedCharacterInfoList(DeletedInfoList& foundList, bool useName, std::string searchString)
 {
-    QueryResult* resultChar = nullptr;
+    std::unique_ptr<QueryResult> resultChar;
     if (!searchString.empty())
     {
         if (useName)
@@ -1381,7 +1381,7 @@ bool ChatHandler::GetDeletedCharacterInfoList(DeletedInfoList& foundList, bool u
                     return false;
 
                 LoginDatabase.escape_string(searchString);
-                QueryResult* result = LoginDatabase.PQuery("SELECT `id` FROM `account` WHERE `username` " _LIKE_ " " _CONCAT2_("'%s'", "'%%'"), searchString.c_str());
+                std::unique_ptr<QueryResult> result = LoginDatabase.PQuery("SELECT `id` FROM `account` WHERE `username` " _LIKE_ " " _CONCAT2_("'%s'", "'%%'"), searchString.c_str());
                 std::vector<uint32> list;
                 if (result)
                 {
@@ -1391,8 +1391,6 @@ bool ChatHandler::GetDeletedCharacterInfoList(DeletedInfoList& foundList, bool u
                         uint32 accId = fields[0].GetUInt32();
                         list.push_back(accId);
                     } while (result->NextRow());
-
-                    delete result;
                 }
 
                 if (list.empty())
@@ -1427,8 +1425,6 @@ bool ChatHandler::GetDeletedCharacterInfoList(DeletedInfoList& foundList, bool u
 
             foundList.push_back(info);
         } while (resultChar->NextRow());
-
-        delete resultChar;
     }
 
     return true;
@@ -1733,7 +1729,7 @@ bool ChatHandler::HandleCharacterEraseCommand(char* args)
 
 bool ChatHandler::HandleCleanCharactersToDeleteCommand(char* args)
 {
-    QueryResult* toDeleteCharsResult = CharacterDatabase.Query("SELECT `guid` FROM `characters_guid_delete`;");
+    std::unique_ptr<QueryResult> toDeleteCharsResult = CharacterDatabase.Query("SELECT `guid` FROM `characters_guid_delete`;");
     if (!toDeleteCharsResult)
     {
         SendSysMessage("Table 'characters_guid_delete' is empty or does not exist.");
@@ -1759,7 +1755,6 @@ bool ChatHandler::HandleCleanCharactersToDeleteCommand(char* args)
         }
         while (toDeleteCharsResult->NextRow());
         PSendSysMessage("%u characters have been deleted.", deleteCount);
-        delete toDeleteCharsResult;
     }
     return true;
 }
@@ -1770,7 +1765,7 @@ bool ChatHandler::HandleCleanCharactersItemsCommand(char* args)
     if (m_session->GetSecurity() == SEC_CONSOLE)
         Real = true;
 
-    QueryResult* listDeleteItems = CharacterDatabase.Query("SELECT `entry` FROM `characters_item_delete`;");
+    std::unique_ptr<QueryResult> listDeleteItems = CharacterDatabase.Query("SELECT `entry` FROM `characters_item_delete`;");
     if (!listDeleteItems)
     {
         SendSysMessage("Cannot find items to delete. Table 'characters_item_delete' is empty ?");
@@ -1792,9 +1787,8 @@ bool ChatHandler::HandleCleanCharactersItemsCommand(char* args)
     }
     while (listDeleteItems->NextRow());
     PSendSysMessage("%u items to delete.", lDeleteEntries.size());
-    delete listDeleteItems;
 
-    QueryResult* allPlayersItems = CharacterDatabase.Query("SELECT `guid`, `item_id`, `owner_guid` FROM `item_instance`;");
+    std::unique_ptr<QueryResult> allPlayersItems = CharacterDatabase.Query("SELECT `guid`, `item_id`, `owner_guid` FROM `item_instance`;");
     if (!allPlayersItems)
     {
         SendSysMessage("Unable to retrieve player items list.");
@@ -1839,7 +1833,7 @@ bool ChatHandler::HandleCleanCharactersItemsCommand(char* args)
     PSendSysMessage("- %u items deleted", deleteCount);
     if (!Real)
         SendSysMessage("-> Not executed. (for security purposes).");
-    delete allPlayersItems;
+
     return true;
 }
 
@@ -2199,7 +2193,7 @@ bool ChatHandler::HandleCharacterPremadeSaveSpecCommand(char* args)
     if (!pInfo)
         return false;
 
-    result.reset(CharacterDatabase.PQuery("SELECT DISTINCT `spell` FROM `character_spell` WHERE `disabled`=0 && `active`=1 && `guid`=%u", pPlayer->GetGUIDLow()));
+    result = CharacterDatabase.PQuery("SELECT DISTINCT `spell` FROM `character_spell` WHERE `disabled`=0 && `active`=1 && `guid`=%u", pPlayer->GetGUIDLow());
 
     if (result)
     {
@@ -2251,7 +2245,7 @@ bool ChatHandler::HandleCharacterCopySkinCommand(char* args)
         CharacterDatabase.escape_string(plName); // No SQL injection
 
         //                                                      0       1       2             3             4              5
-        QueryResult* result = CharacterDatabase.PQuery("SELECT `skin`, `face`, `hair_style`, `hair_color`, `facial_hair`, `gender` FROM `characters` WHERE `name`='%s'", plName.c_str());
+        std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT `skin`, `face`, `hair_style`, `hair_color`, `facial_hair`, `gender` FROM `characters` WHERE `name`='%s'", plName.c_str());
         if (!result)
         {
             PSendSysMessage("Player %s not found.", args);
@@ -3272,7 +3266,7 @@ bool ChatHandler::HandleAddItemCommand(char* args)
     {
         std::string itemName = cId;
         WorldDatabase.escape_string(itemName);
-        QueryResult* result = WorldDatabase.PQuery("SELECT `entry` FROM `item_template` WHERE `name` = '%s'", itemName.c_str());
+        std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT `entry` FROM `item_template` WHERE `name` = '%s'", itemName.c_str());
         if (!result)
         {
             PSendSysMessage(LANG_COMMAND_COULDNOTFIND, cId);
@@ -3280,7 +3274,6 @@ bool ChatHandler::HandleAddItemCommand(char* args)
             return false;
         }
         itemId = result->Fetch()->GetUInt16();
-        delete result;
     }
 
     int32 count;
@@ -3437,10 +3430,10 @@ bool ChatHandler::HandleDeleteItemCommand(char* args)
 
         while (stacksToRemove)
         {
-            result.reset(CharacterDatabase.PQuery(
+            result = CharacterDatabase.PQuery(
                 "SELECT `guid`, `count` FROM `item_instance` ii WHERE `item_id` = %u and `owner_guid` = %u ORDER BY `count` DESC",
                 itemId, target_guid.GetCounter()
-            ));
+            );
 
             if (!result)
             {
@@ -3589,7 +3582,7 @@ bool ChatHandler::HandleListItemCommand(char* args)
     if (!ExtractOptUInt32(&args, count, 10))
         return false;
 
-    QueryResult* result;
+    std::unique_ptr<QueryResult> result;
 
     // inventory case
     uint32 inv_count = 0;
@@ -3597,7 +3590,6 @@ bool ChatHandler::HandleListItemCommand(char* args)
     if (result)
     {
         inv_count = (*result)[0].GetUInt32();
-        delete result;
     }
 
     result = CharacterDatabase.PQuery(
@@ -3636,8 +3628,6 @@ bool ChatHandler::HandleListItemCommand(char* args)
 
         uint32 res_count = uint32(result->GetRowCount());
 
-        delete result;
-
         if (count > res_count)
             count -= res_count;
         else if (count)
@@ -3650,7 +3640,6 @@ bool ChatHandler::HandleListItemCommand(char* args)
     if (result)
     {
         mail_count = (*result)[0].GetUInt32();
-        delete result;
     }
 
     if (count > 0)
@@ -3687,8 +3676,6 @@ bool ChatHandler::HandleListItemCommand(char* args)
 
         uint32 res_count = uint32(result->GetRowCount());
 
-        delete result;
-
         if (count > res_count)
             count -= res_count;
         else if (count)
@@ -3701,7 +3688,6 @@ bool ChatHandler::HandleListItemCommand(char* args)
     if (result)
     {
         auc_count = (*result)[0].GetUInt32();
-        delete result;
     }
 
     if (count > 0)
@@ -3730,8 +3716,6 @@ bool ChatHandler::HandleListItemCommand(char* args)
             PSendSysMessage(LANG_ITEMLIST_AUCTION, item_guid, owner_name.c_str(), owner, owner_acc, item_pos);
         }
         while (result->NextRow());
-
-        delete result;
     }
 
     if (inv_count + mail_count + auc_count == 0)
@@ -5583,7 +5567,7 @@ bool ChatHandler::HandleServiceDeleteCharacters(char* args)
         }
     }
 
-    QueryResult* result = CharacterDatabase.Query(s.str().c_str());
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query(s.str().c_str());
     uint32 count = 0;
     if (result)
     {
@@ -5598,8 +5582,6 @@ bool ChatHandler::HandleServiceDeleteCharacters(char* args)
 
             Player::DeleteFromDB(guid, accountId, true, true);
         } while (result->NextRow());
-
-        delete result;
     }
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Service: Removed %u characters", count);

--- a/src/game/Commands/CreatureCommands.cpp
+++ b/src/game/Commands/CreatureCommands.cpp
@@ -1865,10 +1865,9 @@ bool ChatHandler::HandleWpAddCommand(char* args)
                 wpDestination = PATH_FROM_ENTRY;                // Default place to store paths
                 if (wpOwner->HasStaticDBSpawnData())
                 {
-                    QueryResult* result = WorldDatabase.PQuery("SELECT COUNT(id) FROM creature WHERE id = %u", wpOwner->GetEntry());
+                    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT COUNT(id) FROM creature WHERE id = %u", wpOwner->GetEntry());
                     if (result && result->Fetch()[0].GetUInt32() != 1)
                         wpDestination = PATH_FROM_GUID;
-                    delete result;
                 }
             }
         }
@@ -2639,8 +2638,9 @@ bool ChatHandler::HandleEscortAddWpCommand(char *args)
         SetSentErrorMessage(true);
         return false;
     }
-    QueryResult* pResult = nullptr;
-    Field* pFields       = nullptr;
+
+    std::unique_ptr<QueryResult> pResult = nullptr;
+    Field* pFields = nullptr;
     if (waypointId == 0)
     {
         pResult = WorldDatabase.PQuery("SELECT MAX(pointid) FROM script_waypoint WHERE entry=%u", creatureEntry);

--- a/src/game/Commands/MiscCommands.cpp
+++ b/src/game/Commands/MiscCommands.cpp
@@ -201,7 +201,7 @@ bool ChatHandler::HandleSetViewCommand(char* /*args*/)
 bool ChatHandler::HandleGMListFullCommand(char* /*args*/)
 {
     // Get the accounts with GM Level >0
-    QueryResult* result = LoginDatabase.PQuery("SELECT `username`, `account_access`.`gmlevel` FROM `account`, `account_access` "
+    std::unique_ptr<QueryResult> result = LoginDatabase.PQuery("SELECT `username`, `account_access`.`gmlevel` FROM `account`, `account_access` "
         "WHERE `account_access`.`id` = `account`.`id` AND `account_access`.`gmlevel` > 0 AND `RealmID`=%u", realmID);
     if (result)
     {
@@ -218,7 +218,6 @@ bool ChatHandler::HandleGMListFullCommand(char* /*args*/)
         } while (result->NextRow());
 
         PSendSysMessage("========================");
-        delete result;
     }
     else
         PSendSysMessage(LANG_GMLIST_EMPTY);

--- a/src/game/Commands/ObjectCommands.cpp
+++ b/src/game/Commands/ObjectCommands.cpp
@@ -32,7 +32,7 @@
 bool ChatHandler::HandleGameObjectTargetCommand(char* args)
 {
     Player* pl = m_session->GetPlayer();
-    QueryResult* result;
+    std::unique_ptr<QueryResult> result;
     GameEventMgr::ActiveEvents const& activeEventsList = sGameEventMgr.GetActiveEventList();
     if (*args)
     {
@@ -111,8 +111,6 @@ bool ChatHandler::HandleGameObjectTargetCommand(char* args)
             found = true;
     }
     while (result->NextRow() && (!found));
-
-    delete result;
 
     if (!found)
     {
@@ -516,7 +514,7 @@ bool ChatHandler::HandleGameObjectNearCommand(char* args)
     uint32 count = 0;
 
     Player* pl = m_session->GetPlayer();
-    QueryResult* result = WorldDatabase.PQuery("SELECT guid, id, position_x, position_y, position_z, map, "
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT guid, id, position_x, position_y, position_z, map, "
                           "(POW(position_x - '%f', 2) + POW(position_y - '%f', 2) + POW(position_z - '%f', 2)) AS order_ "
                           "FROM gameobject WHERE map='%u' AND (POW(position_x - '%f', 2) + POW(position_y - '%f', 2) + POW(position_z - '%f', 2)) <= '%f' ORDER BY order_",
                           pl->GetPositionX(), pl->GetPositionY(), pl->GetPositionZ(),
@@ -544,8 +542,6 @@ bool ChatHandler::HandleGameObjectNearCommand(char* args)
             ++count;
         }
         while (result->NextRow());
-
-        delete result;
     }
 
     PSendSysMessage(LANG_COMMAND_NEAROBJMESSAGE, distance, count);

--- a/src/game/Commands/TeleportCommands.cpp
+++ b/src/game/Commands/TeleportCommands.cpp
@@ -458,7 +458,7 @@ bool ChatHandler::HandleGoCreatureCommand(char* args)
         {
             std::string name = pParam1;
             WorldDatabase.escape_string(name);
-            QueryResult* result = WorldDatabase.PQuery("SELECT guid FROM creature, creature_template WHERE creature.id = creature_template.entry AND creature_template.name " _LIKE_ " " _CONCAT3_("'%%'", "'%s'", "'%%'"), name.c_str());
+            std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT guid FROM creature, creature_template WHERE creature.id = creature_template.entry AND creature_template.name " _LIKE_ " " _CONCAT3_("'%%'", "'%s'", "'%%'"), name.c_str());
             if (!result)
             {
                 SendSysMessage(LANG_COMMAND_GOCREATNOTFOUND);
@@ -480,8 +480,6 @@ bool ChatHandler::HandleGoCreatureCommand(char* args)
                 worker(*cr_data);
 
             } while (result->NextRow());
-
-            delete result;
 
             CreatureDataPair const* dataPair = worker.GetResult();
             if (!dataPair)
@@ -613,7 +611,7 @@ bool ChatHandler::HandleGoObjectCommand(char* args)
         {
             std::string name = pParam1;
             WorldDatabase.escape_string(name);
-            QueryResult* result = WorldDatabase.PQuery("SELECT guid FROM gameobject, gameobject_template WHERE gameobject.id = gameobject_template.entry AND gameobject_template.name " _LIKE_ " " _CONCAT3_("'%%'", "'%s'", "'%%'"), name.c_str());
+            std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT guid FROM gameobject, gameobject_template WHERE gameobject.id = gameobject_template.entry AND gameobject_template.name " _LIKE_ " " _CONCAT3_("'%%'", "'%s'", "'%%'"), name.c_str());
             if (!result)
             {
                 SendSysMessage(LANG_COMMAND_GOOBJNOTFOUND);
@@ -635,8 +633,6 @@ bool ChatHandler::HandleGoObjectCommand(char* args)
                 worker(*go_data);
 
             } while (result->NextRow());
-
-            delete result;
 
             GameObjectDataPair const* dataPair = worker.GetResult();
             if (!dataPair)

--- a/src/game/CreatureGroups.cpp
+++ b/src/game/CreatureGroups.cpp
@@ -469,7 +469,7 @@ void CreatureGroupsManager::Load()
     }
     while (result->NextRow());
 
-    result.reset(WorldDatabase.Query("SELECT `leader_guid`, `creature_id`, `min_count`, `max_count` FROM `creature_groups_entry_limit` ORDER BY `leader_guid`"));
+    result = WorldDatabase.Query("SELECT `leader_guid`, `creature_id`, `min_count`, `max_count` FROM `creature_groups_entry_limit` ORDER BY `leader_guid`");
 
     if (result)
     {

--- a/src/game/Database/CharacterDatabaseCache.cpp
+++ b/src/game/Database/CharacterDatabaseCache.cpp
@@ -28,21 +28,21 @@ void CharacterDatabaseCache::LoadCharacterPet(uint32 singlePetId)
     std::unique_ptr<QueryResult> result;
     if (singlePetId)
     {
-        result.reset(CharacterDatabase.PQuery(
+        result = CharacterDatabase.PQuery(
                      "SELECT `id`, `entry`, `owner_guid`, `display_id`, `level`, `xp`, `react_state`, `loyalty_points`, `loyalty`, `training_points`, "
                      "`slot`, `name`, `renamed`, `current_health`, `current_mana`, `current_happiness`, `action_bar_data`, `teach_spell_data`, `save_time`, `reset_talents_cost`, "
                      "`reset_talents_time`, `created_by_spell`, `pet_type` FROM `character_pet` WHERE `id`=%u", singlePetId
-                 ));
+                 );
     }
     else if (!singlePetId)
     {
         m_petsByCharacter.clear();
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "* Loading table `character_pet`");
-        result.reset(CharacterDatabase.Query(
+        result = CharacterDatabase.Query(
                      "SELECT `id`, `entry`, `owner_guid`, `display_id`, `level`, `xp`, `react_state`, `loyalty_points`, `loyalty`, `training_points`, "
                      "`slot`, `name`, `renamed`, `current_health`, `current_mana`, `current_happiness`, `action_bar_data`, `teach_spell_data`, `save_time`, `reset_talents_cost`, "
                      "`reset_talents_time`, `created_by_spell`, `pet_type` FROM `character_pet`"
-                 ));
+                 );
     }
 
     if (!result)
@@ -90,10 +90,10 @@ void CharacterDatabaseCache::LoadPetSpell(uint32 singlePetId)
     std::unique_ptr<QueryResult> result;
     if (singlePetId)
     {
-        result.reset(CharacterDatabase.PQuery(
+        result = CharacterDatabase.PQuery(
                      "SELECT `guid`, `spell`, `active` "
                      "FROM `pet_spell` WHERE `guid`=%u", singlePetId
-                 ));
+                 );
     }
     else
     {
@@ -102,10 +102,10 @@ void CharacterDatabaseCache::LoadPetSpell(uint32 singlePetId)
             it.second->spells.clear();
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "* Loading `pet_spell`");
-        result.reset(CharacterDatabase.Query(
+        result = CharacterDatabase.Query(
                      "SELECT `guid`, `spell`, `active` "
                      "FROM `pet_spell` ORDER BY `guid` ASC"
-                 ));
+                 );
     }
 
     if (!result)
@@ -140,10 +140,10 @@ void CharacterDatabaseCache::LoadPetSpellCooldown(uint32 singlePetId)
     std::unique_ptr<QueryResult> result;
     if (singlePetId)
     {
-        result.reset(CharacterDatabase.PQuery(
+        result = CharacterDatabase.PQuery(
                      "SELECT `guid`, `spell`, `time` "
                      "FROM `pet_spell_cooldown` WHERE `guid`=%u", singlePetId
-                 ));
+                 );
     }
     else
     {
@@ -152,10 +152,10 @@ void CharacterDatabaseCache::LoadPetSpellCooldown(uint32 singlePetId)
             it.second->spellCooldowns.clear();
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "* Loading `pet_spell_cooldown`");
-        result.reset(CharacterDatabase.Query(
+        result = CharacterDatabase.Query(
                      "SELECT `guid`, `spell`, `time` "
                      "FROM `pet_spell_cooldown` ORDER BY `guid` ASC"
-                 ));
+                 );
     }
 
     if (!result)
@@ -191,11 +191,11 @@ void CharacterDatabaseCache::LoadPetAura(uint32 singlePetId)
     std::unique_ptr<QueryResult> result;
     if (singlePetId)
     {
-        result.reset(CharacterDatabase.PQuery(
+        result = CharacterDatabase.PQuery(
                      "SELECT `guid`, `caster_guid`, `item_guid`, `spell`, `stacks`, `charges`, `max_duration`, `duration`, `effect_index_mask`, "
                      "`base_points0`, `base_points1`, `base_points2`, `periodic_time0`, `periodic_time1`, `periodic_time2` "
                      "FROM `pet_aura` WHERE `guid`=%u", singlePetId
-                 ));
+                 );
     }
     else
     {
@@ -204,13 +204,13 @@ void CharacterDatabaseCache::LoadPetAura(uint32 singlePetId)
             it.second->auras.clear();
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "* Loading table `pet_aura`");
-        result.reset(CharacterDatabase.Query(
+        result = CharacterDatabase.Query(
                                   //       0       1              2            3        4         5          6               7           8
                                   "SELECT `guid`, `caster_guid`, `item_guid`, `spell`, `stacks`, `charges`, `max_duration`, `duration`, `effect_index_mask`, "
                                   // 9 -> 11                                        12 -> 14
                                   "`base_points0`, `base_points1`, `base_points2`, `periodic_time0`, `periodic_time1`, `periodic_time2` "
                                   "FROM `pet_aura` ORDER BY `guid` ASC"
-                              ));
+                              );
     }
 
     if (!result)

--- a/src/game/Database/CharacterDatabaseCleaner.cpp
+++ b/src/game/Database/CharacterDatabaseCleaner.cpp
@@ -35,11 +35,10 @@ void CharacterDatabaseCleaner::CleanDatabase()
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Cleaning character database...");
 
     // check flags which clean ups are necessary
-    QueryResult* result = CharacterDatabase.PQuery("SELECT cleaning_flags FROM saved_variables");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT cleaning_flags FROM saved_variables");
     if (!result)
         return;
     uint32 flags = (*result)[0].GetUInt32();
-    delete result;
 
     // clean up
     if (flags & CLEANING_FLAG_SKILLS)
@@ -51,7 +50,7 @@ void CharacterDatabaseCleaner::CleanDatabase()
 
 void CharacterDatabaseCleaner::CheckUnique(char const* column, char const* table, bool (*check)(uint32))
 {
-    QueryResult* result = CharacterDatabase.PQuery("SELECT DISTINCT %s FROM %s", column, table);
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT DISTINCT %s FROM %s", column, table);
     if (!result)
     {
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Table %s is empty.", table);
@@ -82,7 +81,6 @@ void CharacterDatabaseCleaner::CheckUnique(char const* column, char const* table
         }
     }
     while (result->NextRow());
-    delete result;
 
     if (found)
     {

--- a/src/game/GMTicketMgr.h
+++ b/src/game/GMTicketMgr.h
@@ -262,11 +262,9 @@ public:
 
     void SendTicket(WorldSession* session, GmTicket* ticket) const;
     void ReloadTicket(uint32 ticketId);
-    void ReloadTicketCallback(QueryResult* holder);
+    void ReloadTicketCallback(std::unique_ptr<QueryResult> result);
 
 protected:
-    void _RemoveTicket(uint32 ticketId, int64 source = -1, bool permanently = false);
-
     GmTicketList _ticketList;
 
     bool   _status;

--- a/src/game/GameEventMgr.cpp
+++ b/src/game/GameEventMgr.cpp
@@ -165,7 +165,7 @@ bool GameEventMgr::IsEnabled(uint16 event_id)
 void GameEventMgr::LoadFromDB()
 {
     {
-        QueryResult* result = WorldDatabase.Query("SELECT MAX(entry) FROM game_event");
+        std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT MAX(entry) FROM game_event");
         if (!result)
         {
             sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Table game_event is empty.");
@@ -176,12 +176,11 @@ void GameEventMgr::LoadFromDB()
         Field* fields = result->Fetch();
 
         uint32 max_event_id = fields[0].GetUInt16();
-        delete result;
 
         mGameEvent.resize(max_event_id + 1);
     }
 
-    QueryResult* result = WorldDatabase.Query("SELECT entry,UNIX_TIMESTAMP(start_time),UNIX_TIMESTAMP(end_time),occurence,length,holiday,description,hardcoded,disabled,patch_min,patch_max FROM game_event");
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT entry,UNIX_TIMESTAMP(start_time),UNIX_TIMESTAMP(end_time),occurence,length,holiday,description,hardcoded,disabled,patch_min,patch_max FROM game_event");
     if (!result)
     {
         mGameEvent.clear();
@@ -254,7 +253,6 @@ void GameEventMgr::LoadFromDB()
             }
         }
         while (result->NextRow());
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u game events", count);
@@ -349,7 +347,6 @@ void GameEventMgr::LoadFromDB()
 
         }
         while (result->NextRow());
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u creatures in game events", count);
@@ -428,7 +425,6 @@ void GameEventMgr::LoadFromDB()
 
         }
         while (result->NextRow());
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u gameobjects in game events", count);
@@ -528,7 +524,6 @@ void GameEventMgr::LoadFromDB()
 
         }
         while (result->NextRow());
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u creature reactions at game events", count);
@@ -589,7 +584,6 @@ void GameEventMgr::LoadFromDB()
 
         }
         while (result->NextRow());
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u quest additions in game events", count);
@@ -670,7 +664,6 @@ void GameEventMgr::LoadFromDB()
 
         }
         while (result->NextRow());
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u start/end game event mails", count);
@@ -683,7 +676,7 @@ uint32 GameEventMgr::Initialize()                           // return the next e
 
     ActiveEvents activeAtShutdown;
 
-    if (QueryResult* result = CharacterDatabase.Query("SELECT event FROM game_event_status"))
+    if (std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT event FROM game_event_status"))
     {
         do
         {
@@ -692,7 +685,6 @@ uint32 GameEventMgr::Initialize()                           // return the next e
             activeAtShutdown.insert(event_id);
         }
         while (result->NextRow());
-        delete result;
 
         CharacterDatabase.Execute("TRUNCATE game_event_status");
     }

--- a/src/game/Group/CreatureLinkingMgr.cpp
+++ b/src/game/Group/CreatureLinkingMgr.cpp
@@ -116,7 +116,7 @@ void CreatureLinkingMgr::LoadFromDB()
     // Load `creature_linking`
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "> Loading table `creature_linking`");
     count = 0;
-    result.reset(WorldDatabase.Query("SELECT `guid`, `master_guid`, `flag` FROM `creature_linking`"));
+    result = WorldDatabase.Query("SELECT `guid`, `master_guid`, `flag` FROM `creature_linking`");
     if (!result)
     {
         BarGoLink bar(1);
@@ -234,7 +234,7 @@ bool CreatureLinkingMgr::IsLinkingEntryValid(uint32 slaveEntry, CreatureLinkingI
         // Check for uniqueness of mob whom is followed, on whom spawning is dependend
         if (pTmp->searchRange == 0 && pTmp->linkingFlag & (FLAG_FOLLOW | FLAG_CANT_SPAWN_IF_BOSS_DEAD | FLAG_CANT_SPAWN_IF_BOSS_ALIVE))
         {
-            QueryResult* result = WorldDatabase.PQuery("SELECT guid FROM creature WHERE id=%u AND map=%u LIMIT 2", pTmp->masterId, pTmp->mapId);
+            std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT guid FROM creature WHERE id=%u AND map=%u LIMIT 2", pTmp->masterId, pTmp->mapId);
             if (!result)
             {
                 sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "`creature_linking_template` has FLAG_FOLLOW, but no master, (entry: %u, map: %u, master: %u)", slaveEntry, pTmp->mapId, pTmp->masterId);
@@ -244,12 +244,10 @@ bool CreatureLinkingMgr::IsLinkingEntryValid(uint32 slaveEntry, CreatureLinkingI
             if (result->GetRowCount() > 1)
             {
                 sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "`creature_linking_template` has FLAG_FOLLOW, but non unique master, (entry: %u, map: %u, master: %u)", slaveEntry, pTmp->mapId, pTmp->masterId);
-                delete result;
                 return false;
             }
             Field* fields = result->Fetch();
             pTmp->masterDBGuid = fields[0].GetUInt32();
-            delete result;
         }
     }
 

--- a/src/game/Guild/Guild.cpp
+++ b/src/game/Guild/Guild.cpp
@@ -292,7 +292,7 @@ void Guild::SetGINFO(std::string ginfo)
     CharacterDatabase.PExecute("UPDATE `guild` SET `info`='%s' WHERE `guild_id`='%u'", ginfo.c_str(), m_Id);
 }
 
-bool Guild::LoadGuildFromDB(QueryResult* guildDataResult)
+bool Guild::LoadGuildFromDB(const std::unique_ptr<QueryResult>& guildDataResult)
 {
     if (!guildDataResult)
         return false;
@@ -347,7 +347,7 @@ bool Guild::CheckGuildStructure()
     return true;
 }
 
-bool Guild::LoadRanksFromDB(QueryResult* guildRanksResult)
+bool Guild::LoadRanksFromDB(const std::unique_ptr<QueryResult>& guildRanksResult)
 {
     if (!guildRanksResult)
     {
@@ -424,7 +424,7 @@ bool Guild::LoadRanksFromDB(QueryResult* guildRanksResult)
     return true;
 }
 
-bool Guild::LoadMembersFromDB(QueryResult* guildMembersResult)
+bool Guild::LoadMembersFromDB(const std::unique_ptr<QueryResult>& guildMembersResult)
 {
     if (!guildMembersResult)
         return false;
@@ -898,7 +898,7 @@ void Guild::DisplayGuildEventLog(WorldSession* session)
 void Guild::LoadGuildEventLogFromDB()
 {
     //                                                      0           1             2               3               4           5
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `log_guid`, `event_type`, `player_guid1`, `player_guid2`, `new_rank`, `timestamp` FROM `guild_eventlog` WHERE `guild_id`=%u ORDER BY `timestamp` DESC,`log_guid` DESC LIMIT %u", m_Id, GUILD_EVENTLOG_MAX_RECORDS);
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT `log_guid`, `event_type`, `player_guid1`, `player_guid2`, `new_rank`, `timestamp` FROM `guild_eventlog` WHERE `guild_id`=%u ORDER BY `timestamp` DESC,`log_guid` DESC LIMIT %u", m_Id, GUILD_EVENTLOG_MAX_RECORDS);
     if (!result)
         return;
     bool isNextLogGuidSet = false;
@@ -929,7 +929,6 @@ void Guild::LoadGuildEventLogFromDB()
 
     }
     while (result->NextRow());
-    delete result;
 }
 
 // Add entry to guild eventlog

--- a/src/game/Guild/Guild.h
+++ b/src/game/Guild/Guild.h
@@ -247,10 +247,10 @@ class Guild
         uint32 GetMemberSize() const { return members.size(); }
         uint32 GetAccountsNumber();
 
-        bool LoadGuildFromDB(QueryResult* guildDataResult);
+        bool LoadGuildFromDB(const std::unique_ptr<QueryResult>& guildDataResult);
         bool CheckGuildStructure();
-        bool LoadRanksFromDB(QueryResult* guildRanksResult);
-        bool LoadMembersFromDB(QueryResult* guildMembersResult);
+        bool LoadRanksFromDB(const std::unique_ptr<QueryResult>& guildRanksResult);
+        bool LoadMembersFromDB(const std::unique_ptr<QueryResult>& guildMembersResult);
 
         void BroadcastToGuild(WorldSession* session, char const* msg, uint32 language = LANG_UNIVERSAL);
         void BroadcastToOfficers(WorldSession* session, char const* msg, uint32 language = LANG_UNIVERSAL);

--- a/src/game/Guild/GuildMgr.cpp
+++ b/src/game/Guild/GuildMgr.cpp
@@ -105,7 +105,7 @@ void GuildMgr::LoadGuilds()
 {
     uint32 count = 0;
 
-    //                                                     0           1       2              3               4               5               6
+    //                                                                     0           1       2              3               4               5               6
     std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `guild_id`, `name`, `leader_guid`, `emblem_style`, `emblem_color`, `border_style`, `border_color`,"
                           //   7                8       9       10
                           "`background_Color`, `info`, `motd`, `create_date` FROM `guild` ORDER BY `guild_id` ASC");
@@ -122,11 +122,11 @@ void GuildMgr::LoadGuilds()
     }
 
     // load guild ranks
-    //                                                                 0           1     2       3
+    //                                                                                 0           1     2       3
     std::unique_ptr<QueryResult> guildRanksResult   = CharacterDatabase.Query("SELECT `guild_id`, `id`, `name`, `rights` FROM `guild_rank` ORDER BY `guild_id` ASC, `id` ASC");
 
     // load guild members
-    //                                                                 0                          1       2       3              4
+    //                                                                                 0                          1       2       3              4
     std::unique_ptr<QueryResult> guildMembersResult = CharacterDatabase.Query("SELECT `guild_id`, `guild_member`.`guid`, `rank`, `player_note`, `officer_note`,"
                                       //             5                    6                     7                     8                    9                           10
                                       "`characters`.`name`, `characters`.`level`, `characters`.`class`, `characters`.`zone`, `characters`.`logout_time`, `characters`.`account` "
@@ -170,7 +170,7 @@ void GuildMgr::LoadPetitions()
     CleanUpPetitions(); // for reload
     uint32 count = 0;
 
-    //                                                      0            1                2               3
+    //                                                                     0            1                2               3
     std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `owner_guid`, `petition_guid`, `charter_guid`, `name` FROM `petition`");
 
     if (!result)
@@ -185,7 +185,7 @@ void GuildMgr::LoadPetitions()
     }
 
     // load signatures
-    //                                                                 0             1                2              3
+    //                                                                                         0             1                2              3
     std::unique_ptr<QueryResult> petitionSignaturesDbResult = CharacterDatabase.Query("SELECT `owner_guid`, `petition_guid`, `player_guid`, `player_account` FROM `petition_sign`");
 
     BarGoLink bar(result->GetRowCount());

--- a/src/game/Guild/GuildMgr.cpp
+++ b/src/game/Guild/GuildMgr.cpp
@@ -106,7 +106,7 @@ void GuildMgr::LoadGuilds()
     uint32 count = 0;
 
     //                                                     0           1       2              3               4               5               6
-    QueryResult* result = CharacterDatabase.Query("SELECT `guild_id`, `name`, `leader_guid`, `emblem_style`, `emblem_color`, `border_style`, `border_color`,"
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `guild_id`, `name`, `leader_guid`, `emblem_style`, `emblem_color`, `border_style`, `border_color`,"
                           //   7                8       9       10
                           "`background_Color`, `info`, `motd`, `create_date` FROM `guild` ORDER BY `guild_id` ASC");
 
@@ -123,11 +123,11 @@ void GuildMgr::LoadGuilds()
 
     // load guild ranks
     //                                                                 0           1     2       3
-    QueryResult* guildRanksResult   = CharacterDatabase.Query("SELECT `guild_id`, `id`, `name`, `rights` FROM `guild_rank` ORDER BY `guild_id` ASC, `id` ASC");
+    std::unique_ptr<QueryResult> guildRanksResult   = CharacterDatabase.Query("SELECT `guild_id`, `id`, `name`, `rights` FROM `guild_rank` ORDER BY `guild_id` ASC, `id` ASC");
 
     // load guild members
     //                                                                 0                          1       2       3              4
-    QueryResult* guildMembersResult = CharacterDatabase.Query("SELECT `guild_id`, `guild_member`.`guid`, `rank`, `player_note`, `officer_note`,"
+    std::unique_ptr<QueryResult> guildMembersResult = CharacterDatabase.Query("SELECT `guild_id`, `guild_member`.`guid`, `rank`, `player_note`, `officer_note`,"
                                       //             5                    6                     7                     8                    9                           10
                                       "`characters`.`name`, `characters`.`level`, `characters`.`class`, `characters`.`zone`, `characters`.`logout_time`, `characters`.`account` "
                                       "FROM `guild_member` LEFT JOIN `characters` ON `characters`.`guid` = `guild_member`.`guid` ORDER BY `guild_id` ASC");
@@ -157,10 +157,6 @@ void GuildMgr::LoadGuilds()
     }
     while (result->NextRow());
 
-    delete result;
-    delete guildRanksResult;
-    delete guildMembersResult;
-
     //delete unused log_guid records in guild_eventlog table
     //you can comment these lines if you don't plan to change CONFIG_UINT32_GUILD_EVENT_LOG_COUNT
     CharacterDatabase.PExecute("DELETE FROM `guild_eventlog` WHERE `log_guid` > '%u'", sWorld.getConfig(CONFIG_UINT32_GUILD_EVENT_LOG_COUNT));
@@ -175,7 +171,7 @@ void GuildMgr::LoadPetitions()
     uint32 count = 0;
 
     //                                                      0            1                2               3
-    QueryResult* result = CharacterDatabase.Query("SELECT `owner_guid`, `petition_guid`, `charter_guid`, `name` FROM `petition`");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `owner_guid`, `petition_guid`, `charter_guid`, `name` FROM `petition`");
 
     if (!result)
     {
@@ -190,7 +186,7 @@ void GuildMgr::LoadPetitions()
 
     // load signatures
     //                                                                 0             1                2              3
-    QueryResult* petitionSignatures = CharacterDatabase.Query("SELECT `owner_guid`, `petition_guid`, `player_guid`, `player_account` FROM `petition_sign`");
+    std::unique_ptr<QueryResult> petitionSignaturesDbResult = CharacterDatabase.Query("SELECT `owner_guid`, `petition_guid`, `player_guid`, `player_account` FROM `petition_sign`");
 
     BarGoLink bar(result->GetRowCount());
 
@@ -199,8 +195,8 @@ void GuildMgr::LoadPetitions()
         bar.step();
         ++count;
 
-        Petition *petition = new Petition;
-        if (!petition->LoadFromDB(result))
+        Petition* petition = new Petition();
+        if (!petition->LoadFromDB(std::move(result)))
         {
             petition->Delete();
             delete petition;
@@ -209,13 +205,12 @@ void GuildMgr::LoadPetitions()
 
         m_petitionMap[petition->GetId()] = petition;
     } while (result->NextRow());
-    delete result;
 
-    if (petitionSignatures)
+    if (petitionSignaturesDbResult)
     {
         do
         {
-            Field* fields = petitionSignatures->Fetch();
+            Field* fields = petitionSignaturesDbResult->Fetch();
 
             ObjectGuid ownerGuid = ObjectGuid(HIGHGUID_PLAYER, fields[0].GetUInt32());
             uint32 petitionId = fields[1].GetUInt32();
@@ -244,8 +239,7 @@ void GuildMgr::LoadPetitions()
             PetitionSignature* signature = new PetitionSignature(petition, playerGuid, accountId);
             petition->AddSignature(signature);
 
-        } while (petitionSignatures->NextRow());
-        delete petitionSignatures;
+        } while (petitionSignaturesDbResult->NextRow());
     }
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
@@ -328,7 +322,7 @@ void GuildMgr::DeletePetitionSignaturesByPlayer(ObjectGuid guid, uint32 exceptPe
     }
 }
 
-bool Petition::LoadFromDB(QueryResult* result)
+bool Petition::LoadFromDB(const std::unique_ptr<QueryResult>& result)
 {
     if (!result)
     {

--- a/src/game/Guild/GuildMgr.h
+++ b/src/game/Guild/GuildMgr.h
@@ -96,7 +96,7 @@ public:
 
     ~Petition();
 
-    bool LoadFromDB(QueryResult* result);
+    bool LoadFromDB(const std::unique_ptr<QueryResult>& result);
     void Delete();
     void SaveToDB();
 

--- a/src/game/Handlers/MailHandler.cpp
+++ b/src/game/Handlers/MailHandler.cpp
@@ -92,12 +92,12 @@ public:
     Player*     receiverPtr;
     Team        rcTeam;
     uint8       mailsCount;
-    void Callback(QueryResult* result)
+
+    void Callback(std::unique_ptr<QueryResult> result)
     {
         WorldSession* sess = sWorld.FindSession(accountId);
         if (!sess || !sess->GetPlayer() || sess->GetPlayer()->GetObjectGuid() != senderGuid || !sess->GetPlayer()->IsInWorld())
         {
-            delete result;
             delete this;
             return;
         }
@@ -106,7 +106,6 @@ public:
         {
             Field* fields = result->Fetch();
             mailsCount = fields[0].GetUInt32();
-            delete result;
         }
         sess->HandleSendMailCallback(this);
         delete this;

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1244,7 +1244,7 @@ void WorldSession::HandleWhoisOpcode(WorldPacket& recv_data)
 
     uint32 accid = plr->GetSession()->GetAccountId();
 
-    QueryResult* result = LoginDatabase.PQuery("SELECT `username`, `email`, `last_ip` FROM `account` WHERE `id`=%u", accid);
+    std::unique_ptr<QueryResult> result = LoginDatabase.PQuery("SELECT `username`, `email`, `last_ip` FROM `account` WHERE `id`=%u", accid);
     if (!result)
     {
         SendNotification(LANG_ACCOUNT_FOR_PLAYER_NOT_FOUND, charname.c_str());
@@ -1267,8 +1267,6 @@ void WorldSession::HandleWhoisOpcode(WorldPacket& recv_data)
     WorldPacket data(SMSG_WHOIS, msg.size() + 1); // max CString length allowed: 256
     data << msg;
     _player->GetSession()->SendPacket(&data);
-
-    delete result;
 }
 
 void WorldSession::HandleFarSightOpcode(WorldPacket& recv_data)

--- a/src/game/Handlers/SpellHandler.cpp
+++ b/src/game/Handlers/SpellHandler.cpp
@@ -222,7 +222,7 @@ void WorldSession::HandleOpenItemOpcode(WorldPacket& recvPacket)
 
     if (pItem->HasFlag(ITEM_FIELD_FLAGS, ITEM_DYNFLAG_WRAPPED))// wrapped?
     {
-        QueryResult* result = CharacterDatabase.PQuery("SELECT `item_id`, `flags` FROM `character_gifts` WHERE `item_guid` = '%u'", pItem->GetGUIDLow());
+        std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT `item_id`, `flags` FROM `character_gifts` WHERE `item_guid` = '%u'", pItem->GetGUIDLow());
         if (result)
         {
             Field* fields = result->Fetch();
@@ -233,7 +233,6 @@ void WorldSession::HandleOpenItemOpcode(WorldPacket& recvPacket)
             pItem->SetEntry(entry);
             pItem->SetUInt32Value(ITEM_FIELD_FLAGS, flags);
             pItem->SetState(ITEM_CHANGED, pUser);
-            delete result;
         }
         else
         {

--- a/src/game/HonorMgr.h
+++ b/src/game/HonorMgr.h
@@ -159,7 +159,7 @@ class HonorMgr
 
         void Save();
         void SaveStoredData();
-        void Load(QueryResult* result);
+        void Load(std::unique_ptr<QueryResult> result);
 
         bool Add(float CP, uint8 type, Unit const* source = nullptr);
         void Update();

--- a/src/game/InstanceStatistics.cpp
+++ b/src/game/InstanceStatistics.cpp
@@ -65,7 +65,7 @@ void InstanceStatisticsMgr::LoadFromDB()
     m_instanceCreatureKills.clear();
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "> Loading table `instance_creature_kills`");
     count = 0;
-    result.reset(LogsDatabase.Query("SELECT `mapId`, `creatureEntry`, `spellEntry`, `count` FROM `instance_creature_kills`"));
+    result = LogsDatabase.Query("SELECT `mapId`, `creatureEntry`, `spellEntry`, `count` FROM `instance_creature_kills`");
     if (!result)
     {
         BarGoLink bar(1);
@@ -111,7 +111,7 @@ void InstanceStatisticsMgr::LoadFromDB()
     m_instanceCustomCounters.clear();
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "> Loading table `instance_custom_counters`");
     count = 0;
-    result.reset(LogsDatabase.Query("SELECT `index`, `count` FROM `instance_custom_counters`"));
+    result = LogsDatabase.Query("SELECT `index`, `count` FROM `instance_custom_counters`");
     if (!result)
     {
         BarGoLink bar(1);

--- a/src/game/ItemEnchantmentMgr.cpp
+++ b/src/game/ItemEnchantmentMgr.cpp
@@ -56,7 +56,7 @@ void LoadRandomEnchantmentsTable()
     uint32 entry, ench;
     uint32 count = 0;
 
-    QueryResult* result = WorldDatabase.PQuery("SELECT entry, ench, chance FROM item_enchantment_template WHERE ((%u >= patch_min) && (%u <= patch_max))", sWorld.GetWowPatch(), sWorld.GetWowPatch());
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT entry, ench, chance FROM item_enchantment_template WHERE ((%u >= patch_min) && (%u <= patch_max))", sWorld.GetWowPatch(), sWorld.GetWowPatch());
 
     if (result)
     {
@@ -77,8 +77,6 @@ void LoadRandomEnchantmentsTable()
             ++count;
         }
         while (result->NextRow());
-
-        delete result;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u Item Enchantment definitions", count);

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -102,7 +102,7 @@ void LootStore::LoadLootTable()
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "%s :", GetName());
 
     //                                                 0      1     2                    3        4              5         6
-    QueryResult* result = WorldDatabase.PQuery("SELECT entry, item, ChanceOrQuestChance, groupid, mincountOrRef, maxcount, condition_id FROM %s WHERE ((%u >= patch_min) && (%u <= patch_max)) && ((mincountOrRef < 0) || (item NOT IN (SELECT entry FROM forbidden_items WHERE (after_or_before = 0 && patch <= %u) || (after_or_before = 1 && patch >= %u))))", GetName(), sWorld.GetWowPatch(), sWorld.GetWowPatch(), sWorld.GetWowPatch(), sWorld.GetWowPatch());
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT entry, item, ChanceOrQuestChance, groupid, mincountOrRef, maxcount, condition_id FROM %s WHERE ((%u >= patch_min) && (%u <= patch_max)) && ((mincountOrRef < 0) || (item NOT IN (SELECT entry FROM forbidden_items WHERE (after_or_before = 0 && patch <= %u) || (after_or_before = 1 && patch >= %u))))", GetName(), sWorld.GetWowPatch(), sWorld.GetWowPatch(), sWorld.GetWowPatch(), sWorld.GetWowPatch());
 
     if (result)
     {
@@ -183,8 +183,6 @@ void LootStore::LoadLootTable()
 
         }
         while (result->NextRow());
-
-        delete result;
 
         Verify();                                           // Checks validity of the loot store
 

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -101,7 +101,7 @@ void LootStore::LoadLootTable()
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "%s :", GetName());
 
-    //                                                 0      1     2                    3        4              5         6
+    //                                                                 0      1     2                    3        4              5         6
     std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT entry, item, ChanceOrQuestChance, groupid, mincountOrRef, maxcount, condition_id FROM %s WHERE ((%u >= patch_min) && (%u <= patch_max)) && ((mincountOrRef < 0) || (item NOT IN (SELECT entry FROM forbidden_items WHERE (after_or_before = 0 && patch <= %u) || (after_or_before = 1 && patch >= %u))))", GetName(), sWorld.GetWowPatch(), sWorld.GetWowPatch(), sWorld.GetWowPatch(), sWorld.GetWowPatch());
 
     if (result)

--- a/src/game/Mail/MassMailMgr.cpp
+++ b/src/game/Mail/MassMailMgr.cpp
@@ -58,7 +58,7 @@ void MassMailMgr::AddMassMailTask(MailDraft* mailProto, MailSender const& sender
 
 struct MassMailerQueryHandler
 {
-    void HandleQueryCallback(QueryResult* result, MailDraft* mailProto, MailSender sender)
+    void HandleQueryCallback(std::unique_ptr<QueryResult> result, MailDraft* mailProto, MailSender sender)
     {
         if (!result)
             return;
@@ -69,10 +69,8 @@ struct MassMailerQueryHandler
         {
             Field* fields = result->Fetch();
             recievers.insert(fields[0].GetUInt32());
-
         }
         while (result->NextRow());
-        delete result;
     }
 } massMailerQueryHandler;
 

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1973,7 +1973,7 @@ void Map::CreateInstanceData(bool load)
     if (load)
     {
         // TODO: make a global storage for this
-        QueryResult* result;
+        std::unique_ptr<QueryResult> result;
 
         if (Instanceable())
             result = CharacterDatabase.PQuery("SELECT data FROM instance WHERE id = '%u'", i_InstanceId);
@@ -1991,8 +1991,6 @@ void Map::CreateInstanceData(bool load)
             }
             else
                 i_data->Create();
-
-            delete result;
         }
         else
         {

--- a/src/game/Maps/MapManager.cpp
+++ b/src/game/Maps/MapManager.cpp
@@ -450,11 +450,10 @@ void MapManager::InitMaxInstanceId()
 {
     i_MaxInstanceId = RESERVED_INSTANCES_LAST;
 
-    QueryResult* result = CharacterDatabase.Query("SELECT MAX(`id`) FROM `instance`");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT MAX(`id`) FROM `instance`");
     if (result)
     {
         i_MaxInstanceId = result->Fetch()[0].GetUInt32();
-        delete result;
     }
     if (i_MaxInstanceId < RESERVED_INSTANCES_LAST)
         i_MaxInstanceId = RESERVED_INSTANCES_LAST;

--- a/src/game/Maps/MapPersistentStateMgr.cpp
+++ b/src/game/Maps/MapPersistentStateMgr.cpp
@@ -332,7 +332,7 @@ void DungeonResetScheduler::LoadResetTimes()
     // _____BAD_____
     ResetTimeMapType InstResetTime;
 
-    QueryResult* result = CharacterDatabase.Query("SELECT `id`, `map`, `reset_time` FROM `instance`");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `id`, `map`, `reset_time` FROM `instance`");
     if (result)
     {
         do
@@ -358,7 +358,6 @@ void DungeonResetScheduler::LoadResetTimes()
                 resetTime ? resetTime : now + 2 * HOUR);
         }
         while (result->NextRow());
-        delete result;
 
         // update reset time for normal instances with the max creature respawn time + X hours
         result = CharacterDatabase.Query("SELECT MAX(`respawn_time`), `instance` FROM `creature_respawn` WHERE `instance` > 0 GROUP BY `instance`");
@@ -377,7 +376,6 @@ void DungeonResetScheduler::LoadResetTimes()
                 }
             }
             while (result->NextRow());
-            delete result;
         }
     }
 
@@ -410,7 +408,6 @@ void DungeonResetScheduler::LoadResetTimes()
             SetResetTimeFor(mapId, newresettime);
         }
         while (result->NextRow());
-        delete result;
     }
 
     // clean expired instances, references to them will be deleted in CleanupInstances
@@ -428,7 +425,7 @@ void DungeonResetScheduler::ScheduleAllDungeonResets()
     // Reset times have already been updated and set in LoadResetTimes(). We just need to start
     // the initial reset events based on them. Since LoadResetTimes() is called before
     // PackInstances(), it cannot be done there.
-    QueryResult* result = CharacterDatabase.Query("SELECT `id`, `map`, `reset_time` FROM `instance`");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `id`, `map`, `reset_time` FROM `instance`");
     if (result)
     {
         do
@@ -444,7 +441,6 @@ void DungeonResetScheduler::ScheduleAllDungeonResets()
 
             InstResetTime[id] = std::pair<uint32, time_t>(mapId, resetTime);
         } while (result->NextRow());
-        delete result;
     }
 
     for (const auto& itr : InstResetTime)
@@ -745,7 +741,7 @@ void MapPersistentStateManager::_DelHelper(DatabaseType &db, char const* fields,
     vsnprintf(szQueryTail, MAX_QUERY_LEN, queryTail, ap);
     va_end(ap);
 
-    QueryResult* result = db.PQuery("SELECT %s FROM %s %s", fields, table, szQueryTail);
+    std::unique_ptr<QueryResult> result = db.PQuery("SELECT %s FROM %s %s", fields, table, szQueryTail);
     if (result)
     {
         do
@@ -761,7 +757,6 @@ void MapPersistentStateManager::_DelHelper(DatabaseType &db, char const* fields,
             db.PExecute("DELETE FROM %s WHERE %s", table, ss.str().c_str());
         }
         while (result->NextRow());
-        delete result;
     }
 }
 
@@ -816,7 +811,7 @@ void MapPersistentStateManager::PackInstances()
         CharacterDatabase.PExecute("UPDATE `group_instance` SET `instance` = `instance` + %u WHERE `instance` >= 0 ORDER BY `instance` DESC", RESERVED_INSTANCES_LAST, RESERVED_INSTANCES_LAST);
         CharacterDatabase.Execute("DELETE FROM `instance` WHERE `map` <= 1");
     CharacterDatabase.CommitTransaction();
-    QueryResult* result = CharacterDatabase.Query("SELECT `id` FROM `instance`");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `id` FROM `instance`");
     if (result)
     {
         do
@@ -825,7 +820,6 @@ void MapPersistentStateManager::PackInstances()
             InstanceSet.insert(fields[0].GetUInt32());
         }
         while (result->NextRow());
-        delete result;
     }
 
     BarGoLink bar(InstanceSet.size() + 1);
@@ -1018,7 +1012,7 @@ void MapPersistentStateManager::LoadCreatureRespawnTimes()
 
     uint32 count = 0;
 
-    QueryResult* result = CharacterDatabase.Query("SELECT `guid`, `respawn_time`, `creature_respawn`.`map`, `instance`, `reset_time` FROM `creature_respawn` LEFT JOIN `instance` ON `instance` = `id`");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `guid`, `respawn_time`, `creature_respawn`.`map`, `instance`, `reset_time` FROM `creature_respawn` LEFT JOIN `instance` ON `instance` = `id`");
     if (!result)
     {
         BarGoLink bar(1);
@@ -1086,8 +1080,6 @@ void MapPersistentStateManager::LoadCreatureRespawnTimes()
     }
     while (result->NextRow());
 
-    delete result;
-
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u creature respawn times", count);
 }
@@ -1099,7 +1091,7 @@ void MapPersistentStateManager::LoadGameobjectRespawnTimes()
 
     uint32 count = 0;
 
-    QueryResult* result = CharacterDatabase.Query("SELECT `guid`, `respawn_time`, `gameobject_respawn`.`map`, `instance`, `reset_time` FROM `gameobject_respawn` LEFT JOIN `instance` ON `instance` = id");
+    std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT `guid`, `respawn_time`, `gameobject_respawn`.`map`, `instance`, `reset_time` FROM `gameobject_respawn` LEFT JOIN `instance` ON `instance` = id");
 
     if (!result)
     {
@@ -1164,8 +1156,6 @@ void MapPersistentStateManager::LoadGameobjectRespawnTimes()
 
     }
     while (result->NextRow());
-
-    delete result;
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u gameobject respawn times", count);

--- a/src/game/Maps/Pool/PoolManager.cpp
+++ b/src/game/Maps/Pool/PoolManager.cpp
@@ -666,7 +666,7 @@ bool CheckPoolAndChance(char const* table, uint16 pool_id, float chance)
 
 void PoolManager::LoadFromDB()
 {
-    QueryResult* result = WorldDatabase.PQuery("SELECT MAX(`entry`) FROM `pool_template` WHERE %u BETWEEN `patch_min` AND `patch_max`", sWorld.GetWowPatch());
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT MAX(`entry`) FROM `pool_template` WHERE %u BETWEEN `patch_min` AND `patch_max`", sWorld.GetWowPatch());
     if (!result)
     {
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Table pool_template is empty.");
@@ -677,7 +677,6 @@ void PoolManager::LoadFromDB()
     {
         Field* fields = result->Fetch();
         max_pool_id = fields[0].GetUInt16();
-        delete result;
     }
 
     mPoolTemplate.resize(max_pool_id + 1);
@@ -716,7 +715,6 @@ void PoolManager::LoadFromDB()
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u objects pools", count);
-    delete result;
 
     PoolMapChecker mapChecker(mPoolTemplate);
 
@@ -798,7 +796,6 @@ void PoolManager::LoadFromDB()
         while (result->NextRow());
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u creatures in pools from `pool_creature` and `pool_creature_template`", count);
-        delete result;
     }
 
     // Gameobjects (guids and entries)
@@ -886,7 +883,6 @@ void PoolManager::LoadFromDB()
         while (result->NextRow());
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u gameobject in pools from `pool_gameobject` and `pool_gameobject_template`", count);
-        delete result;
     }
 
     // Pool of pools
@@ -986,7 +982,6 @@ void PoolManager::LoadFromDB()
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u pools in mother pools", count);
-        delete result;
     }
 
     // check chances integrity

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -2089,7 +2089,7 @@ void ObjectMgr::LoadCreatureClassLevelStats()
             } while (result->NextRow());
         }
 
-        //                                         0        1               2                3               4                      5         6              7       8            9           10         11         12           13        14
+        //                                     0        1               2                3               4                      5         6              7       8            9           10         11         12           13        14
         result = WorldDatabase.PQuery("SELECT `level`, `melee_damage`, `ranged_damage`, `attack_power`, `ranged_attack_power`, `health`, `base_health`, `mana`, `base_mana`, `strength`, `agility`, `stamina`, `intellect`, `spirit`, `armor` FROM `creature_classlevelstats` WHERE `class`=%u ORDER BY `level`", unitClass);
 
         if (result)
@@ -5187,7 +5187,7 @@ void ObjectMgr::LoadGroups()
 
     // -- loading members --
     count = 0;
-    //                                            0              1            2           3
+    //                                        0              1            2           3
     result = CharacterDatabase.Query("SELECT `member_guid`, `assistant`, `subgroup`, `group_id` FROM `group_member` ORDER BY `group_id`");
     if (!result)
     {
@@ -8275,7 +8275,7 @@ void ObjectMgr::LoadFactions()
 
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_12_1
         // Load localized texts (currently we only have 1.12 locales).
-        //                                        0        1            2            3            4            5            6            7                   8                   9                   10                  11                  12
+        //                                    0        1            2            3            4            5            6            7                   8                   9                   10                  11                  12
         result = WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6`, `description_loc1`, `description_loc2`, `description_loc3`, `description_loc4`, `description_loc5`, `description_loc6` FROM `locales_faction`");
         if (result)
         {
@@ -8880,7 +8880,7 @@ void ObjectMgr::LoadTaxiNodes()
 
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_12_1
     // Load localized texts (currently we only have 1.12 locales).
-    //                                        0        1            2            3            4            5            6
+    //                                    0        1            2            3            4            5            6
     result = WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6` FROM `locales_taxi_node`");
     if (result)
     {

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -181,7 +181,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
     
     m_QuestIdSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `entry` FROM `quest_template`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `entry` FROM `quest_template`");
 
     if (result)
     {
@@ -194,7 +194,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_CreatureIdSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `entry` FROM `creature_template`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `entry` FROM `creature_template`");
 
     if (result)
     {
@@ -207,7 +207,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_GameObjectIdSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `entry` FROM `gameobject_template`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `entry` FROM `gameobject_template`");
 
     if (result)
     {
@@ -220,7 +220,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_CreatureGuidSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `guid` FROM `creature`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `guid` FROM `creature`");
 
     if (result)
     {
@@ -233,7 +233,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_GameObjectGuidSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `guid` FROM `gameobject`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `guid` FROM `gameobject`");
 
     if (result)
     {
@@ -246,7 +246,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_AreaTriggerIdSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `id` FROM `areatrigger_template`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `id` FROM `areatrigger_template`");
 
     if (result)
     {
@@ -259,7 +259,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_CreatureSpellsIdSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `entry` FROM `creature_spells`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `entry` FROM `creature_spells`");
 
     if (result)
     {
@@ -272,7 +272,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_VendorTemplateIdSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `entry` FROM `npc_vendor_template`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `entry` FROM `npc_vendor_template`");
 
     if (result)
     {
@@ -285,7 +285,7 @@ void ObjectMgr::LoadAllIdentifiers()
     }
 
     m_GossipMenuIdSet.clear();
-    result.reset(WorldDatabase.Query("SELECT DISTINCT `entry` FROM `gossip_menu`"));
+    result = WorldDatabase.Query("SELECT DISTINCT `entry` FROM `gossip_menu`");
 
     if (result)
     {
@@ -654,16 +654,16 @@ void ObjectMgr::LoadPlayerCacheData(uint32 lowGuid)
         m_playerCacheData.clear();
         m_playerNameToGuid.clear();
 
-        result.reset(CharacterDatabase.Query(
+        result = CharacterDatabase.Query(
             //       0       1       2        3         4          5       6        7          8      9             10            11            12             13
-            "SELECT `guid`, `race`, `class`, `gender`, `account`, `name`, `level`, `zone`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `current_taxi_path` FROM `characters`;"));
+            "SELECT `guid`, `race`, `class`, `gender`, `account`, `name`, `level`, `zone`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `current_taxi_path` FROM `characters`;");
     }
     else
     {
         // load a single character (likely just restored)
-        result.reset(CharacterDatabase.PQuery(
+        result = CharacterDatabase.PQuery(
             //       0       1       2        3         4          5       6        7          8      9             10            11            12             13
-            "SELECT `guid`, `race`, `class`, `gender`, `account`, `name`, `level`, `zone`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `current_taxi_path` FROM `characters` WHERE `guid`=%u;", lowGuid));
+            "SELECT `guid`, `race`, `class`, `gender`, `account`, `name`, `level`, `zone`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `current_taxi_path` FROM `characters` WHERE `guid`=%u;", lowGuid);
     }
 
     uint32 totalCount = 0;
@@ -1913,7 +1913,7 @@ void ObjectMgr::LoadCreatureSpells()
     m_CreatureSpellsMap.clear(); // for reload case
 
                                      //       0        1            2                3               4                 5                 6              7                    8                    9                   10                  11
-    result.reset(WorldDatabase.Query("SELECT `entry`, `spellId_1`, `probability_1`, `castTarget_1`, `targetParam1_1`, `targetParam2_1`, `castFlags_1`, `delayInitialMin_1`, `delayInitialMax_1`, `delayRepeatMin_1`, `delayRepeatMax_1`, `scriptId_1`, "
+    result = WorldDatabase.Query("SELECT `entry`, `spellId_1`, `probability_1`, `castTarget_1`, `targetParam1_1`, `targetParam2_1`, `castFlags_1`, `delayInitialMin_1`, `delayInitialMax_1`, `delayRepeatMin_1`, `delayRepeatMax_1`, `scriptId_1`, "
                                       //               12           13               14              15                16                17             18                   19                   20                  21                  22
                                                      "`spellId_2`, `probability_2`, `castTarget_2`, `targetParam1_2`, `targetParam2_2`, `castFlags_2`, `delayInitialMin_2`, `delayInitialMax_2`, `delayRepeatMin_2`, `delayRepeatMax_2`, `scriptId_2`, "
                                      //                23           24               25              26                27                28             29                   30                   31                  32                  33
@@ -1927,7 +1927,7 @@ void ObjectMgr::LoadCreatureSpells()
                                      //                67           68               69              70                71                72             73                   74                   75                  76                  77
                                                      "`spellId_7`, `probability_7`, `castTarget_7`, `targetParam1_7`, `targetParam2_7`, `castFlags_7`, `delayInitialMin_7`, `delayInitialMax_7`, `delayRepeatMin_7`, `delayRepeatMax_7`, `scriptId_7`, "
                                      //                78           79               80              81                82                83             84                   85                   86                  87                  88
-                                                     "`spellId_8`, `probability_8`, `castTarget_8`, `targetParam1_8`, `targetParam2_8`, `castFlags_8`, `delayInitialMin_8`, `delayInitialMax_8`, `delayRepeatMin_8`, `delayRepeatMax_8`, `scriptId_8` FROM `creature_spells`"));
+                                                     "`spellId_8`, `probability_8`, `castTarget_8`, `targetParam1_8`, `targetParam2_8`, `castFlags_8`, `delayInitialMin_8`, `delayInitialMax_8`, `delayRepeatMin_8`, `delayRepeatMax_8`, `scriptId_8` FROM `creature_spells`");
     if (!result)
     {
         BarGoLink bar(1);
@@ -2055,7 +2055,7 @@ void ObjectMgr::LoadCreatureClassLevelStats()
 
     for (auto unitClass : creatureClasses)
     {
-        result.reset(WorldDatabase.PQuery("SELECT MAX(`level_max`) FROM `creature_template` WHERE `unit_class`=%u", unitClass));
+        result = WorldDatabase.PQuery("SELECT MAX(`level_max`) FROM `creature_template` WHERE `unit_class`=%u", unitClass);
 
         uint32 requiredMaxLevel = MAX_LEVEL;
         if (result)
@@ -2069,7 +2069,7 @@ void ObjectMgr::LoadCreatureClassLevelStats()
             } while (result->NextRow());
         }
 
-        result.reset(WorldDatabase.PQuery("SELECT MAX(`level`) FROM `creature_classlevelstats` WHERE `class`=%u", unitClass));
+        result = WorldDatabase.PQuery("SELECT MAX(`level`) FROM `creature_classlevelstats` WHERE `class`=%u", unitClass);
 
         uint32 currentMaxLevel = CREATURE_MAX_LEVEL;
         if (result)
@@ -2090,7 +2090,7 @@ void ObjectMgr::LoadCreatureClassLevelStats()
         }
 
         //                                         0        1               2                3               4                      5         6              7       8            9           10         11         12           13        14
-        result.reset(WorldDatabase.PQuery("SELECT `level`, `melee_damage`, `ranged_damage`, `attack_power`, `ranged_attack_power`, `health`, `base_health`, `mana`, `base_mana`, `strength`, `agility`, `stamina`, `intellect`, `spirit`, `armor` FROM `creature_classlevelstats` WHERE `class`=%u ORDER BY `level`", unitClass));
+        result = WorldDatabase.PQuery("SELECT `level`, `melee_damage`, `ranged_damage`, `attack_power`, `ranged_attack_power`, `health`, `base_health`, `mana`, `base_mana`, `strength`, `agility`, `stamina`, `intellect`, `spirit`, `armor` FROM `creature_classlevelstats` WHERE `class`=%u ORDER BY `level`", unitClass);
 
         if (result)
         {
@@ -5188,7 +5188,7 @@ void ObjectMgr::LoadGroups()
     // -- loading members --
     count = 0;
     //                                            0              1            2           3
-    result.reset(CharacterDatabase.Query("SELECT `member_guid`, `assistant`, `subgroup`, `group_id` FROM `group_member` ORDER BY `group_id`"));
+    result = CharacterDatabase.Query("SELECT `member_guid`, `assistant`, `subgroup`, `group_id` FROM `group_member` ORDER BY `group_id`");
     if (!result)
     {
         BarGoLink bar2(1);
@@ -5251,7 +5251,7 @@ void ObjectMgr::LoadGroups()
 
     // -- loading instances --
     count = 0;
-    result.reset(CharacterDatabase.Query(
+    result = CharacterDatabase.Query(
                  //                        0              1      2           3            4
                  "SELECT `group_instance`.`leader_guid`, `map`, `instance`, `permanent`, `reset_time`, "
                  // 5
@@ -5259,7 +5259,7 @@ void ObjectMgr::LoadGroups()
                  // 6
                  " `groups`.`group_id` "
                  "FROM `group_instance` LEFT JOIN `instance` ON `instance` = `id` LEFT JOIN `groups` ON `groups`.`leader_guid` = `group_instance`.`leader_guid` ORDER BY `leader_guid`"
-             ));
+             );
 
     if (!result)
     {
@@ -6606,7 +6606,7 @@ public:
     ObjectGuid receiverGuid;
     uint32 itemTextId;
 
-    void Callback(QueryResult* result)
+    void Callback(std::unique_ptr<QueryResult> result)
     {
         uint32 item_guid = 0;
         if (result)
@@ -6614,8 +6614,8 @@ public:
             Field* fields2 = result->Fetch();
 
             item_guid = fields2[0].GetUInt32();
-            delete result;
         }
+
         if (!sObjectAccessor.FindPlayerNotInWorld(receiverGuid)) // Do not process online players!
         {
             if (!returnToLowGuid) // Delete mail and items
@@ -6654,7 +6654,7 @@ public:
     OldMailsReturner() : serverUp(false), basetime(0) {}
     bool serverUp;
     time_t basetime;
-    void Callback(QueryResult* result)
+    void Callback(std::unique_ptr<QueryResult> result)
     {
         if (!result)
         {
@@ -6724,7 +6724,7 @@ public:
         }
         while (result->NextRow());
         sObjectMgr.IncrementOldMailCounter(skippedCount);
-        delete result;
+
         delete this;
     }
 };
@@ -7578,11 +7578,11 @@ void ObjectMgr::SetHighestGuids()
     if (result)
         m_CharGuids.Set((*result)[0].GetUInt32() + 1);
 
-    result.reset(WorldDatabase.Query("SELECT MAX(`guid`) FROM `creature`"));
+    result = WorldDatabase.Query("SELECT MAX(`guid`) FROM `creature`");
     if (result)
         m_FirstTemporaryCreatureGuid = (*result)[0].GetUInt32() + 1;
 
-    result.reset(CharacterDatabase.Query("SELECT MAX(`guid`) FROM `item_instance`"));
+    result = CharacterDatabase.Query("SELECT MAX(`guid`) FROM `item_instance`");
     if (result)
         m_ItemGuids.Set((*result)[0].GetUInt32() + 1);
 
@@ -7593,11 +7593,11 @@ void ObjectMgr::SetHighestGuids()
     CharacterDatabase.PExecute("DELETE FROM `auction` WHERE `item_guid` >= '%u'", m_ItemGuids.GetNextAfterMaxUsed());
     CharacterDatabase.CommitTransaction();
 
-    result.reset(WorldDatabase.Query("SELECT MAX(`guid`) FROM `gameobject`"));
+    result = WorldDatabase.Query("SELECT MAX(`guid`) FROM `gameobject`");
     if (result)
         m_FirstTemporaryGameObjectGuid = (*result)[0].GetUInt32() + 1;
 
-    result.reset(CharacterDatabase.Query("SELECT `id` FROM `auction`"));
+    result = CharacterDatabase.Query("SELECT `id` FROM `auction`");
     if (result)
     {
         do
@@ -7608,27 +7608,27 @@ void ObjectMgr::SetHighestGuids()
     }
     m_NextAuctionId = 1;
 
-    result.reset(CharacterDatabase.Query("SELECT MAX(`id`) FROM `mail`"));
+    result = CharacterDatabase.Query("SELECT MAX(`id`) FROM `mail`");
     if (result)
         m_MailIds.Set((*result)[0].GetUInt32() + 1);
 
-    result.reset(CharacterDatabase.Query("SELECT MAX(`id`) FROM `item_text`"));
+    result = CharacterDatabase.Query("SELECT MAX(`id`) FROM `item_text`");
     if (result)
         m_ItemTextIds.Set((*result)[0].GetUInt32() + 1);
 
-    result.reset(CharacterDatabase.Query("SELECT MAX(`guid`) FROM `corpse`"));
+    result = CharacterDatabase.Query("SELECT MAX(`guid`) FROM `corpse`");
     if (result)
         m_CorpseGuids.Set((*result)[0].GetUInt32() + 1);
 
-    result.reset(CharacterDatabase.Query("SELECT MAX(`guild_id`) FROM `guild`"));
+    result = CharacterDatabase.Query("SELECT MAX(`guild_id`) FROM `guild`");
     if (result)
         m_GuildIds.Set((*result)[0].GetUInt32() + 1);
 
-    result.reset(CharacterDatabase.Query("SELECT MAX(`group_id`) FROM `groups`"));
+    result = CharacterDatabase.Query("SELECT MAX(`group_id`) FROM `groups`");
     if (result)
         m_GroupIds.Set((*result)[0].GetUInt32() + 1);
 
-    result.reset(CharacterDatabase.Query("SELECT MAX(`petition_guid`) FROM `petition`"));
+    result = CharacterDatabase.Query("SELECT MAX(`petition_guid`) FROM `petition`");
     if (result)
         m_PetitionIds.Set((*result)[0].GetUInt32() + 1);
 
@@ -8276,7 +8276,7 @@ void ObjectMgr::LoadFactions()
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_12_1
         // Load localized texts (currently we only have 1.12 locales).
         //                                        0        1            2            3            4            5            6            7                   8                   9                   10                  11                  12
-        result.reset(WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6`, `description_loc1`, `description_loc2`, `description_loc3`, `description_loc4`, `description_loc5`, `description_loc6` FROM `locales_faction`"));
+        result = WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6`, `description_loc1`, `description_loc2`, `description_loc3`, `description_loc4`, `description_loc5`, `description_loc6` FROM `locales_faction`");
         if (result)
         {
             do
@@ -8841,7 +8841,7 @@ void ObjectMgr::LoadTaxiNodes()
     uint32 maxTaxiNodeEntry = fields[0].GetUInt32() + 1;
 
     // Actually loading the taxi nodes.
-    result.reset(WorldDatabase.PQuery("SELECT * FROM `taxi_nodes` t1 WHERE `build`=(SELECT max(`build`) FROM `taxi_nodes` t2 WHERE t1.`id`=t2.`id` && `build` <= %u)", SUPPORTED_CLIENT_BUILD));
+    result = WorldDatabase.PQuery("SELECT * FROM `taxi_nodes` t1 WHERE `build`=(SELECT max(`build`) FROM `taxi_nodes` t2 WHERE t1.`id`=t2.`id` && `build` <= %u)", SUPPORTED_CLIENT_BUILD);
 
     if (!result)
     {
@@ -8881,7 +8881,7 @@ void ObjectMgr::LoadTaxiNodes()
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_12_1
     // Load localized texts (currently we only have 1.12 locales).
     //                                        0        1            2            3            4            5            6
-    result.reset(WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6` FROM `locales_taxi_node`"));
+    result = WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6` FROM `locales_taxi_node`");
     if (result)
     {
         do
@@ -9327,7 +9327,7 @@ void ObjectMgr::LoadSkillLineAbility()
     uint32 maxSkillLineAbilityId = fields[0].GetUInt32() + 1;
 
     // Actually loading the skills.
-    result.reset(WorldDatabase.PQuery("SELECT * FROM `skill_line_ability` WHERE `build`=%u", SUPPORTED_CLIENT_BUILD));
+    result = WorldDatabase.PQuery("SELECT * FROM `skill_line_ability` WHERE `build`=%u", SUPPORTED_CLIENT_BUILD);
 
     if (!result)
     {
@@ -10156,7 +10156,7 @@ void ObjectMgr::LoadTrainers(char const* tableName, bool isTemplates)
         } while (result->NextRow());
     }
 
-    result.reset(WorldDatabase.PQuery("SELECT `entry`, `spell`, `spellcost`, `reqskill`, `reqskillvalue`, `reqlevel` FROM %s WHERE %u BETWEEN `build_min` AND `build_max`", tableName, SUPPORTED_CLIENT_BUILD));
+    result = WorldDatabase.PQuery("SELECT `entry`, `spell`, `spellcost`, `reqskill`, `reqskillvalue`, `reqlevel` FROM %s WHERE %u BETWEEN `build_min` AND `build_max`", tableName, SUPPORTED_CLIENT_BUILD);
 
     if (!result)
     {

--- a/src/game/ObjectMgr.h
+++ b/src/game/ObjectMgr.h
@@ -39,8 +39,6 @@
 #include <map>
 #include <limits>
 
-extern SQLStorage sCreatureDataLinkGroupStorage;
-
 class Group;
 class Item;
 

--- a/src/game/Objects/Corpse.cpp
+++ b/src/game/Objects/Corpse.cpp
@@ -155,7 +155,7 @@ void Corpse::DeleteFromDB()
 
 bool Corpse::LoadFromDB(uint32 lowguid, Field* fields)
 {
-    ////                                                    0            1            2                  3                  4                  5                   6
+    ////                                                                    0            1            2                  3                  4                  5                   6
     //std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT corpse.guid, player_guid, corpse.position_x, corpse.position_y, corpse.position_z, corpse.orientation, corpse.map,"
     ////   7     8            9         10      11    12     13     14   15          16          17           18               19        20
     //    "time, corpse_type, instance, gender, race, class, skin, face, hair_style, hair_color, facial_hair, equipment_cache, guild_id, player_flags FROM corpse"

--- a/src/game/Objects/Corpse.cpp
+++ b/src/game/Objects/Corpse.cpp
@@ -156,7 +156,7 @@ void Corpse::DeleteFromDB()
 bool Corpse::LoadFromDB(uint32 lowguid, Field* fields)
 {
     ////                                                    0            1            2                  3                  4                  5                   6
-    //QueryResult* result = CharacterDatabase.Query("SELECT corpse.guid, player_guid, corpse.position_x, corpse.position_y, corpse.position_z, corpse.orientation, corpse.map,"
+    //std::unique_ptr<QueryResult> result = CharacterDatabase.Query("SELECT corpse.guid, player_guid, corpse.position_x, corpse.position_y, corpse.position_z, corpse.orientation, corpse.map,"
     ////   7     8            9         10      11    12     13     14   15          16          17           18               19        20
     //    "time, corpse_type, instance, gender, race, class, skin, face, hair_style, hair_color, facial_hair, equipment_cache, guild_id, player_flags FROM corpse"
     uint32 playerLowGuid = fields[1].GetUInt32();

--- a/src/game/Objects/Pet.cpp
+++ b/src/game/Objects/Pet.cpp
@@ -1565,7 +1565,7 @@ uint32 Pet::GetCurrentFoodBenefitLevel(uint32 itemLevel) const
 
 void Pet::_LoadSpellCooldowns()
 {
-    //QueryResult* result = CharacterDatabase.PQuery("SELECT spell,time FROM pet_spell_cooldown WHERE guid = '%u'",m_charmInfo->GetPetNumber());
+    //std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT spell,time FROM pet_spell_cooldown WHERE guid = '%u'",m_charmInfo->GetPetNumber());
 
     if (m_pTmpCache)
     {
@@ -1659,7 +1659,7 @@ void Pet::_SaveSpellCooldowns()
 
 void Pet::_LoadSpells()
 {
-    //QueryResult* result = CharacterDatabase.PQuery("SELECT spell,active FROM pet_spell WHERE guid = '%u'",m_charmInfo->GetPetNumber());
+    //std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT spell,active FROM pet_spell WHERE guid = '%u'",m_charmInfo->GetPetNumber());
 
     if (m_pTmpCache)
     {
@@ -1736,7 +1736,7 @@ void Pet::_LoadAuras(uint32 timediff)
     for (int i = UNIT_FIELD_AURA; i <= UNIT_FIELD_AURASTATE; ++i)
         SetUInt32Value(i, 0);
 
-    //QueryResult* result = CharacterDatabase.PQuery("SELECT caster_guid, item_guid, spell, stacks, charges, base_points0, base_points1, base_points2, periodic_time0, periodic_time1, periodic_time2, max_duration, duration, effect_index_mask FROM pet_aura WHERE guid = '%u'",m_charmInfo->GetPetNumber());
+    //std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT caster_guid, item_guid, spell, stacks, charges, base_points0, base_points1, base_points2, periodic_time0, periodic_time1, periodic_time2, max_duration, duration, effect_index_mask FROM pet_aura WHERE guid = '%u'",m_charmInfo->GetPetNumber());
     if (m_pTmpCache)
     {
         for (const auto& it : m_pTmpCache->auras)

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -4817,7 +4817,7 @@ void Player::DeleteFromDB(ObjectGuid playerGuid, uint32 accountId, bool updateRe
         // completely remove from the database
         case 0:
         {
-            // return back all mails with COD and Item                 0      1               2                   3              4          5               6        7
+            // return back all mails with COD and Item                                  0      1               2                   3              4          5               6        7
             std::unique_ptr<QueryResult> resultMail = CharacterDatabase.PQuery("SELECT `id`, `message_type`, `mail_template_id`, `sender_guid`, `subject`, `item_text_id`, `money`, `has_items` FROM `mail` WHERE `receiver_guid`='%u' AND `has_items`<>0 AND `cod`<>0", lowguid);
             if (resultMail)
             {
@@ -16136,7 +16136,7 @@ void Player::_LoadQuestStatus(std::unique_ptr<QueryResult> result)
 
     uint32 slot = 0;
 
-    ////                                                     0      1       2         3         4      5           6           7           8           9            10           11           12           13
+    ////                                                                     0      1       2         3         4      5           6           7           8           9            10           11           12           13
     //std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT quest, status, rewarded, explored, timer, mob_count1, mob_count2, mob_count3, mob_count4, item_count1, item_count2, item_count3, item_count4, reward_choice FROM character_queststatus WHERE guid = '%u'", GetGUIDLow());
 
     if (result)

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -973,7 +973,7 @@ class Player final: public Unit
         // Initializes a new Player object that was not loaded from the database.
         bool Create(uint32 guidlow, std::string const& name, uint8 race, uint8 class_, uint8 gender, uint8 skin, uint8 face, uint8 hairStyle, uint8 hairColor, uint8 facialHair);
         void Update(uint32 update_diff, uint32 time) override;
-        static bool BuildEnumData(QueryResult const* result,  WorldPacket* pData);
+        static bool BuildEnumData(const std::unique_ptr<QueryResult>& result,  WorldPacket* pData);
 
         /**
          * @brief Can only be called from Master server (or ASSERT will fail)
@@ -1410,22 +1410,22 @@ class Player final: public Unit
     private:
         void LoadAura(AuraSaveStruct& saveStruct, uint32 timediff);
         bool SaveAura(SpellAuraHolder const* holder, AuraSaveStruct& saveStruct);
-        void _LoadAuras(QueryResult* result, uint32 timediff);
-        void _LoadBoundInstances(QueryResult* result);
-        bool _LoadInventory(QueryResult* result, uint32 timediff, bool& hasEpicMount);
-        void _LoadItemLoot(QueryResult* result);
-        void _LoadQuestStatus(QueryResult* result);
-        void _LoadGroup(QueryResult* result);
-        void _LoadSkills(QueryResult* result);
+        void _LoadAuras(std::unique_ptr<QueryResult> result, uint32 timediff);
+        void _LoadBoundInstances(std::unique_ptr<QueryResult> result);
+        bool _LoadInventory(std::unique_ptr<QueryResult> result, uint32 timediff, bool& hasEpicMount);
+        void _LoadItemLoot(std::unique_ptr<QueryResult> result);
+        void _LoadQuestStatus(std::unique_ptr<QueryResult> result);
+        void _LoadGroup(std::unique_ptr<QueryResult> result);
+        void _LoadSkills(std::unique_ptr<QueryResult> result);
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2
-        void _LoadForgottenSkills(QueryResult* result);
+        void _LoadForgottenSkills(std::unique_ptr<QueryResult> result);
 #endif
         void LoadSkillsFromFields();
-        void _LoadSpells(QueryResult* result);
-        bool _LoadHomeBind(QueryResult* result);
-        void _LoadBGData(QueryResult* result);
+        void _LoadSpells(std::unique_ptr<QueryResult> result);
+        bool _LoadHomeBind(std::unique_ptr<QueryResult> result);
+        void _LoadBGData(std::unique_ptr<QueryResult> result);
         void _LoadIntoDataField(char const* data, uint32 startOffset, uint32 count);
-        void _LoadGuild(QueryResult* result);
+        void _LoadGuild(std::unique_ptr<QueryResult> result);
         uint32 m_atLoginFlags;
     public:
         bool LoadFromDB(ObjectGuid guid, SqlQueryHolder* holder);
@@ -1577,7 +1577,7 @@ class Player final: public Unit
         void SendClearCooldown(uint32 spellId, Unit const* target) const;
         void SendClearAllCooldowns(Unit const* target) const;
         void SendSpellCooldown(uint32 spellId, uint32 cooldown, ObjectGuid target) const;
-        void _LoadSpellCooldowns(QueryResult* result);
+        void _LoadSpellCooldowns(std::unique_ptr<QueryResult> result);
         void _SaveSpellCooldowns();
 
         template <typename F>

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -73,7 +73,7 @@ void PlayerBotMgr::Load()
     LoadConfig();
 
     // 3- Load usable account ID
-    QueryResult* result = LoginDatabase.PQuery(
+    std::unique_ptr<QueryResult> result = LoginDatabase.PQuery(
                               "SELECT MAX(`id`)"
                               " FROM `account`");
     if (!result)
@@ -83,7 +83,6 @@ void PlayerBotMgr::Load()
     }
     Field* fields = result->Fetch();
     m_maxAccountId = fields[0].GetUInt32() + 10000;
-    delete result;
 
     // 4- LoadFromDB
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> [PlayerBotMgr] Loading Bots ...");
@@ -111,7 +110,6 @@ void PlayerBotMgr::Load()
             m_totalChance += chance;
         }
         while (result->NextRow());
-        delete result;
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "%u bots loaded", m_bots.size());
     }
 

--- a/src/game/ReputationMgr.cpp
+++ b/src/game/ReputationMgr.cpp
@@ -394,12 +394,12 @@ void ReputationMgr::SetInactive(FactionState* faction, bool inactive)
     faction->needSave = true;
 }
 
-void ReputationMgr::LoadFromDB(QueryResult* result)
+void ReputationMgr::LoadFromDB(std::unique_ptr<QueryResult> result)
 {
     // Set initial reputations (so everything is nifty before DB data load)
     Initialize();
 
-    //QueryResult* result = CharacterDatabase.PQuery("SELECT faction,standing,flags FROM character_reputation WHERE guid = '%u'",GetGUIDLow());
+    //std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT faction,standing,flags FROM character_reputation WHERE guid = '%u'",GetGUIDLow());
 
     if (result)
     {

--- a/src/game/ReputationMgr.h
+++ b/src/game/ReputationMgr.h
@@ -64,7 +64,7 @@ class ReputationMgr
         ~ReputationMgr() {}
 
         void SaveToDB();
-        void LoadFromDB(QueryResult* result);
+        void LoadFromDB(std::unique_ptr<QueryResult> result);
     public:                                                 // statics
         static int32 const PointsInRank[MAX_REPUTATION_RANK];
         static int32 const Reputation_Cap    =  42999;

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -82,7 +82,7 @@ void ScriptMgr::LoadScripts(ScriptMapMap& scripts, char const* tablename)
     scripts.clear();                                        // need for reload support
 
     //                                                  0     1        2          3           4            5            6            7                8                9              10            11         12          13          14         15   16   17   18       19
-    QueryResult* result = WorldDatabase.PQuery("SELECT `id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id` FROM %s ORDER BY `id`, `delay`, `priority`", tablename);
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT `id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id` FROM %s ORDER BY `id`, `delay`, `priority`", tablename);
 
     uint32 count = 0;
 
@@ -1237,8 +1237,6 @@ void ScriptMgr::LoadScripts(ScriptMapMap& scripts, char const* tablename)
     }
     while (result->NextRow());
 
-    delete result;
-
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u script definitions", count);
 }
@@ -1581,8 +1579,7 @@ void ScriptMgr::LoadCreatureEventAIScripts()
 {
     LoadScripts(sCreatureAIScripts, "creature_ai_scripts");
 
-    
-    QueryResult* result;
+    std::unique_ptr<QueryResult> result;
     Field* fields;
 
     // Check for scripts with delay, which is not supported for this table.
@@ -1598,7 +1595,6 @@ void ScriptMgr::LoadCreatureEventAIScripts()
                 uint32 scriptId = fields[0].GetUInt32();
                 sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Table `creature_ai_scripts` has script (Id: %u) with delay!=0 but this is not supported for creature AI events.", scriptId);
             } while (result->NextRow());
-            delete result;
         }
     }
 
@@ -1617,7 +1613,6 @@ void ScriptMgr::LoadCreatureEventAIScripts()
                 if (scriptId)
                     actionIds.insert(scriptId);
             } while (result->NextRow());
-            delete result;
         }
     }
 
@@ -1665,7 +1660,7 @@ void ScriptMgr::CheckScriptTexts(ScriptMapMap const& scripts)
 void ScriptMgr::LoadAreaTriggerScripts()
 {
     m_AreaTriggerScripts.clear();                           // need for reload case
-    QueryResult* result = WorldDatabase.Query("SELECT `entry`, `script_name` FROM `scripted_areatrigger`");
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT `entry`, `script_name` FROM `scripted_areatrigger`");
 
     uint32 count = 0;
 
@@ -1702,8 +1697,6 @@ void ScriptMgr::LoadAreaTriggerScripts()
     }
     while (result->NextRow());
 
-    delete result;
-
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u areatrigger scripts", count);
 }
@@ -1711,7 +1704,7 @@ void ScriptMgr::LoadAreaTriggerScripts()
 void ScriptMgr::LoadEventIdScripts()
 {
     m_EventIdScripts.clear();                           // need for reload case
-    QueryResult* result = WorldDatabase.Query("SELECT `id`, `script_name` FROM `scripted_event_id`");
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT `id`, `script_name` FROM `scripted_event_id`");
 
     uint32 count = 0;
 
@@ -1750,8 +1743,6 @@ void ScriptMgr::LoadEventIdScripts()
     }
     while (result->NextRow());
 
-    delete result;
-
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u scripted event id", count);
 }
@@ -1759,7 +1750,7 @@ void ScriptMgr::LoadEventIdScripts()
 void ScriptMgr::LoadScriptNames()
 {
     m_scriptNames.push_back("");
-    QueryResult* result = WorldDatabase.Query(
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query(
                               "SELECT DISTINCT(`script_name`) FROM `creature_template` WHERE `script_name` <> '' "
                               "UNION "
                               "SELECT DISTINCT(`script_name`) FROM `gameobject_template` WHERE `script_name` <> '' "
@@ -1789,7 +1780,6 @@ void ScriptMgr::LoadScriptNames()
         ++count;
     }
     while (result->NextRow());
-    delete result;
 
     std::sort(m_scriptNames.begin(), m_scriptNames.end());
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
@@ -2144,7 +2134,7 @@ void ScriptMgr::LoadScriptTexts()
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Loading Script Texts...");
     sObjectMgr.LoadMangosStrings(WorldDatabase, "script_texts", TEXT_SOURCE_TEXT_START, TEXT_SOURCE_TEXT_END, true);
 
-    QueryResult* result = WorldDatabase.PQuery("SELECT `entry`, `sound`, `type`, `language`, `emote` FROM `script_texts` WHERE `entry` BETWEEN %i AND %i", TEXT_SOURCE_TEXT_END, TEXT_SOURCE_TEXT_START);
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT `entry`, `sound`, `type`, `language`, `emote` FROM `script_texts` WHERE `entry` BETWEEN %i AND %i", TEXT_SOURCE_TEXT_END, TEXT_SOURCE_TEXT_START);
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Loading Script Texts additional data...");
 
@@ -2187,8 +2177,6 @@ void ScriptMgr::LoadScriptTexts()
             ++uiCount;
         } while (result->NextRow());
 
-        delete result;
-
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u additional Script Texts data.", uiCount);
     }
@@ -2206,7 +2194,7 @@ void ScriptMgr::LoadScriptTextsCustom()
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Loading Custom Texts...");
     sObjectMgr.LoadMangosStrings(WorldDatabase, "custom_texts", TEXT_SOURCE_CUSTOM_START, TEXT_SOURCE_CUSTOM_END, true);
 
-    QueryResult* result = WorldDatabase.PQuery("SELECT `entry`, `sound`, `type`, `language`, `emote` FROM `custom_texts` WHERE `entry` BETWEEN %i AND %i", TEXT_SOURCE_CUSTOM_END, TEXT_SOURCE_CUSTOM_START);
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT `entry`, `sound`, `type`, `language`, `emote` FROM `custom_texts` WHERE `entry` BETWEEN %i AND %i", TEXT_SOURCE_CUSTOM_END, TEXT_SOURCE_CUSTOM_START);
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Loading Custom Texts additional data...");
 
@@ -2249,8 +2237,6 @@ void ScriptMgr::LoadScriptTextsCustom()
             ++uiCount;
         } while (result->NextRow());
 
-        delete result;
-
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u additional Custom Texts data.", uiCount);
     }
@@ -2271,11 +2257,10 @@ void ScriptMgr::LoadScriptWaypoints()
     uint64 uiCreatureCount = 0;
 
     // Load Waypoints
-    QueryResult* result = WorldDatabase.PQuery("SELECT COUNT(`entry`) FROM `script_waypoint` GROUP BY `entry`");
+    std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT COUNT(`entry`) FROM `script_waypoint` GROUP BY `entry`");
     if (result)
     {
         uiCreatureCount = result->GetRowCount();
-        delete result;
     }
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Loading Script Waypoints for %u creature(s)...", uiCreatureCount);
@@ -2317,8 +2302,6 @@ void ScriptMgr::LoadScriptWaypoints()
             ++uiNodeCount;
         } while (result->NextRow());
 
-        delete result;
-
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u Script Waypoint nodes.", uiNodeCount);
     }
@@ -2338,7 +2321,7 @@ void ScriptMgr::LoadEscortData()
 
     uint64 EscortDataCount = 0;
 
-    QueryResult* pResult = WorldDatabase.PQuery("SELECT `creature_id`, `quest`, `escort_faction` FROM `script_escort_data`");
+    std::unique_ptr<QueryResult> pResult = WorldDatabase.PQuery("SELECT `creature_id`, `quest`, `escort_faction` FROM `script_escort_data`");
 
     if (pResult)
     {
@@ -2381,8 +2364,6 @@ void ScriptMgr::LoadEscortData()
             m_mEscortDataMap[pTemp.uiCreatureEntry] = pTemp;
             ++EscortDataCount;
         } while (pResult->NextRow());
-
-        delete pResult;
 
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "");
         sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Loaded %u Escort Creature Data", EscortDataCount);
@@ -2438,7 +2419,7 @@ void ScriptMgr::CollectPossibleGenericIds(std::set<uint32>& genericIds)
         }
 
         // From SCRIPT_COMMAND_TEMP_SUMMON_CREATURE.
-        result.reset(WorldDatabase.PQuery("SELECT `dataint2` FROM `%s` WHERE `command`=10 && `dataint2`!=0", script_table));
+        result = WorldDatabase.PQuery("SELECT `dataint2` FROM `%s` WHERE `command`=10 && `dataint2`!=0", script_table);
 
         if (result)
         {
@@ -2452,7 +2433,7 @@ void ScriptMgr::CollectPossibleGenericIds(std::set<uint32>& genericIds)
         }
 
         // From SCRIPT_COMMAND_START_SCRIPT_FOR_ALL and SCRIPT_COMMAND_START_SCRIPT_ON_ZONE.
-        result.reset(WorldDatabase.PQuery("SELECT `datalong` FROM `%s` WHERE `command` IN (68, 92) && `datalong`!=0", script_table));
+        result = WorldDatabase.PQuery("SELECT `datalong` FROM `%s` WHERE `command` IN (68, 92) && `datalong`!=0", script_table);
 
         if (result)
         {
@@ -2466,7 +2447,7 @@ void ScriptMgr::CollectPossibleGenericIds(std::set<uint32>& genericIds)
         }
 
         // From SCRIPT_COMMAND_START_MAP_EVENT, SCRIPT_COMMAND_ADD_MAP_EVENT_TARGET and SCRIPT_COMMAND_EDIT_MAP_EVENT.
-        result.reset(WorldDatabase.PQuery("SELECT `dataint2`, `dataint4` FROM `%s` WHERE `command` IN (61, 63, 69)", script_table));
+        result = WorldDatabase.PQuery("SELECT `dataint2`, `dataint4` FROM `%s` WHERE `command` IN (61, 63, 69)", script_table);
 
         if (result)
         {
@@ -2499,7 +2480,7 @@ void ScriptMgr::CollectPossibleEventIds(std::set<uint32>& eventIds)
                 eventIds.insert(eventId);
         } while (result->NextRow());
     }
-    result.reset(WorldDatabase.Query("SELECT `data6` FROM `gameobject_template` WHERE `type`=3 && `data6` > 0"));
+    result = WorldDatabase.Query("SELECT `data6` FROM `gameobject_template` WHERE `type`=3 && `data6` > 0");
     if (result)
     {
         do
@@ -2510,7 +2491,7 @@ void ScriptMgr::CollectPossibleEventIds(std::set<uint32>& eventIds)
                 eventIds.insert(eventId);
         } while (result->NextRow());
     }
-    result.reset(WorldDatabase.Query("SELECT `data2` FROM `gameobject_template` WHERE `type`=13 && `data2` > 0"));
+    result = WorldDatabase.Query("SELECT `data2` FROM `gameobject_template` WHERE `type`=13 && `data2` > 0");
     if (result)
     {
         do
@@ -2521,7 +2502,7 @@ void ScriptMgr::CollectPossibleEventIds(std::set<uint32>& eventIds)
                 eventIds.insert(eventId);
         } while (result->NextRow());
     }
-    result.reset(WorldDatabase.Query("SELECT `data4`, `data5`, `data6`, `data7`, `data8`, `data9`, `data10`, `data11` FROM `gameobject_template` WHERE `type`=29"));
+    result = WorldDatabase.Query("SELECT `data4`, `data5`, `data6`, `data7`, `data8`, `data9`, `data10`, `data11` FROM `gameobject_template` WHERE `type`=29");
     if (result)
     {
         do
@@ -2557,7 +2538,7 @@ void ScriptMgr::CollectPossibleEventIds(std::set<uint32>& eventIds)
     // Load all possible script entries from spells.
     for (uint32 i = 1; i < 4; ++i)
     {
-        result.reset(WorldDatabase.PQuery("SELECT `effectMiscValue%u` FROM `spell_template` WHERE `effect%u`=61", i, i));
+        result = WorldDatabase.PQuery("SELECT `effectMiscValue%u` FROM `spell_template` WHERE `effect%u`=61", i, i);
 
         if (result)
         {

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -81,7 +81,7 @@ void ScriptMgr::LoadScripts(ScriptMapMap& scripts, char const* tablename)
 
     scripts.clear();                                        // need for reload support
 
-    //                                                  0     1        2          3           4            5            6            7                8                9              10            11         12          13          14         15   16   17   18       19
+    //                                                                  0     1        2          3           4            5            6            7                8                9              10            11         12          13          14         15   16   17   18       19
     std::unique_ptr<QueryResult> result = WorldDatabase.PQuery("SELECT `id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id` FROM %s ORDER BY `id`, `delay`, `priority`", tablename);
 
     uint32 count = 0;

--- a/src/game/SocialMgr.cpp
+++ b/src/game/SocialMgr.cpp
@@ -304,7 +304,7 @@ void SocialMgr::BroadcastToFriendListers(MasterPlayer* player, WorldPacket* pack
     }
 }
 
-PlayerSocial* SocialMgr::LoadFromDB(QueryResult* result, ObjectGuid guid)
+PlayerSocial* SocialMgr::LoadFromDB(std::unique_ptr<QueryResult> result, ObjectGuid guid)
 {
     std::unique_lock<std::shared_timed_mutex> guard(_socialMapLock);
     PlayerSocial *social = &m_socialMap[guid.GetCounter()];

--- a/src/game/SocialMgr.h
+++ b/src/game/SocialMgr.h
@@ -154,7 +154,7 @@ class SocialMgr
         void SendFriendStatus(MasterPlayer* player, FriendsResult result, ObjectGuid friend_guid, bool broadcast);
         void BroadcastToFriendListers(MasterPlayer* player, WorldPacket* packet);
         // Loading
-        PlayerSocial* LoadFromDB(QueryResult* result, ObjectGuid guid);
+        PlayerSocial* LoadFromDB(std::unique_ptr<QueryResult> result, ObjectGuid guid);
     private:
         SocialMap m_socialMap;
 

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -3996,7 +3996,7 @@ void SpellMgr::LoadSpells()
 
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_12_1
     // Load localized texts (currently we only have 1.12 locales).
-    //                                        0        1            2            3            4            5            6            7                   8                   9                   10                  11                  12                  13                  14                  15                  16                  17                  18                  19                      20                      21                      22                      23                      24
+    //                                    0        1            2            3            4            5            6            7                   8                   9                   10                  11                  12                  13                  14                  15                  16                  17                  18                  19                      20                      21                      22                      23                      24
     result = WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6`, `nameSubtext_loc1`, `nameSubtext_loc2`, `nameSubtext_loc3`, `nameSubtext_loc4`, `nameSubtext_loc5`, `nameSubtext_loc6`, `description_loc1`, `description_loc2`, `description_loc3`, `description_loc4`, `description_loc5`, `description_loc6`, `auraDescription_loc1`, `auraDescription_loc2`, `auraDescription_loc3`, `auraDescription_loc4`, `auraDescription_loc5`, `auraDescription_loc6` FROM `locales_spell`");
     if (result)
     {

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -2050,7 +2050,7 @@ void SpellMgr::LoadSpellScriptTarget()
 
     uint32 count = 0;
 
-    result.reset(WorldDatabase.PQuery("SELECT `entry`, `type`, `targetEntry`, `conditionId`, `inverseEffectMask` FROM `spell_script_target` WHERE %u BETWEEN `build_min` AND `build_max`", SUPPORTED_CLIENT_BUILD));
+    result = WorldDatabase.PQuery("SELECT `entry`, `type`, `targetEntry`, `conditionId`, `inverseEffectMask` FROM `spell_script_target` WHERE %u BETWEEN `build_min` AND `build_max`", SUPPORTED_CLIENT_BUILD);
 
     if (!result)
     {
@@ -3711,7 +3711,7 @@ void SpellMgr::LoadSpells()
     uint32 maxEntry = fields[0].GetUInt32() + 1;
 
     // Actually loading the spells.
-    result.reset(WorldDatabase.PQuery("SELECT * FROM `spell_template` t1 WHERE `build`=(SELECT max(`build`) FROM `spell_template` t2 WHERE t1.`entry`=t2.`entry` && `build` <= %u)", SUPPORTED_CLIENT_BUILD));
+    result = WorldDatabase.PQuery("SELECT * FROM `spell_template` t1 WHERE `build`=(SELECT max(`build`) FROM `spell_template` t2 WHERE t1.`entry`=t2.`entry` && `build` <= %u)", SUPPORTED_CLIENT_BUILD);
 
     if (!result)
     {
@@ -3997,7 +3997,7 @@ void SpellMgr::LoadSpells()
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_12_1
     // Load localized texts (currently we only have 1.12 locales).
     //                                        0        1            2            3            4            5            6            7                   8                   9                   10                  11                  12                  13                  14                  15                  16                  17                  18                  19                      20                      21                      22                      23                      24
-    result.reset(WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6`, `nameSubtext_loc1`, `nameSubtext_loc2`, `nameSubtext_loc3`, `nameSubtext_loc4`, `nameSubtext_loc5`, `nameSubtext_loc6`, `description_loc1`, `description_loc2`, `description_loc3`, `description_loc4`, `description_loc5`, `description_loc6`, `auraDescription_loc1`, `auraDescription_loc2`, `auraDescription_loc3`, `auraDescription_loc4`, `auraDescription_loc5`, `auraDescription_loc6` FROM `locales_spell`"));
+    result = WorldDatabase.Query("SELECT `entry`, `name_loc1`, `name_loc2`, `name_loc3`, `name_loc4`, `name_loc5`, `name_loc6`, `nameSubtext_loc1`, `nameSubtext_loc2`, `nameSubtext_loc3`, `nameSubtext_loc4`, `nameSubtext_loc5`, `nameSubtext_loc6`, `description_loc1`, `description_loc2`, `description_loc3`, `description_loc4`, `description_loc5`, `description_loc6`, `auraDescription_loc1`, `auraDescription_loc2`, `auraDescription_loc3`, `auraDescription_loc4`, `auraDescription_loc5`, `auraDescription_loc6` FROM `locales_spell`");
     if (result)
     {
         do

--- a/src/game/Spells/SpellModMgr.cpp
+++ b/src/game/Spells/SpellModMgr.cpp
@@ -188,13 +188,13 @@ void SpellModMgr::LoadSpellMods()
 
     // 2 : Table spell_effect_mod
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Loading spell effect mods ...");
-    result.reset(WorldDatabase.Query(
+    result = WorldDatabase.Query(
                  "SELECT Id, EffectIndex, Effect, EffectApplyAuraName, EffectMechanic, EffectImplicitTargetA, EffectImplicitTargetB, "
                  "EffectRadiusIndex, EffectItemType, EffectMiscValue, EffectTriggerSpell, "
                  "EffectDieSides, EffectBaseDice, EffectBasePoints, EffectAmplitude, EffectChainTarget, " // Int
                  "EffectDicePerLevel, EffectRealPointsPerLevel, EffectPointsPerComboPoint, EffectMultipleValue " // Float
                  "FROM spell_effect_mod"
-                ));
+                );
     total_count = 0;
 
     if (!result)

--- a/src/game/Transports/TransportMgr.cpp
+++ b/src/game/Transports/TransportMgr.cpp
@@ -390,7 +390,7 @@ void TransportMgr::SpawnContinentTransports()
 
     uint32 oldMSTime = WorldTimer::getMSTime();
 
-    QueryResult* result = WorldDatabase.Query("SELECT `entry`, `period` FROM `transports`");
+    std::unique_ptr<QueryResult> result = WorldDatabase.Query("SELECT `entry`, `period` FROM `transports`");
 
     uint32 count = 0;
     if (result)
@@ -416,7 +416,6 @@ void TransportMgr::SpawnContinentTransports()
             }
 
         } while (result->NextRow());
-        delete result;
     }
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, ">> Spawned %u continent transports in %u ms", count, WorldTimer::getMSTimeDiffToNow(oldMSTime));

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2503,9 +2503,9 @@ private:
 class BanAccountHandler
 {
 public:
-    void HandleAccountSelectResult(QueryResult*, SqlQueryHolder* queryHolder)
+    void HandleAccountSelectResult(std::unique_ptr<QueryResult>, SqlQueryHolder* queryHolder)
     {
-        BanQueryHolder* holder = static_cast<BanQueryHolder*>(queryHolder);
+        BanQueryHolder* holder = dynamic_cast<BanQueryHolder*>(queryHolder);
         if (!holder)
             return;
 
@@ -2513,7 +2513,7 @@ public:
 
         WorldSession* session = sWorld.FindSession(holder->GetAuthorAccountId());
 
-        QueryResult* result = holder->GetResult(0);
+        std::unique_ptr<QueryResult> result = holder->TakeResult(0);
         if (!result)
         {
             if (session)
@@ -2874,13 +2874,12 @@ void World::UpdateRealmCharCount(uint32 accountId)
                                   "SELECT COUNT(`guid`) FROM `characters` WHERE `account` = '%u'", accountId);
 }
 
-void World::_UpdateRealmCharCount(QueryResult* resultCharCount, uint32 accountId)
+void World::_UpdateRealmCharCount(std::unique_ptr<QueryResult> resultCharCount, uint32 accountId)
 {
     if (resultCharCount)
     {
         Field* fields = resultCharCount->Fetch();
         uint32 charCount = fields[0].GetUInt32();
-        delete resultCharCount;
 
         LoginDatabase.PExecute("REPLACE INTO `realmcharacters` (`numchars`, `acctid`, `realmid`) VALUES (%u, %u, %u)", charCount, accountId, realmID);
     }
@@ -3094,7 +3093,7 @@ void World::SetSessionDisconnected(WorldSession* sess)
 
 void World::AddAsyncTask(std::function<void()> task) {
     std::lock_guard<std::mutex> lock(m_asyncTaskQueueMutex);
-    _asyncTasks.push_back(task);
+    _asyncTasks.push_back(std::move(task));
 }
 
 void World::LogMoneyTrade(ObjectGuid sender, ObjectGuid receiver, uint32 amount, const char* type, uint32 dataInt)

--- a/src/game/World.h
+++ b/src/game/World.h
@@ -951,7 +951,7 @@ class World
     protected:
         void _UpdateGameTime();
         // callback for UpdateRealmCharacters
-        void _UpdateRealmCharCount(QueryResult* resultCharCount, uint32 accountId);
+        void _UpdateRealmCharCount(std::unique_ptr<QueryResult> resultCharCount, uint32 accountId);
 
     private:
         void setConfig(eConfigUInt32Values index, char const* fieldname, uint32 defvalue);

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -945,16 +945,14 @@ void WorldSession::SendAuthWaitQue(uint32 position)
 
 void WorldSession::LoadGlobalAccountData()
 {
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `type`, `time`, `data` FROM `account_data` WHERE `account`=%u", GetAccountId());
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT `type`, `time`, `data` FROM `account_data` WHERE `account`=%u", GetAccountId());
     LoadAccountData(
-        result,
+        std::move(result),
         NewAccountData::GLOBAL_CACHE_MASK
     );
-    if (result)
-        delete result;
 }
 
-void WorldSession::LoadAccountData(QueryResult* result, uint32 mask)
+void WorldSession::LoadAccountData(std::unique_ptr<QueryResult> result, uint32 mask)
 {
     for (uint32 i = 0; i < NewAccountData::NUM_ACCOUNT_DATA_TYPES; ++i)
         if (mask & (1 << i))
@@ -1065,7 +1063,7 @@ void WorldSession::LoadTutorialsData()
     for (uint32 & tutorial : m_tutorials)
         tutorial = 0;
 
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `tut0`, `tut1`, `tut2`, `tut3`, `tut4`, `tut5`, `tut6`, `tut7` FROM `character_tutorial` WHERE `account` = '%u'", GetAccountId());
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT `tut0`, `tut1`, `tut2`, `tut3`, `tut4`, `tut5`, `tut6`, `tut7` FROM `character_tutorial` WHERE `account` = '%u'", GetAccountId());
 
     if (!result)
     {
@@ -1081,8 +1079,6 @@ void WorldSession::LoadTutorialsData()
             m_tutorials[iI] = fields[iI].GetUInt32();
     }
     while (result->NextRow());
-
-    delete result;
 
     m_tutorialState = TUTORIALDATA_UNCHANGED;
 }

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -462,7 +462,7 @@ class WorldSession
         void SetAccountData(NewAccountData::AccountDataType type, const std::string& data);
         void SendAccountDataTimes();
         void LoadGlobalAccountData();
-        void LoadAccountData(QueryResult* result, uint32 mask);
+        void LoadAccountData(std::unique_ptr<QueryResult> result, uint32 mask);
 
         void LoadTutorialsData();
         void SendTutorialsData();
@@ -529,8 +529,8 @@ class WorldSession
         void HandleCharDeleteOpcode(WorldPacket& recvPacket);
         void HandleCharCreateOpcode(WorldPacket& recvPacket);
         void HandlePlayerLoginOpcode(WorldPacket& recvPacket);
-        void HandleCharEnum(QueryResult* result);
-        void HandlePlayerLogin(LoginQueryHolder * holder);
+        void HandleCharEnum(std::unique_ptr<QueryResult> result);
+        void HandlePlayerLogin(LoginQueryHolder* holder);
         void HandlePlayedTime(WorldPacket& recvPacket);
 
         // Movement
@@ -828,7 +828,7 @@ class WorldSession
         void HandleRequestPetInfoOpcode(WorldPacket& recv_data);
 
         void HandleCharRenameOpcode(WorldPacket& recv_data);
-        static void HandleChangePlayerNameOpcodeCallBack(QueryResult* result, uint32 accountId, std::string newname);
+        static void HandleChangePlayerNameOpcodeCallBack(std::unique_ptr<QueryResult> result, uint32 accountId, std::string newname);
 
         //BattleGround
         void HandleBattlefieldJoinOpcode(WorldPacket& recv_data);

--- a/src/realmd/RealmList.cpp
+++ b/src/realmd/RealmList.cpp
@@ -158,7 +158,7 @@ void RealmList::UpdateRealms(bool init)
 {
     sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "Updating realm list...");
 
-    QueryResult *result = LoginDatabase.Query(
+    std::unique_ptr<QueryResult> result = LoginDatabase.Query(
         //       0     1       2          3               4                  5       6
         "SELECT `id`, `name`, `address`, `localAddress`, `localSubnetMask`, `port`, `icon`, "
         // 7            8           9                       10            11
@@ -199,7 +199,6 @@ void RealmList::UpdateRealms(bool init)
             if(init)
                 sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Added realm \"%s\"", fields[1].GetString());
         } while( result->NextRow() );
-        delete result;
     }
 }
 
@@ -207,7 +206,7 @@ void RealmList::LoadAllowedClients()
 {
     sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "Loading allowed clients...");
 
-    QueryResult *result = LoginDatabase.Query(
+    std::unique_ptr<QueryResult> result = LoginDatabase.Query(
         //       0                 1               2                 3                 4        5     6           7
         "SELECT `major_version`, `minor_version`, `bugfix_version`, `hotfix_version`, `build`, `os`, `platform`, `integrity_hash` "
         "FROM `allowed_clients`");
@@ -244,6 +243,5 @@ void RealmList::LoadAllowedClients()
             ExpectedRealmdClientBuilds.push_back(buildInfo);
 
         } while (result->NextRow());
-        delete result;
     }
 }

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -46,6 +46,7 @@ set (shared_SRCS
     Config/Config.h
     Config/ConfigEnv.h
     Database/Database.h
+    Database/DatabaseCallback.h
     Database/DatabaseEnv.h
     Database/DatabaseImpl.h
     Database/DatabaseMysql.h

--- a/src/shared/Database/DatabaseCallback.h
+++ b/src/shared/Database/DatabaseCallback.h
@@ -19,8 +19,10 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef MANGOS_CALLBACK_H
-#define MANGOS_CALLBACK_H
+#ifndef MANGOS_DATABASECALLBACK_H
+#define MANGOS_DATABASECALLBACK_H
+
+#include "QueryResult.h"
 
 //defines to simplify multi param templates code and readablity
 #define TYPENAMES_1 typename T1
@@ -63,19 +65,13 @@ namespace MaNGOS
             ParamType2 m_param2;
             ParamType3 m_param3;
             ParamType4 m_param4;
-            void _Execute() { (m_object->*m_method)(m_param1, m_param2, m_param3, m_param4); }
+            void _Execute() { (m_object->*m_method)(std::move(m_param1), m_param2, m_param3, m_param4); }
 
         public:
 
             _Callback(Class *object, Method method, ParamType1 param1, ParamType2 param2, ParamType3 param3, ParamType4 param4)
                 : m_object(object), m_method(method),
-                m_param1(param1), m_param2(param2), m_param3(param3), m_param4(param4)
-            {
-            }
-
-            _Callback(_Callback<Class, ParamType1, ParamType2, ParamType3, ParamType4> const& cb)
-                : m_object(cb.m_object), m_method(cb.m_method),
-                m_param1(cb.m_param1), m_param2(cb.m_param2), m_param3(cb.m_param3), m_param4(cb.m_param4)
+                m_param1(std::move(param1)), m_param2(param2), m_param3(param3), m_param4(param4)
             {
             }
     };
@@ -91,18 +87,12 @@ namespace MaNGOS
             ParamType1 m_param1;
             ParamType2 m_param2;
             ParamType3 m_param3;
-            void _Execute() { (m_object->*m_method)(m_param1, m_param2, m_param3); }
+            void _Execute() { (m_object->*m_method)(std::move(m_param1), m_param2, m_param3); }
 
         public:
             _Callback(Class *object, Method method, ParamType1 param1, ParamType2 param2, ParamType3 param3)
                 : m_object(object), m_method(method),
-                m_param1(param1), m_param2(param2), m_param3(param3)
-            {
-            }
-
-            _Callback(_Callback<Class, ParamType1, ParamType2, ParamType3> const& cb)
-                : m_object(cb.m_object), m_method(cb.m_method),
-                m_param1(cb.m_param1), m_param2(cb.m_param2), m_param3(cb.m_param3)
+                m_param1(std::move(param1)), m_param2(param2), m_param3(param3)
             {
             }
     };
@@ -117,19 +107,13 @@ namespace MaNGOS
             Method m_method;
             ParamType1 m_param1;
             ParamType2 m_param2;
-            void _Execute() { (m_object->*m_method)(m_param1, m_param2); }
+            void _Execute() { (m_object->*m_method)(std::move(m_param1), m_param2); }
 
         public:
 
             _Callback(Class *object, Method method, ParamType1 param1, ParamType2 param2)
                 : m_object(object), m_method(method),
-                m_param1(param1), m_param2(param2)
-            {
-            }
-
-            _Callback(_Callback<Class, ParamType1, ParamType2> const& cb)
-                : m_object(cb.m_object), m_method(cb.m_method),
-                m_param1(cb.m_param1), m_param2(cb.m_param2)
+                m_param1(std::move(param1)), m_param2(param2)
             {
             }
     };
@@ -143,19 +127,13 @@ namespace MaNGOS
             Class *m_object;
             Method m_method;
             ParamType1 m_param1;
-            void _Execute() { (m_object->*m_method)(m_param1); }
+            void _Execute() { (m_object->*m_method)(std::move(m_param1)); }
 
         public:
 
             _Callback(Class *object, Method method, ParamType1 param1)
                 : m_object(object), m_method(method),
-                m_param1(param1)
-            {
-            }
-
-            _Callback(_Callback<Class, ParamType1> const& cb)
-                : m_object(cb.m_object), m_method(cb.m_method),
-                m_param1(cb.m_param1)
+                m_param1(std::move(param1))
             {
             }
     };
@@ -194,19 +172,13 @@ namespace MaNGOS
             ParamType2 m_param2;
             ParamType3 m_param3;
             ParamType4 m_param4;
-            void _Execute() { (*m_method)(m_param1, m_param2, m_param3, m_param4); }
+            void _Execute() { (*m_method)(std::move(m_param1), m_param2, m_param3, m_param4); }
 
         public:
 
             _SCallback(Method method, ParamType1 param1, ParamType2 param2, ParamType3 param3, ParamType4 param4)
                 : m_method(method),
-                m_param1(param1), m_param2(param2), m_param3(param3), m_param4(param4)
-            {
-            }
-
-            _SCallback(_SCallback<ParamType1, ParamType2, ParamType3, ParamType4> const& cb)
-                : m_method(cb.m_method),
-                m_param1(cb.m_param1), m_param2(cb.m_param2), m_param3(cb.m_param3), m_param4(cb.m_param4)
+                m_param1(std::move(param1)), m_param2(param2), m_param3(param3), m_param4(param4)
             {
             }
     };
@@ -221,17 +193,12 @@ namespace MaNGOS
             ParamType1 m_param1;
             ParamType2 m_param2;
             ParamType3 m_param3;
-            void _Execute() { (*m_method)(m_param1, m_param2, m_param3); }
+            void _Execute() { (*m_method)(std::move(m_param1), m_param2, m_param3); }
 
         public:
             _SCallback(Method method, ParamType1 param1, ParamType2 param2, ParamType3 param3)
                 : m_method(method),
-                m_param1(param1), m_param2(param2), m_param3(param3)
-            {
-            }
-            _SCallback(_SCallback<ParamType1, ParamType2, ParamType3> const& cb)
-                : m_method(cb.m_method),
-                m_param1(cb.m_param1), m_param2(cb.m_param2), m_param3(cb.m_param3)
+                m_param1(std::move(param1)), m_param2(param2), m_param3(param3)
             {
             }
     };
@@ -245,18 +212,12 @@ namespace MaNGOS
             Method m_method;
             ParamType1 m_param1;
             ParamType2 m_param2;
-            void _Execute() { (*m_method)(m_param1, m_param2); }
+            void _Execute() { (*m_method)(std::move(m_param1), m_param2); }
 
         public:
             _SCallback(Method method, ParamType1 param1, ParamType2 param2)
                 : m_method(method),
-                m_param1(param1), m_param2(param2)
-            {
-            }
-
-            _SCallback(_SCallback<ParamType1, ParamType2> const& cb)
-                : m_method(cb.m_method),
-                m_param1(cb.m_param1), m_param2(cb.m_param2)
+                m_param1(std::move(param1)), m_param2(param2)
             {
             }
     };
@@ -269,18 +230,12 @@ namespace MaNGOS
             typedef void (*Method)(ParamType1);
             Method m_method;
             ParamType1 m_param1;
-            void _Execute() { (*m_method)(m_param1); }
+            void _Execute() { (*m_method)(std::move(m_param1)); }
 
         public:
             _SCallback(Method method, ParamType1 param1)
                 : m_method(method),
-                m_param1(param1)
-            {
-            }
-
-            _SCallback(_SCallback<ParamType1> const& cb)
-                : m_method(cb.m_method),
-                m_param1(cb.m_param1)
+                m_param1(std::move(param1))
             {
             }
     };
@@ -333,7 +288,7 @@ namespace MaNGOS
     };
 
     template<class Class, typename ParamType1 = void, typename ParamType2 = void, typename ParamType3 = void, typename ParamType4 = void>
-    class Callback : public _ICallback<_Callback<Class, ParamType1, ParamType2, ParamType3, ParamType4> >
+    class Callback : public _ICallback<_Callback<Class, ParamType1, ParamType2, ParamType3, ParamType4>>
     {
         private:
 
@@ -347,7 +302,7 @@ namespace MaNGOS
     };
 
     template<class Class, typename ParamType1, typename ParamType2, typename ParamType3>
-    class Callback<Class, ParamType1, ParamType2, ParamType3> : public _ICallback<_Callback<Class, ParamType1, ParamType2, ParamType3> >
+    class Callback<Class, ParamType1, ParamType2, ParamType3> : public _ICallback<_Callback<Class, ParamType1, ParamType2, ParamType3>>
     {
         private:
 
@@ -361,7 +316,7 @@ namespace MaNGOS
     };
 
     template<class Class, typename ParamType1, typename ParamType2>
-    class Callback<Class, ParamType1, ParamType2> : public _ICallback<_Callback<Class, ParamType1, ParamType2> >
+    class Callback<Class, ParamType1, ParamType2> : public _ICallback<_Callback<Class, ParamType1, ParamType2>>
     {
         private:
 
@@ -375,7 +330,7 @@ namespace MaNGOS
     };
 
     template<class Class, typename ParamType1>
-    class Callback<Class, ParamType1> : public _ICallback<_Callback<Class, ParamType1> >
+    class Callback<Class, ParamType1> : public _ICallback<_Callback<Class, ParamType1>>
     {
         private:
 
@@ -390,7 +345,7 @@ namespace MaNGOS
     };
 
     template<class Class>
-    class Callback<Class> : public _ICallback<_Callback<Class> >
+    class Callback<Class> : public _ICallback<_Callback<Class>>
     {
         private:
 
@@ -417,8 +372,8 @@ namespace MaNGOS
             IQueryCallback() : threadSafe(true) {}
             virtual void Execute() = 0;
             virtual ~IQueryCallback() {}
-            virtual void SetResult(QueryResult* result) = 0;
-            virtual QueryResult* GetResult() = 0;
+            virtual void SetResult(std::unique_ptr<QueryResult> result) = 0;
+            virtual std::unique_ptr<QueryResult>& GetResult() = 0;
             bool IsThreadSafe() const { return threadSafe; }
             bool threadSafe;
     };
@@ -428,70 +383,70 @@ namespace MaNGOS
     {
         public:
 
-            _IQueryCallback(CB const& cb) : CB(cb)
+            _IQueryCallback(CB cb) : CB(std::move(cb))
             {
             }
 
             void Execute() { CB::_Execute(); }
-            void SetResult(QueryResult* result) { CB::m_param1 = result; }
-            QueryResult* GetResult() { return CB::m_param1; }
+            void SetResult(std::unique_ptr<QueryResult> result) { CB::m_param1 = std::move(result); }
+            std::unique_ptr<QueryResult>& GetResult() { return CB::m_param1; }
     };
 
     template<class Class, typename ParamType1 = void, typename ParamType2 = void, typename ParamType3 = void>
-    class QueryCallback : public _IQueryCallback<_Callback<Class, QueryResult*, ParamType1, ParamType2, ParamType3> >
+    class QueryCallback : public _IQueryCallback<_Callback<Class, std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3>>
     {
         private:
 
-            typedef _Callback<Class, QueryResult*, ParamType1, ParamType2, ParamType3> QC3;
+            typedef _Callback<Class, std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3> QC3;
 
         public:
 
-            QueryCallback(Class *object, typename QC3::Method method, QueryResult* result, ParamType1 param1, ParamType2 param2, ParamType3 param3)
-                : _IQueryCallback<QC3>(QC3(object, method, result, param1, param2, param3))
+            QueryCallback(Class *object, typename QC3::Method method, std::unique_ptr<QueryResult> result, ParamType1 param1, ParamType2 param2, ParamType3 param3)
+                : _IQueryCallback<QC3>(QC3(object, method, std::move(result), param1, param2, param3))
             {
             }
     };
 
     template<class Class, typename ParamType1, typename ParamType2>
-    class QueryCallback<Class, ParamType1, ParamType2> : public _IQueryCallback<_Callback<Class, QueryResult*, ParamType1, ParamType2> >
+    class QueryCallback<Class, ParamType1, ParamType2> : public _IQueryCallback<_Callback<Class, std::unique_ptr<QueryResult>, ParamType1, ParamType2>>
     {
         private:
 
-            typedef _Callback<Class, QueryResult*, ParamType1, ParamType2> QC2;
+            typedef _Callback<Class, std::unique_ptr<QueryResult>, ParamType1, ParamType2> QC2;
 
         public:
 
-            QueryCallback(Class *object, typename QC2::Method method, QueryResult* result, ParamType1 param1, ParamType2 param2)
-                : _IQueryCallback<QC2>(QC2(object, method, result, param1, param2))
+            QueryCallback(Class *object, typename QC2::Method method, std::unique_ptr<QueryResult> result, ParamType1 param1, ParamType2 param2)
+                : _IQueryCallback<QC2>(QC2(object, method, std::move(result), param1, param2))
             {
             }
     };
 
     template<class Class, typename ParamType1>
-    class QueryCallback<Class, ParamType1> : public _IQueryCallback<_Callback<Class, QueryResult*, ParamType1> >
+    class QueryCallback<Class, ParamType1> : public _IQueryCallback<_Callback<Class, std::unique_ptr<QueryResult>, ParamType1>>
     {
         private:
 
-            typedef _Callback<Class, QueryResult*, ParamType1> QC1;
+            typedef _Callback<Class, std::unique_ptr<QueryResult>, ParamType1> QC1;
 
         public:
 
-            QueryCallback(Class *object, typename QC1::Method method, QueryResult* result, ParamType1 param1)
-                : _IQueryCallback<QC1>(QC1(object, method, result, param1))
+            QueryCallback(Class *object, typename QC1::Method method, std::unique_ptr<QueryResult> result, ParamType1 param1)
+                : _IQueryCallback<QC1>(QC1(object, method, std::move(result), param1))
             {
             }
     };
 
     template<class Class>
-    class QueryCallback<Class> : public _IQueryCallback<_Callback<Class, QueryResult*> >
+    class QueryCallback<Class> : public _IQueryCallback<_Callback<Class, std::unique_ptr<QueryResult>>>
     {
         private:
 
-            typedef _Callback<Class, QueryResult*> QC0;
+            typedef _Callback<Class, std::unique_ptr<QueryResult>> QC0;
 
         public:
-            QueryCallback(Class *object, typename QC0::Method method, QueryResult* result)
-                : _IQueryCallback<QC0>(QC0(object, method, result))
+            QueryCallback(Class *object, typename QC0::Method method, std::unique_ptr<QueryResult> result)
+                : _IQueryCallback<QC0>(QC0(object, method, std::move(result)))
             {
             }
     };
@@ -499,61 +454,61 @@ namespace MaNGOS
     // ---- Statics ----
 
     template<typename ParamType1 = void, typename ParamType2 = void, typename ParamType3 = void>
-    class SQueryCallback : public _IQueryCallback<_SCallback<QueryResult*, ParamType1, ParamType2, ParamType3> >
+    class SQueryCallback : public _IQueryCallback<_SCallback<std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3>>
     {
         private:
 
-            typedef _SCallback<QueryResult*, ParamType1, ParamType2, ParamType3> QC3;
+            typedef _SCallback<std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3> QC3;
 
         public:
 
-            SQueryCallback(typename QC3::Method method, QueryResult* result, ParamType1 param1, ParamType2 param2, ParamType3 param3)
-                : _IQueryCallback<QC3>(QC3(method, result, param1, param2, param3))
+            SQueryCallback(typename QC3::Method method, std::unique_ptr<QueryResult> result, ParamType1 param1, ParamType2 param2, ParamType3 param3)
+                : _IQueryCallback<QC3>(QC3(method, std::move(result), param1, param2, param3))
             {
             }
     };
 
     template<typename ParamType1, typename ParamType2>
-    class SQueryCallback < ParamType1, ParamType2 > : public _IQueryCallback<_SCallback<QueryResult*, ParamType1, ParamType2> >
+    class SQueryCallback < ParamType1, ParamType2 > : public _IQueryCallback<_SCallback<std::unique_ptr<QueryResult>, ParamType1, ParamType2>>
     {
         private:
 
-            typedef _SCallback<QueryResult*, ParamType1, ParamType2> QC2;
+            typedef _SCallback<std::unique_ptr<QueryResult>, ParamType1, ParamType2> QC2;
 
         public:
 
-            SQueryCallback(typename QC2::Method method, QueryResult* result, ParamType1 param1, ParamType2 param2)
-                : _IQueryCallback<QC2>(QC2(method, result, param1, param2))
+            SQueryCallback(typename QC2::Method method, std::unique_ptr<QueryResult> result, ParamType1 param1, ParamType2 param2)
+                : _IQueryCallback<QC2>(QC2(method, std::move(result), param1, param2))
             {
             }
     };
 
     template<typename ParamType1>
-    class SQueryCallback<ParamType1> : public _IQueryCallback<_SCallback<QueryResult*, ParamType1> >
+    class SQueryCallback<ParamType1> : public _IQueryCallback<_SCallback<std::unique_ptr<QueryResult>, ParamType1>>
     {
         private:
 
-            typedef _SCallback<QueryResult*, ParamType1> QC1;
+            typedef _SCallback<std::unique_ptr<QueryResult>, ParamType1> QC1;
 
         public:
 
-            SQueryCallback(typename QC1::Method method, QueryResult* result, ParamType1 param1)
-                : _IQueryCallback<QC1>(QC1(method, result, param1))
+            SQueryCallback(typename QC1::Method method, std::unique_ptr<QueryResult> result, ParamType1 param1)
+                : _IQueryCallback<QC1>(QC1(method, std::move(result), param1))
             {
             }
     };
 
     template<>
-    class SQueryCallback<> : public _IQueryCallback<_SCallback<QueryResult*> >
+    class SQueryCallback<> : public _IQueryCallback<_SCallback<std::unique_ptr<QueryResult>>>
     {
         private:
 
-            typedef _SCallback<QueryResult*> QC0;
+            typedef _SCallback<std::unique_ptr<QueryResult>> QC0;
 
         public:
 
-            SQueryCallback(QC0::Method method, QueryResult* result)
-                : _IQueryCallback<QC0>(QC0(method, result))
+            SQueryCallback(QC0::Method method, std::unique_ptr<QueryResult> result)
+                : _IQueryCallback<QC0>(QC0(method, std::move(result)))
             {
             }
     };

--- a/src/shared/Database/DatabaseImpl.h
+++ b/src/shared/Database/DatabaseImpl.h
@@ -51,19 +51,19 @@
 
 template<class Class>
 bool
-Database::AsyncQuery(Class* object, void (Class::*method)(QueryResult*), char const* sql)
+Database::AsyncQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>), char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class>(object, method, (QueryResult*)nullptr), m_pResultQueue));
+    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr))), m_pResultQueue));
     return true;
 }
 
 template<class Class>
 bool
-Database::AsyncQueryUnsafe(Class* object, void (Class::*method)(QueryResult*), char const* sql)
+Database::AsyncQueryUnsafe(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>), char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    MaNGOS::QueryCallback<Class>* cb = new MaNGOS::QueryCallback<Class>(object, method, (QueryResult*)nullptr);
+    MaNGOS::QueryCallback<Class>* cb = new MaNGOS::QueryCallback<Class>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)));
     cb->threadSafe = false;
     AddToDelayQueue(new SqlQuery(sql, cb, m_pResultQueue));
     return true;
@@ -71,18 +71,18 @@ Database::AsyncQueryUnsafe(Class* object, void (Class::*method)(QueryResult*), c
 
 template<class Class, typename ParamType1>
 bool
-Database::AsyncQuery(Class* object, void (Class::*method)(QueryResult*, ParamType1), ParamType1 param1, char const* sql)
+Database::AsyncQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class, ParamType1>(object, method, (QueryResult*)nullptr, param1), m_pResultQueue));
+    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class, ParamType1>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1), m_pResultQueue));
     return true;
 }
 template<class Class, typename ParamType1>
 bool
-Database::AsyncQueryUnsafe(Class* object, void (Class::*method)(QueryResult*, ParamType1), ParamType1 param1, char const* sql)
+Database::AsyncQueryUnsafe(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    MaNGOS::QueryCallback<Class, ParamType1>* cb = new MaNGOS::QueryCallback<Class, ParamType1>(object, method, (QueryResult*)nullptr, param1);
+    MaNGOS::QueryCallback<Class, ParamType1>* cb = new MaNGOS::QueryCallback<Class, ParamType1>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1);
     cb->threadSafe = false;
     AddToDelayQueue(new SqlQuery(sql, cb, m_pResultQueue));
     return true;
@@ -90,19 +90,19 @@ Database::AsyncQueryUnsafe(Class* object, void (Class::*method)(QueryResult*, Pa
 
 template<class Class, typename ParamType1, typename ParamType2>
 bool
-Database::AsyncQuery(Class* object, void (Class::*method)(QueryResult*, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* sql)
+Database::AsyncQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class, ParamType1, ParamType2>(object, method, (QueryResult*)nullptr, param1, param2), m_pResultQueue));
+    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class, ParamType1, ParamType2>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1, param2), m_pResultQueue));
     return true;
 }
 
 template<class Class, typename ParamType1, typename ParamType2, typename ParamType3>
 bool
-Database::AsyncQuery(Class* object, void (Class::*method)(QueryResult*, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* sql)
+Database::AsyncQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class, ParamType1, ParamType2, ParamType3>(object, method, (QueryResult*)nullptr, param1, param2, param3), m_pResultQueue));
+    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::QueryCallback<Class, ParamType1, ParamType2, ParamType3>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1, param2, param3), m_pResultQueue));
     return true;
 }
 
@@ -110,37 +110,37 @@ Database::AsyncQuery(Class* object, void (Class::*method)(QueryResult*, ParamTyp
 
 template<typename ParamType1>
 bool
-Database::AsyncQuery(void (*method)(QueryResult*, ParamType1), ParamType1 param1, char const* sql)
+Database::AsyncQuery(void (*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::SQueryCallback<ParamType1>(method, (QueryResult*)nullptr, param1), m_pResultQueue));
+    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::SQueryCallback<ParamType1>(method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1), m_pResultQueue));
     return true;
 }
 
 template<typename ParamType1, typename ParamType2>
 bool
-Database::AsyncQuery(void (*method)(QueryResult*, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* sql)
+Database::AsyncQuery(void (*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::SQueryCallback<ParamType1, ParamType2>(method, (QueryResult*)nullptr, param1, param2), m_pResultQueue));
+    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::SQueryCallback<ParamType1, ParamType2>(method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1, param2), m_pResultQueue));
     return true;
 }
 
 template<typename ParamType1, typename ParamType2, typename ParamType3>
 bool
-Database::AsyncQuery(void (*method)(QueryResult*, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* sql)
+Database::AsyncQuery(void (*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::SQueryCallback<ParamType1, ParamType2, ParamType3>(method, (QueryResult*)nullptr, param1, param2, param3), m_pResultQueue));
+    AddToDelayQueue(new SqlQuery(sql, new MaNGOS::SQueryCallback<ParamType1, ParamType2, ParamType3>(method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1, param2, param3), m_pResultQueue));
     return true;
 }
 
 template<typename ParamType1>
 bool
-Database::AsyncQueryUnsafe(void (*method)(QueryResult*, ParamType1), ParamType1 param1, char const* sql)
+Database::AsyncQueryUnsafe(void (*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    MaNGOS::SQueryCallback<ParamType1>* cb = new MaNGOS::SQueryCallback<ParamType1>(method, (QueryResult*)nullptr, param1);
+    MaNGOS::SQueryCallback<ParamType1>* cb = new MaNGOS::SQueryCallback<ParamType1>(method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1);
     cb->threadSafe = false;
     AddToDelayQueue(new SqlQuery(sql, cb, m_pResultQueue));
     return true;
@@ -148,10 +148,10 @@ Database::AsyncQueryUnsafe(void (*method)(QueryResult*, ParamType1), ParamType1 
 
 template<typename ParamType1, typename ParamType2>
 bool
-Database::AsyncQueryUnsafe(void(*method)(QueryResult*, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* sql)
+Database::AsyncQueryUnsafe(void(*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* sql)
 {
     ASYNC_QUERY_BODY(sql)
-    MaNGOS::SQueryCallback<ParamType1, ParamType2>* cb = new MaNGOS::SQueryCallback<ParamType1, ParamType2>(method, (QueryResult*)nullptr, param1, param2);
+    MaNGOS::SQueryCallback<ParamType1, ParamType2>* cb = new MaNGOS::SQueryCallback<ParamType1, ParamType2>(method, std::move(std::unique_ptr<QueryResult>(nullptr)), param1, param2);
     cb->threadSafe = false;
     AddToDelayQueue(new SqlQuery(sql, cb, m_pResultQueue));
     return true;
@@ -161,7 +161,7 @@ Database::AsyncQueryUnsafe(void(*method)(QueryResult*, ParamType1, ParamType2), 
 
 template<class Class>
 bool
-Database::AsyncPQuery(Class* object, void (Class::*method)(QueryResult*), char const* format,...)
+Database::AsyncPQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>), char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQuery(object, method, szQuery);
@@ -169,7 +169,7 @@ Database::AsyncPQuery(Class* object, void (Class::*method)(QueryResult*), char c
 
 template<class Class>
 bool
-Database::AsyncPQueryUnsafe(Class* object, void (Class::*method)(QueryResult*), char const* format,...)
+Database::AsyncPQueryUnsafe(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>), char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQueryUnsafe(object, method, szQuery);
@@ -177,21 +177,21 @@ Database::AsyncPQueryUnsafe(Class* object, void (Class::*method)(QueryResult*), 
 
 template<class Class, typename ParamType1>
 bool
-Database::AsyncPQuery(Class* object, void (Class::*method)(QueryResult*, ParamType1), ParamType1 param1, char const* format,...)
+Database::AsyncPQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQuery(object, method, param1, szQuery);
 }
 template<class Class, typename ParamType1>
 bool
-Database::AsyncPQueryUnsafe(Class* object, void (Class::*method)(QueryResult*, ParamType1), ParamType1 param1, char const* format,...)
+Database::AsyncPQueryUnsafe(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQueryUnsafe(object, method, param1, szQuery);
 }
 template<class Class, typename ParamType1, typename ParamType2>
 bool
-Database::AsyncPQuery(Class* object, void (Class::*method)(QueryResult*, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* format,...)
+Database::AsyncPQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQuery(object, method, param1, param2, szQuery);
@@ -199,7 +199,7 @@ Database::AsyncPQuery(Class* object, void (Class::*method)(QueryResult*, ParamTy
 
 template<class Class, typename ParamType1, typename ParamType2, typename ParamType3>
 bool
-Database::AsyncPQuery(Class* object, void (Class::*method)(QueryResult*, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* format,...)
+Database::AsyncPQuery(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQuery(object, method, param1, param2, param3, szQuery);
@@ -209,7 +209,7 @@ Database::AsyncPQuery(Class* object, void (Class::*method)(QueryResult*, ParamTy
 
 template<typename ParamType1>
 bool
-Database::AsyncPQuery(void (*method)(QueryResult*, ParamType1), ParamType1 param1, char const* format,...)
+Database::AsyncPQuery(void (*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQuery(method, param1, szQuery);
@@ -217,7 +217,7 @@ Database::AsyncPQuery(void (*method)(QueryResult*, ParamType1), ParamType1 param
 
 template<typename ParamType1, typename ParamType2>
 bool
-Database::AsyncPQuery(void (*method)(QueryResult*, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* format,...)
+Database::AsyncPQuery(void (*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQuery(method, param1, param2, szQuery);
@@ -225,7 +225,7 @@ Database::AsyncPQuery(void (*method)(QueryResult*, ParamType1, ParamType2), Para
 
 template<typename ParamType1, typename ParamType2, typename ParamType3>
 bool
-Database::AsyncPQuery(void (*method)(QueryResult*, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* format,...)
+Database::AsyncPQuery(void (*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2, ParamType3), ParamType1 param1, ParamType2 param2, ParamType3 param3, char const* format,...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQuery(method, param1, param2, param3, szQuery);
@@ -233,7 +233,7 @@ Database::AsyncPQuery(void (*method)(QueryResult*, ParamType1, ParamType2, Param
 
 template<typename ParamType1>
 bool
-Database::AsyncPQueryUnsafe(void (*method)(QueryResult*, ParamType1), ParamType1 param1, char const* format, ...)
+Database::AsyncPQueryUnsafe(void (*method)(std::unique_ptr<QueryResult>, ParamType1), ParamType1 param1, char const* format, ...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQueryUnsafe(method, param1, szQuery);
@@ -241,7 +241,7 @@ Database::AsyncPQueryUnsafe(void (*method)(QueryResult*, ParamType1), ParamType1
 
 template<typename ParamType1, typename ParamType2>
 bool
-Database::AsyncPQueryUnsafe(void(*method)(QueryResult*, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* format, ...)
+Database::AsyncPQueryUnsafe(void(*method)(std::unique_ptr<QueryResult>, ParamType1, ParamType2), ParamType1 param1, ParamType2 param2, char const* format, ...)
 {
     ASYNC_PQUERY_BODY(format, szQuery)
     return AsyncQueryUnsafe(method, param1, param2, szQuery);
@@ -251,43 +251,43 @@ Database::AsyncPQueryUnsafe(void(*method)(QueryResult*, ParamType1, ParamType2),
 
 template<class Class>
 bool
-Database::DelayQueryHolder(Class* object, void (Class::*method)(QueryResult*, SqlQueryHolder*), SqlQueryHolder* holder)
+Database::DelayQueryHolder(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, SqlQueryHolder*), SqlQueryHolder* holder)
 {
     ASYNC_DELAYHOLDER_BODY(holder)
-    return holder->Execute(new MaNGOS::QueryCallback<Class, SqlQueryHolder*>(object, method, (QueryResult*)nullptr, holder), this, m_pResultQueue);
+    return holder->Execute(new MaNGOS::QueryCallback<Class, SqlQueryHolder*>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)), holder), this, m_pResultQueue);
 }
 template<class Class>
 bool
-Database::DelayQueryHolderUnsafe(Class* object, void (Class::*method)(QueryResult*, SqlQueryHolder*), SqlQueryHolder* holder)
+Database::DelayQueryHolderUnsafe(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, SqlQueryHolder*), SqlQueryHolder* holder)
 {
     ASYNC_DELAYHOLDER_BODY(holder)
-    MaNGOS::QueryCallback<Class, SqlQueryHolder*>* cb = new MaNGOS::QueryCallback<Class, SqlQueryHolder*>(object, method, (QueryResult*)nullptr, holder);
+    MaNGOS::QueryCallback<Class, SqlQueryHolder*>* cb = new MaNGOS::QueryCallback<Class, SqlQueryHolder*>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)), holder);
     cb->threadSafe = false;
     return holder->Execute(cb, this, m_pResultQueue);
 }
 template<class Class, typename ParamType1>
 bool
-Database::DelayQueryHolder(Class* object, void (Class::*method)(QueryResult*, SqlQueryHolder*, ParamType1), SqlQueryHolder* holder, ParamType1 param1)
+Database::DelayQueryHolder(Class* object, void (Class::*method)(std::unique_ptr<QueryResult>, SqlQueryHolder*, ParamType1), SqlQueryHolder* holder, ParamType1 param1)
 {
     ASYNC_DELAYHOLDER_BODY(holder)
-    return holder->Execute(new MaNGOS::QueryCallback<Class, SqlQueryHolder*, ParamType1>(object, method, (QueryResult*)nullptr, holder, param1), this, m_pResultQueue);
+    return holder->Execute(new MaNGOS::QueryCallback<Class, SqlQueryHolder*, ParamType1>(object, method, std::move(std::unique_ptr<QueryResult>(nullptr)), holder, param1), this, m_pResultQueue);
 }
 
 // -- QueryHolder static --
 template<typename ParamType1>
 bool
-Database::DelayQueryHolder(void (*method)(QueryResult*, SqlQueryHolder*, ParamType1), SqlQueryHolder* holder, ParamType1 param1)
+Database::DelayQueryHolder(void (*method)(std::unique_ptr<QueryResult>, SqlQueryHolder*, ParamType1), SqlQueryHolder* holder, ParamType1 param1)
 {
     ASYNC_DELAYHOLDER_BODY(holder)
-    return holder->Execute(new MaNGOS::SQueryCallback<SqlQueryHolder*, ParamType1>(method, (QueryResult*)nullptr, holder, param1), this, m_pResultQueue);
+    return holder->Execute(new MaNGOS::SQueryCallback<SqlQueryHolder*, ParamType1>(method, std::move(std::unique_ptr<QueryResult>(nullptr)), holder, param1), this, m_pResultQueue);
 }
 
 template<typename ParamType1>
 bool
-Database::DelayQueryHolderUnsafe(void (*method)(QueryResult*, SqlQueryHolder*, ParamType1), SqlQueryHolder* holder, ParamType1 param1)
+Database::DelayQueryHolderUnsafe(void (*method)(std::unique_ptr<QueryResult>, SqlQueryHolder*, ParamType1), SqlQueryHolder* holder, ParamType1 param1)
 {
     ASYNC_DELAYHOLDER_BODY(holder)
-    MaNGOS::SQueryCallback<SqlQueryHolder*, ParamType1>* cb = new MaNGOS::SQueryCallback<SqlQueryHolder*, ParamType1>(method, (QueryResult*)nullptr, holder, param1);
+    MaNGOS::SQueryCallback<SqlQueryHolder*, ParamType1>* cb = new MaNGOS::SQueryCallback<SqlQueryHolder*, ParamType1>(method, std::move(std::unique_ptr<QueryResult>(nullptr)), holder, param1);
     cb->threadSafe = false;
     return holder->Execute(cb, this, m_pResultQueue);
 }

--- a/src/shared/Database/DatabaseMysql.cpp
+++ b/src/shared/Database/DatabaseMysql.cpp
@@ -237,7 +237,7 @@ bool MySQLConnection::_Query(char const* sql, MYSQL_RES** pResult, MYSQL_FIELD**
     return true;
 }
 
-QueryResult* MySQLConnection::Query(char const* sql)
+std::unique_ptr<QueryResult> MySQLConnection::Query(char const* sql)
 {
     MYSQL_RES* result = nullptr;
     MYSQL_FIELD* fields = nullptr;
@@ -247,13 +247,13 @@ QueryResult* MySQLConnection::Query(char const* sql)
     if(!_Query(sql,&result,&fields,&rowCount,&fieldCount))
         return nullptr;
 
-    QueryResultMysql *queryResult = new QueryResultMysql(result, fields, rowCount, fieldCount);
+    std::unique_ptr<QueryResultMysql> queryResult(new QueryResultMysql(result, fields, rowCount, fieldCount));
 
     queryResult->NextRow();
     return queryResult;
 }
 
-QueryNamedResult* MySQLConnection::QueryNamed(char const* sql)
+std::unique_ptr<QueryNamedResult> MySQLConnection::QueryNamed(char const* sql)
 {
     MYSQL_RES* result = nullptr;
     MYSQL_FIELD* fields = nullptr;
@@ -267,10 +267,10 @@ QueryNamedResult* MySQLConnection::QueryNamed(char const* sql)
     for (uint32 i = 0; i < fieldCount; i++)
         names[i] = fields[i].name;
 
-    QueryResultMysql *queryResult = new QueryResultMysql(result, fields, rowCount, fieldCount);
+    std::unique_ptr<QueryResultMysql> queryResult(new QueryResultMysql(result, fields, rowCount, fieldCount));
 
     queryResult->NextRow();
-    return new QueryNamedResult(queryResult,names);
+    return std::make_unique<QueryNamedResult>(std::move(queryResult), names);
 }
 
 bool MySQLConnection::Execute(char const* sql)

--- a/src/shared/Database/DatabaseMysql.h
+++ b/src/shared/Database/DatabaseMysql.h
@@ -85,8 +85,8 @@ class MySQLConnection : public SqlConnection
         bool Reconnect();
         bool HandleMySQLError(uint32 errNo);
 
-        QueryResult* Query(char const* sql) override;
-        QueryNamedResult* QueryNamed(char const* sql) override;
+        std::unique_ptr<QueryResult> Query(char const* sql) override;
+        std::unique_ptr<QueryNamedResult> QueryNamed(char const* sql) override;
         bool Execute(char const* sql) override;
 
         unsigned long escape_string(char* to, char const* from, unsigned long length) override;

--- a/src/shared/Database/DatabasePostgre.cpp
+++ b/src/shared/Database/DatabasePostgre.cpp
@@ -116,7 +116,7 @@ bool PostgreSQLConnection::_Query(char const* sql, PGresult** pResult, uint64* p
     return true;
 }
 
-QueryResult* PostgreSQLConnection::Query(char const* sql)
+std::unique_ptr<QueryResult> PostgreSQLConnection::Query(char const* sql)
 {
     if (!mPGconn)
         return nullptr;
@@ -128,13 +128,13 @@ QueryResult* PostgreSQLConnection::Query(char const* sql)
     if(!_Query(sql,&result,&rowCount,&fieldCount))
         return nullptr;
 
-    QueryResultPostgre * queryResult = new QueryResultPostgre(result, rowCount, fieldCount);
+    std::unique_ptr<QueryResultPostgre> queryResult(new QueryResultPostgre(result, rowCount, fieldCount));
 
     queryResult->NextRow();
     return queryResult;
 }
 
-QueryNamedResult* PostgreSQLConnection::QueryNamed(char const* sql)
+std::unique_ptr<QueryNamedResult> PostgreSQLConnection::QueryNamed(char const* sql)
 {
     if (!mPGconn)
         return nullptr;
@@ -150,10 +150,10 @@ QueryNamedResult* PostgreSQLConnection::QueryNamed(char const* sql)
     for (uint32 i = 0; i < fieldCount; i++)
         names[i] = PQfname(result, i);
 
-    QueryResultPostgre * queryResult = new QueryResultPostgre(result, rowCount, fieldCount);
+    std::unique_ptr<QueryResultPostgre> queryResult(new QueryResultPostgre(result, rowCount, fieldCount));
 
     queryResult->NextRow();
-    return new QueryNamedResult(queryResult,names);
+    return std::make_unique<QueryNamedResult>(std::move(queryResult), names);
 }
 
 bool PostgreSQLConnection::Execute(char const* sql)

--- a/src/shared/Database/DatabasePostgre.h
+++ b/src/shared/Database/DatabasePostgre.h
@@ -43,8 +43,8 @@ class PostgreSQLConnection : public SqlConnection
 
         bool OpenConnection(bool reconnect);
 
-        QueryResult* Query(char const* sql);
-        QueryNamedResult* QueryNamed(char const* sql);
+        std::unique_ptr<QueryResult> Query(char const* sql);
+        std::unique_ptr<QueryNamedResult> QueryNamed(char const* sql);
         bool Execute(char const* sql);
 
         unsigned long escape_string(char* to, char const* from, unsigned long length);

--- a/src/shared/Database/QueryResult.h
+++ b/src/shared/Database/QueryResult.h
@@ -24,6 +24,7 @@
 
 #include "Common.h"
 #include "Field.h"
+#include <memory>
 
 class QueryResult
 {
@@ -53,8 +54,7 @@ typedef std::vector<std::string> QueryFieldNames;
 class QueryNamedResult
 {
     public:
-        explicit QueryNamedResult(QueryResult* query, QueryFieldNames const& names) : mQuery(query), mFieldNames(names) {}
-        ~QueryNamedResult() { delete mQuery; }
+        explicit QueryNamedResult(std::unique_ptr<QueryResult> query, QueryFieldNames names) : mQuery(std::move(query)), mFieldNames(std::move(names)) {}
 
         // compatible interface with QueryResult
         bool NextRow() { return mQuery->NextRow(); }
@@ -79,7 +79,7 @@ class QueryNamedResult
         }
 
     protected:
-        QueryResult* mQuery;
+        std::unique_ptr<QueryResult> mQuery;
         QueryFieldNames mFieldNames;
 };
 

--- a/src/shared/Database/SqlDelayThread.cpp
+++ b/src/shared/Database/SqlDelayThread.cpp
@@ -68,8 +68,7 @@ void SqlDelayThread::run()
         {
             loopCounter = 0;
             m_dbEngine->Ping();
-            if (QueryResult* res = m_dbConnection->Query("SELECT 1"))
-                delete res;
+            /* ignore result */ m_dbConnection->Query("SELECT 1"); // TODO: Why is this here, when its already check in m_dbEngine->Ping(); ???
         }
     }
 

--- a/src/shared/Database/SqlOperations.cpp
+++ b/src/shared/Database/SqlOperations.cpp
@@ -93,8 +93,11 @@ bool SqlQuery::Execute(SqlConnection* conn)
         return false;
 
     LOCK_DB_CONN(conn);
+
     // execute the query and store the result in the callback
-    m_callback->SetResult(conn->Query(m_sql));
+    std::unique_ptr<QueryResult> result = conn->Query(m_sql);
+    m_callback->SetResult(std::move(result));
+
     // add the callback to the sql result queue of the thread it originated from
     m_queue->add(m_callback);
 
@@ -224,31 +227,31 @@ bool SqlQueryHolder::SetPQuery(size_t index, char const* format, ...)
     return SetQuery(index,szQuery);
 }
 
-QueryResult* SqlQueryHolder::GetResult(size_t index)
+/// When you are using this function, you are the new owner of the ptr. The query will be removed from the QueryHolder
+std::unique_ptr<QueryResult> SqlQueryHolder::TakeResult(size_t index)
 {
     if(index < m_queries.size())
     {
-        // the query strings are freed on the first GetResult or in the destructor
+        // the query strings are freed on the first TakeResult or in the destructor
         if(m_queries[index].first != nullptr)
         {
             delete [] (const_cast<char*>(m_queries[index].first));
             m_queries[index].first = nullptr;
         }
-        // when you get a result aways remember to delete it!
-        return m_queries[index].second;
+        return std::move(m_queries[index].second);
     }
     else
         return nullptr;
 }
 
-void SqlQueryHolder::SetResult(size_t index, QueryResult* result)
+void SqlQueryHolder::SetResult(size_t index, std::unique_ptr<QueryResult> result)
 {
     // store the result in the holder
     if(index < m_queries.size())
-        m_queries[index].second = result;
+        m_queries[index].second = std::move(result);
 }
 
-SqlQueryHolder::~SqlQueryHolder()
+SqlQueryHolder::~SqlQueryHolder() // TODO: Delete me when .first is also a smartpointer
 {
     for(size_t i = 0; i < m_queries.size(); i++)
     {
@@ -257,26 +260,17 @@ SqlQueryHolder::~SqlQueryHolder()
         if(m_queries[i].first != nullptr)
         {
             delete [] (const_cast<char*>(m_queries[i].first));
-            if(m_queries[i].second)
-            {
-                delete m_queries[i].second;
-                m_queries[i].second = nullptr;
-            }
         }
     }
 }
 
 void SqlQueryHolder::DeleteAllResults()
 {
-    for(size_t i = 0; i < m_queries.size(); i++)
+    for (size_t i = 0; i < m_queries.size(); i++)
     {
         // if the result was never used, free the resources
         // results used already (getresult called) are expected to be deleted
-        if (m_queries[i].second != nullptr)
-        {
-            delete m_queries[i].second;
-            m_queries[i].second = nullptr;
-        }
+        m_queries[i].second.reset();
     }
 }
 

--- a/src/shared/Database/SqlOperations.h
+++ b/src/shared/Database/SqlOperations.h
@@ -26,7 +26,7 @@
 
 #include "LockedQueue.h"
 #include <queue>
-#include "Utilities/Callback.h"
+#include "DatabaseCallback.h"
 #include <memory>
 
 // ---- BASE ---
@@ -129,7 +129,7 @@ class SqlQueryHolder
 {
     friend class SqlQueryHolderEx;
     private:
-        typedef std::pair<char const*, QueryResult*> SqlResultPair;
+        typedef std::pair<char const*, std::unique_ptr<QueryResult>> SqlResultPair; // TODO: Use std::string for .first
         std::vector<SqlResultPair> m_queries;
 
         uint32 serialId;
@@ -141,8 +141,9 @@ class SqlQueryHolder
         bool SetPQuery(size_t index, char const* format, ...) ATTR_PRINTF(3,4);
         void SetSize(size_t size);
         size_t GetSize() const { return m_queries.size(); }
-        QueryResult* GetResult(size_t index);
-        void SetResult(size_t index, QueryResult* result);
+        /// When you are using this function, you are the new owner of the ptr. The query will be removed from the QueryHolder
+        std::unique_ptr<QueryResult> TakeResult(size_t index);
+        void SetResult(size_t index, std::unique_ptr<QueryResult> result);
         bool Execute(MaNGOS::IQueryCallback* callback, Database* db, SqlResultQueue* queue);
         void DeleteAllResults();
         uint32 GetSerialId() const { return serialId; }


### PR DESCRIPTION
## 🍰 Pullrequest
This pull request will change every occurrence of `QueryResult*` to a smart pointer.

This will ensure that no `QueryResult` might ever accidently leak memory.
