### PR TITLE
Fix patch for several objects/NPCs.

### DIFF
--- a/sql/migrations/20240623045909_world.sql
+++ b/sql/migrations/20240623045909_world.sql
@@ -1,0 +1,54 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20240623045909');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20240623045909');
+-- Add your query below.
+
+
+-- Bonfires at Blackwood GY shouldn't be spawned pre 1.11 naxx
+UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=45609;
+UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=45611;
+UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=45610;
+UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=45608;
+
+-- Objects in Horde camp in Silithus shouldn't be spawned pre 1.9
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49377;
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49281;
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49379;
+
+-- Objects in Alliance camp in Silithus shouldn't be spawned pre 1.9
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49274;
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49381;
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49374;
+
+-- Stonelash Flayer shouldn't be spawned pre 1.8
+UPDATE `creature` SET `patch_min`=6 WHERE `guid`=44397;
+UPDATE `creature` SET `patch_min`=6 WHERE `guid`=44396;
+
+-- Set patch of pooled food/barrel to not spawn pre 1.11
+UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=902;
+UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=904;
+
+-- Moonwell at Cenarion Hold shouldn't be spawned pre 1.8
+UPDATE `gameobject` SET `patch_min`=6 WHERE `guid`=49378;
+
+-- Twilight Masters in northeast Silithus shouldn't be spawned pre 1.8
+UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43069;
+UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43070;
+UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43071;
+UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43076;
+UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43077;
+-- Bonfire Damage in northeast Silithus shouldn't be spawned in pre 1.8
+UPDATE `gameobject` SET `patch_min`=6 WHERE `guid`=49282;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20240623045909_world.sql
+++ b/sql/migrations/20240623045909_world.sql
@@ -62,6 +62,24 @@ UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43077;
 -- Bonfire Damage in northeast Silithus shouldn't be spawned in pre 1.8
 UPDATE `gameobject` SET `patch_min`=6 WHERE `guid`=49282;
 
+-- Terrain was changed a bit in Cenarion Hold in 1.9, remove objects that didn't exist prior to 1.9.0:
+-- Forge
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49393;
+-- Anvil
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49394;
+-- Cooking Brazier
+UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49395;
+
+-- Several Cenarion Hold Infantry NPCs shouldn't be spawned pre 1.9.
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42772;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42784;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42868;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42769;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42773;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42776;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42777;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42768;
+
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20240623045909_world.sql
+++ b/sql/migrations/20240623045909_world.sql
@@ -70,6 +70,17 @@ UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49394;
 -- Cooking Brazier
 UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49395;
 
+-- Cenarion Hold Infantry with waypoints should be mounted pre 1.9.
+INSERT INTO `creature_addon` (`guid`, `patch`, `display_id`, `mount_display_id`, `equipment_id`, `stand_state`, `sheath_state`, `emote_state`, `auras`) VALUES 
+(42895, 6, 0, 14330, -1, 0, 1, 0, NULL),
+(42898, 6, 0, 14330, -1, 0, 1, 0, NULL),
+(42895, 7, 0, 0, -1, 0, 1, 0, NULL),
+(42898, 7, 0, 0, -1, 0, 1, 0, NULL),
+(42897, 6, 0, 14330, -1, 0, 1, 0, NULL),
+(60006, 6, 0, 14330, -1, 0, 1, 0, NULL),
+(42897, 7, 0, 0, -1, 0, 1, 0, NULL),
+(60006, 7, 0, 0, -1, 0, 1, 0, NULL);
+
 -- Several Cenarion Hold Infantry NPCs shouldn't be spawned pre 1.9.
 UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42772;
 UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42784;
@@ -79,6 +90,11 @@ UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42773;
 UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42776;
 UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42777;
 UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42768;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42884;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42782;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42783;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42766;
+UPDATE `creature` SET `patch_min`=7 WHERE `guid`=42767;
 
 
 -- End of migration.

--- a/sql/migrations/20240623045909_world.sql
+++ b/sql/migrations/20240623045909_world.sql
@@ -15,15 +15,31 @@ UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=45611;
 UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=45610;
 UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=45608;
 
--- Objects in Horde camp in Silithus shouldn't be spawned pre 1.9
-UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49377;
-UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49281;
-UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49379;
+-- 1.12 objects in Horde camp in Silithus shouldn't be spawned pre 1.12
+UPDATE `gameobject` SET `patch_min`=10 WHERE `guid`=49377;
+UPDATE `gameobject` SET `patch_min`=10 WHERE `guid`=49281;
+UPDATE `gameobject` SET `patch_min`=10 WHERE `guid`=49379;
+UPDATE `gameobject` SET `patch_min`=10 WHERE `guid`=49375;
+-- Update in gameobject_template as well
+UPDATE `gameobject_template` SET `patch`=10 WHERE `entry`=181633;
+UPDATE `gameobject_template` SET `patch`=10 WHERE `entry`=181634;
+UPDATE `gameobject_template` SET `patch`=10 WHERE `entry`=181619;
 
--- Objects in Alliance camp in Silithus shouldn't be spawned pre 1.9
-UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49274;
-UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49381;
-UPDATE `gameobject` SET `patch_min`=7 WHERE `guid`=49374;
+-- Spawn missing pre 1.12 Cooking Brazier in Horde camp in Silithus
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES 
+(49998, 180689, 1, -7554.36, 742.9, -17.7829, 4.79809, 0, 0, 0.676168, -0.736748, 25, 25, 0, 1, 0, 0, 7, 9);
+
+-- 1.12 objects in Alliance camp in Silithus shouldn't be spawned pre 1.12
+UPDATE `gameobject` SET `patch_min`=10 WHERE `guid`=49274;
+UPDATE `gameobject` SET `patch_min`=10 WHERE `guid`=49381;
+UPDATE `gameobject` SET `patch_min`=10 WHERE `guid`=49374;
+-- Update in gameobject_template as well
+UPDATE `gameobject_template` SET `patch`=10 WHERE `entry`=181635;
+UPDATE `gameobject_template` SET `patch`=10 WHERE `entry`=181618;
+
+-- Spawn missing pre 1.12 Cooking Brazier in Alliance camp in Silithus
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES 
+(49999, 180688, 1, -7165.76, 1389.52, 2.41821, 3.06785, 0, 0, 0.99932, 0.0368614, 25, 25, 0, 1, 0, 0, 7, 9);
 
 -- Stonelash Flayer shouldn't be spawned pre 1.8
 UPDATE `creature` SET `patch_min`=6 WHERE `guid`=44397;
@@ -33,7 +49,7 @@ UPDATE `creature` SET `patch_min`=6 WHERE `guid`=44396;
 UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=902;
 UPDATE `gameobject` SET `patch_min`=9 WHERE `guid`=904;
 
--- Moonwell at Cenarion Hold shouldn't be spawned pre 1.8
+-- Moonwell (for mooncloth crafting) at Cenarion Hold shouldn't be spawned pre 1.8
 UPDATE `gameobject` SET `patch_min`=6 WHERE `guid`=49378;
 
 -- Twilight Masters in northeast Silithus shouldn't be spawned pre 1.8
@@ -42,6 +58,7 @@ UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43070;
 UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43071;
 UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43076;
 UPDATE `creature` SET `patch_min`=6 WHERE `guid`=43077;
+
 -- Bonfire Damage in northeast Silithus shouldn't be spawned in pre 1.8
 UPDATE `gameobject` SET `patch_min`=6 WHERE `guid`=49282;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes the patch for several objects/NPCs that should not be spawned in earlier versions of the game.
The PR also adds two objects that were previously missing from alliance/horde camp, used only pre patch 1.12.

### Proof
<!-- Link resources as proof -->
- The horde and alliance camps were added in 1.9.0 and then in patch 1.12.0 the terrain changed when the sandlol pvp event was added.

- Images from vanilla camps pre 1.12:
March 27, 2006:
![WoWScrnShot_032706_000831](https://github.com/vmangos/core/assets/6137576/f3c81df6-d95d-4d25-ac46-e682eb20ef04)
Unknown date pre 1.12:
![BattleKnightskillAbomination](https://github.com/vmangos/core/assets/6137576/a9a87725-5f89-4caa-b4f8-71d1cf35d15c)

From vmangos after PR applied:
![WoW_NxjF8de0cA](https://github.com/vmangos/core/assets/6137576/054beb85-0561-4613-a332-00618a4bfc40)
![WoW_ExvXibchLA](https://github.com/vmangos/core/assets/6137576/b40cd35e-ae32-4a64-b2f8-224941045b1c)

Old images from from Cenarion Hold pre 1.9:
Wearing old t2 art, t2 was updated in 1.9 so this image is from 1.8 (Hallows End was added in 1.8 October 10 2005):
![58965626301](https://github.com/vmangos/core/assets/6137576/f4621b1b-b1b3-44e0-8543-1e3df41f436e)
Wearing old t2 art, t2 was updated in 1.9 so this image is from 1.8 (Hallows End was added in 1.8 October 10 2005):
![58965626300](https://github.com/vmangos/core/assets/6137576/69991cdf-1c38-4547-88c3-7df2bc2ec146)
Unknown date, but from originally from same image folder as the rogue wearing old t2. (Hallows End was added in 1.8 October 10 2005):
![58965626302](https://github.com/vmangos/core/assets/6137576/02bd0188-1525-4bc5-aa63-8b3541979659)
Wearing old t2 art, t2 was updated in 1.9 so this image is from 1.8 (Hallows End was added in 1.8 October 10 2005):
![58965626308](https://github.com/vmangos/core/assets/6137576/c2687ac4-780e-48c4-955a-9790e3b47950)
Wearing old t2 art, t2 was updated in 1.9 so this image is from 1.8 (Hallows End was added in 1.8 October 10 2005):
![58965626309](https://github.com/vmangos/core/assets/6137576/32d29810-2b4a-433d-8cee-13feb134d25d)
Unknown date, but from originally from same image folder as the rogue wearing old t2.
![58965626319](https://github.com/vmangos/core/assets/6137576/fdd9b058-a78a-4aec-b352-2c7e885b4e46)
Unknown date, but as the Cenarion Hold Infantry are mounted, I believe its from 1.8:
![ThebattlefieldofCenarionHold](https://github.com/vmangos/core/assets/6137576/4c7e44bc-cb7c-40ce-84a2-6a9d0dce43ba)
- September 30, 2005 (patch 1.8.2):
![WoWScrnShot_093005_103242](https://github.com/vmangos/core/assets/6137576/6853bb32-494f-495e-9527-e5f9dc89a0d9)
Unknown date, but as the Cenarion Hold Infantry are mounted, I believe its from 1.8:
![125 - QIDtM](https://github.com/vmangos/core/assets/6137576/03963b8d-17b2-4c81-92fa-375575993dc3)
This image is dated July 22, 2006 (patch 1.11.2) Why the guard by the ladder is not spawned I do not know. It's possible it was added in later patch than 1.9.:
![WoWScrnShot_072206_192602](https://github.com/vmangos/core/assets/6137576/d01b9d0a-4725-4fde-baf1-8b7312cc963b)
It's possible in this image that someone has bugged the NPC into a pillar, since there is a very faint C in the middle of the screen inside the pillar.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Use 1.7.1 or set wowpatch to 5
- Try to .go creature or .go ob any of the guids

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
