### PR TITLE
Sweeping Strikes + Rend

### DIFF
--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -640,13 +640,6 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 amount, uint
                             triggered_spell_id = 12723; // Note this SS id deals 1 damage by itself (Cannot crit)
                         }
                     }
-                    else if (procSpell && procSpell->Id == 1680 && stacks_left > 1) // If procced by Whirlwind
-                    {   
-                        basepoints[0] = ditheru(amount * 100 / CalcArmorReducedDamage(pVictim, 100)); 
-                        triggered_spell_id = 12723;                                                   
-                        CastSpell(pVictim, 26654, true);                                              
-                        triggeredByAura->GetHolder()->DropAuraCharge();
-                    }
                     else // Full damage on anything else
 #endif
                     {

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -371,7 +371,12 @@ SpellProcEventTriggerCheck Unit::IsTriggeredAtSpellProcEvent(Unit* pVictim, Spel
                 return SPELL_PROC_TRIGGER_OK;
         }
 #endif
-
+        //  Never proc for Rend.	
+         if (spellProto->Id == 12292) 
+         {
+             if (procSpell->SpellIconID == 245)      
+                 return SPELL_PROC_TRIGGER_FAILED;
+         }
         // SHAMAN
         // Elemental Mastery
         // Do not consume aura if spell did not benefit from crit chance bonus.

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -640,6 +640,13 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 amount, uint
                             triggered_spell_id = 12723; // Note this SS id deals 1 damage by itself (Cannot crit)
                         }
                     }
+                    else if (procSpell && procSpell->Id == 1680 && stacks_left > 1) // If procced by Whirlwind
+                    {   
+                        basepoints[0] = ditheru(amount * 100 / CalcArmorReducedDamage(pVictim, 100)); 
+                        triggered_spell_id = 12723;                                                   
+                        CastSpell(pVictim, 26654, true);                                              
+                        triggeredByAura->GetHolder()->DropAuraCharge();
+                    }
                     else // Full damage on anything else
 #endif
                     {


### PR DESCRIPTION
## 🍰 Pullrequest
Greetings, this is my first time doing a pull request.

### Proof
footage from classic era server (idk, is that a good enough proof?)
https://youtu.be/y6ALTZoDCw4 

### Issues
If you use Rend with sweeping strikes up you will hit second target for 1 damage, SS should not get trigger by rend.

### How2Test
.learn 12292
.learn 11574
.npc summon 17685
.npc summon 17685 next to previous one
.modify rage 100
use ss use rend see the combat log

### Todo / Checklist
- [X] None
