### PR TITLE
handle negative time value in CharacterScreenIdleKick

### DIFF
--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -1333,7 +1333,8 @@ bool WorldSession::CharacterScreenIdleKick(uint32 currTime)
     if (!maxIdle) // disabled
         return false;
 
-    if ((currTime - m_idleTime) >= (maxIdle * 1000))
+    auto idleTime = (int64)currTime - m_idleTime;
+    if (idleTime >= (maxIdle * 1000))
     {
         sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "SESSION: Kicking session [%s] from character selection", GetRemoteAddress().c_str());
         return true;

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -1333,8 +1333,7 @@ bool WorldSession::CharacterScreenIdleKick(uint32 currTime)
     if (!maxIdle) // disabled
         return false;
 
-    auto idleTime = (int64)currTime - m_idleTime;
-    if (idleTime >= (maxIdle * 1000))
+    if (currTime > m_idleTime && (currTime - m_idleTime) >= (maxIdle * 1000))
     {
         sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "SESSION: Kicking session [%s] from character selection", GetRemoteAddress().c_str());
         return true;


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes idle time calculation in CharacterScreenIdleKick.

The values can be negative since m_idleTime is set after the sessionUpdateTime, because the logout packet is proccessed after the sessionUpdateTime is set.

### Proof
Proof that negative values are possible:
![idletime](https://github.com/vmangos/core/assets/10067406/95a12a70-8e0f-432b-a720-46e94d24fcd9)


### Issues
If `CharacterScreenMaxIdleTime` is set, session will close upon logout and skip character screen.

### How2Test
1. set `CharacterScreenMaxIdleTime` to any value
2. Login
3. Logout
4. Disconnected from server instead of character screen

