### PR TITLE
spawn ObjectsUpdate threads only for continents

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -156,14 +156,14 @@ Map::Map(uint32 id, time_t expiry, uint32 InstanceId)
     m_persistentState->SetUsedByMapState(this);
     m_weatherSystem = new WeatherSystem(this);
 
-    int numObjThreads = (int)sWorld.getConfig(CONFIG_UINT32_MAP_OBJECTSUPDATE_THREADS);
-    if (numObjThreads > 1)
-    {
-        m_objectThreads.reset(new ThreadPool(numObjThreads -1));
-        m_objectThreads->start<ThreadPool::MySQL<ThreadPool::MultiQueue>>();
-    }
     if (IsContinent())
     {
+        int numObjThreads = (int)sWorld.getConfig(CONFIG_UINT32_MAP_OBJECTSUPDATE_THREADS);
+        if (numObjThreads > 1)
+        {
+            m_objectThreads.reset(new ThreadPool(numObjThreads -1));
+            m_objectThreads->start<ThreadPool::MySQL<ThreadPool::MultiQueue>>();
+        }
         m_motionThreads.reset(new ThreadPool(sWorld.getConfig(CONFIG_UINT32_CONTINENTS_MOTIONUPDATE_THREADS)));
         m_visibilityThreads.reset(new ThreadPool(std::max((int)sWorld.getConfig(CONFIG_UINT32_MAP_VISIBILITYUPDATE_THREADS) -1,0)));
         m_cellThreads.reset(new ThreadPool(std::max((int)sWorld.getConfig(CONFIG_UINT32_MTCELLS_THREADS) - 1, 0)));


### PR DESCRIPTION
## 🍰 Pullrequest
spawn ObjectsUpdate threads only for continents

### Issues
This fix is relevant for the following config option:
```
# Per-map subthreads (not for instanced maps)
MapUpdate.ObjectsUpdate.MaxThreads = 4
```
Currently, a ThreadPool is initialized for all maps, even though the comment above it states it's not for instanced maps (rather continents only). By default, this value is 4 which causes every map created to have 3 worker threads for object update, which is unnecessary for instanced maps with low player count and only adds overhead and memory usage. The PR that introduced this change is [#1870](https://github.com/vmangos/core/pull/1870), not sure why.

### How2Test
1. set MapUpdate.ObjectsUpdate.MaxThreads = 1
--> object updates work in continents and instances
2. set MapUpdate.ObjectsUpdate.MaxThreads = 4
--> object updates work in continents and instances
