### PR TITLE
Refactoring #includes

### DIFF
--- a/src/framework/Policies/CreationPolicy.h
+++ b/src/framework/Policies/CreationPolicy.h
@@ -22,7 +22,7 @@
 #ifndef MANGOS_CREATIONPOLICY_H
 #define MANGOS_CREATIONPOLICY_H
 
-#include <stdlib.h>
+#include <cstdlib>
 #include "Platform/Define.h"
 
 namespace MaNGOS

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "PetAI.h"
-#include "Errors.h"
 #include "Pet.h"
 #include "Player.h"
 #include "Spell.h"

--- a/src/game/Camera.cpp
+++ b/src/game/Camera.cpp
@@ -23,7 +23,6 @@
 #include "GridNotifiersImpl.h"
 #include "CellImpl.h"
 #include "Log.h"
-#include "Errors.h"
 #include "Player.h"
 
 Camera::Camera(Player* pl) : m_owner(*pl), m_source(pl)

--- a/src/game/Commands/CharacterCommands.cpp
+++ b/src/game/Commands/CharacterCommands.cpp
@@ -28,7 +28,6 @@
 #include "Language.h"
 #include "AccountMgr.h"
 #include "ObjectMgr.h"
-#include "SystemConfig.h"
 #include "Util.h"
 #include "AsyncCommandHandlers.h"
 #include "WaypointMovementGenerator.h"

--- a/src/game/ItemEnchantmentMgr.cpp
+++ b/src/game/ItemEnchantmentMgr.cpp
@@ -19,7 +19,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <stdlib.h>
 #include <functional>
 #include "ItemEnchantmentMgr.h"
 #include "Database/DatabaseEnv.h"

--- a/src/game/Movement/MotionMaster.cpp
+++ b/src/game/Movement/MotionMaster.cpp
@@ -38,8 +38,6 @@
 #include "MoveSpline.h"
 #include "MoveSplineInit.h"
 
-#include <cassert>
-
 inline bool isStatic(MovementGenerator* mv)
 {
     return (mv == &si_idleMovement);

--- a/src/game/Movement/PointMovementGenerator.cpp
+++ b/src/game/Movement/PointMovementGenerator.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "PointMovementGenerator.h"
-#include "Errors.h"
 #include "Creature.h"
 #include "CreatureAI.h"
 #include "GameObjectAI.h"

--- a/src/game/Movement/TargetedMovementGenerator.cpp
+++ b/src/game/Movement/TargetedMovementGenerator.cpp
@@ -18,7 +18,6 @@
 
 #include "ByteBuffer.h"
 #include "TargetedMovementGenerator.h"
-#include "Errors.h"
 #include "Creature.h"
 #include "CreatureAI.h"
 #include "Player.h"

--- a/src/game/Movement/spline/util.cpp
+++ b/src/game/Movement/spline/util.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "MoveSplineFlag.h"
-#include <math.h>
 #include <string>
 
 namespace Movement

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -68,7 +68,6 @@
 #include "GMTicketMgr.h"
 #include "MasterPlayer.h"
 #include "MovementPacketSender.h"
-#include "Config/Config.h"
 #include "ZoneScript.h"
 #include "ZoneScriptMgr.h"
 #include "PlayerBotMgr.h"

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -57,9 +57,6 @@
 #include "InstanceStatistics.h"
 #include "MovementPacketSender.h"
 
-#include <math.h>
-#include <stdarg.h>
-
 //#define DEBUG_DEBUFF_LIMIT
 
 float baseMoveSpeed[MAX_MOVE_TYPE] =

--- a/src/game/Objects/UpdateMask.h
+++ b/src/game/Objects/UpdateMask.h
@@ -23,7 +23,6 @@
 #define __UPDATEMASK_H
 
 #include "UpdateFields.h"
-#include "Errors.h"
 
 class UpdateMask
 {

--- a/src/game/vmap/RegularGrid.h
+++ b/src/game/vmap/RegularGrid.h
@@ -25,8 +25,6 @@
 #include <G3D/Table.h>
 #include <G3D/PositionTrait.h>
 
-#include "Errors.h"
-
 using G3D::Vector2;
 using G3D::Vector3;
 using G3D::AABox;

--- a/src/game/vmap/VMapDefinitions.h
+++ b/src/game/vmap/VMapDefinitions.h
@@ -32,17 +32,16 @@ namespace VMAP
 }
 
 #ifndef NO_CORE_FUNCS
-#include "Errors.h"
 #include "Log.h"
 #elif defined MMAP_GENERATOR
-#include <assert.h>
+#include <cassert>
 #define MANGOS_ASSERT(x) assert(x)
 #define sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, ...) 0
 #define sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, ...) 0
 #define LOG_FILTER_MAP_LOADING true
 #define DEBUG_FILTER_LOG(F,...) do{ if (F) sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, __VA_ARGS__); } while(0)
 #else
-#include <assert.h>
+#include <cassert>
 #define MANGOS_ASSERT(x) assert(x)
 #define sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, ...) do{ printf(__VA_ARGS__); printf("\n"); } while(0)
 #define sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, ...) do{ printf(__VA_ARGS__); printf("\n"); } while(0)

--- a/src/game/vmap/WorldModel.cpp
+++ b/src/game/vmap/WorldModel.cpp
@@ -20,7 +20,6 @@
 #include "VMapDefinitions.h"
 #include "MapTree.h"
 #include "ModelInstance.h"
-#include <string.h>
 
 using G3D::Vector3;
 using G3D::Ray;

--- a/src/scripts/PrecompiledHeaders/scriptPCH.h
+++ b/src/scripts/PrecompiledHeaders/scriptPCH.h
@@ -32,8 +32,4 @@
 #include "Weather.h"
 #include "TotemAI.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #endif

--- a/src/shared/Auth/Sha1.cpp
+++ b/src/shared/Auth/Sha1.cpp
@@ -18,7 +18,7 @@
 
 #include "Auth/Sha1.h"
 #include "Auth/BigNumber.h"
-#include <stdarg.h>
+#include <cstdarg>
 
 Sha1Hash::Sha1Hash()
 {

--- a/src/shared/Common.h
+++ b/src/shared/Common.h
@@ -64,14 +64,14 @@
 
 #include "Platform/CompilerDefs.h"
 #include "Platform/Define.h"
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <math.h>
-#include <errno.h>
-#include <signal.h>
-#include <assert.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <cerrno>
+#include <csignal>
+#include <cassert>
 
 #if defined(__sun__)
 #include <ieeefp.h> // finite() on Solaris

--- a/src/shared/Database/DBCFileLoader.cpp
+++ b/src/shared/Database/DBCFileLoader.cpp
@@ -19,9 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
 
 #include "DBCFileLoader.h"
 

--- a/src/shared/Errors.h
+++ b/src/shared/Errors.h
@@ -25,11 +25,12 @@
 #include "Common.h"
 
 //#ifndef HAVE_CONFIG_H
-#  define HAVE_ACE_STACK_TRACE_H 1
+#define HAVE_ACE_STACK_TRACE_H 1
 //#endif
 
 #ifdef HAVE_ACE_STACK_TRACE_H
-#  include "ace/Stack_Trace.h"
+#include "ace/Stack_Trace.h"
+#include "Log.h" // sLog in only used when HAVE_ACE_STACK_TRACE_H
 #endif
 
 #ifdef HAVE_ACE_STACK_TRACE_H

--- a/src/shared/LockedQueue.h
+++ b/src/shared/LockedQueue.h
@@ -24,8 +24,7 @@
 
 #include <deque>
 #include <mutex>
-#include <assert.h>
-#include "Errors.h"
+#include <cassert>
 
 template <class T, class LockType, typename StorageType=std::deque<T> >
     class LockedQueue

--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -28,7 +28,6 @@
 #include "ProgressBar.h"
 
 #include <stdarg.h>
-#include <fstream>
 #include <iostream>
 
 #include "ace/OS_NS_unistd.h"

--- a/src/shared/ProgressBar.cpp
+++ b/src/shared/ProgressBar.cpp
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "ProgressBar.h"
 #include "Errors.h"
@@ -40,13 +40,13 @@ BarGoLink::BarGoLink(int row_count)
 
 BarGoLink::BarGoLink(uint32 row_count)
 {
-    //MANGOS_ASSERT(row_count < (uint32)ACE_INT32_MAX);
+    MANGOS_ASSERT(row_count < (uint32)ACE_INT32_MAX);
     init((int)row_count);
 }
 
 BarGoLink::BarGoLink(uint64 row_count)
 {
-    //MANGOS_ASSERT(row_count < (uint64)ACE_INT32_MAX);
+    MANGOS_ASSERT(row_count < (uint64)ACE_INT32_MAX);
     init((int)row_count);
 }
 

--- a/src/shared/ServiceWin32.cpp
+++ b/src/shared/ServiceWin32.cpp
@@ -24,7 +24,6 @@
 #include "Common.h"
 #include "Log.h"
 #include <cstring>
-#include <windows.h>
 #include <winsvc.h>
 
 #if !defined(WINADVAPI)


### PR DESCRIPTION
## 🍰 Pullrequest

- Clang-Tidy: Inclusion of deprecated C++ header
- Removed Windows.h from PCH
- Most of the time `#include "Errors.h"` was leading to the wrong file anyways.

Tested on windows with PCH on and off
