### PR TITLE
WIP Fix patch for AQ gate.

### DIFF
--- a/sql/migrations/20240709003249_world.sql
+++ b/sql/migrations/20240709003249_world.sql
@@ -20,7 +20,7 @@ UPDATE `gameobject_template` SET `name`='Doodad_Ahn_Qiraj_DoorRunes01', `patch`=
 
 -- Update old Gate of Ahn'Qiraj according to sniff
 DELETE FROM `game_event_gameobject` WHERE `guid`=66334 AND `event`=83;
-UPDATE `gameobject` SET `position_x`=-8133.61, `position_y`=1525.3, `position_z`=17.9576, `orientation`=-0.0261799, `rotation2`=-0.0130896, `rotation3`=0.999914, `patch_min`=0, `patch_max`=6 WHERE `entry`=176146;
+UPDATE `gameobject` SET `position_x`=-8133.61, `position_y`=1525.3, `position_z`=17.9576, `orientation`=-0.0261799, `rotation2`=-0.0130896, `rotation3`=0.999914, `patch_min`=0, `patch_max`=6 WHERE `id`=176146;
 
 -- Update old Ahn'Qiraj Gate Roots pre 1.9
 -- It should not be involved in any event

--- a/sql/migrations/20240709003249_world.sql
+++ b/sql/migrations/20240709003249_world.sql
@@ -1,0 +1,57 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20240709003249');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20240709003249');
+-- Add your query below.
+
+
+-- Update old AQ gong according to 1.8 sniff.
+UPDATE `gameobject` SET `orientation`=1.26536, `rotation2`=0.59131, `rotation3`=0.806445 WHERE `id`=177223;
+
+-- Correct custom names in gameobject_template to match 1.8 sniff and later sniffs:
+-- Gate of Ahn'Qiraj is Doodad_Ahn_Qiraj_DoorPlug01
+UPDATE `gameobject_template` SET `name`='Doodad_Ahn_Qiraj_DoorPlug01', `patch`=6, `faction`=114, `flags`=32 WHERE `entry`=176146;
+UPDATE `gameobject_template` SET `name`='Doodad_Ahn_Qiraj_DoorRoots01', `patch`=6, `faction`=114, `flags`=32 WHERE `entry`=176147;
+UPDATE `gameobject_template` SET `name`='Doodad_Ahn_Qiraj_DoorRunes01', `patch`=6, `faction`=114, `flags`=32 WHERE `entry`=176148;
+
+-- Update old Gate of Ahn'Qiraj according to sniff
+DELETE FROM `game_event_gameobject` WHERE `guid`=66334 AND `event`=83;
+UPDATE `gameobject` SET `position_x`=-8133.61, `position_y`=1525.3, `position_z`=17.9576, `orientation`=-0.0261799, `rotation2`=-0.0130896, `rotation3`=0.999914, `patch_min`=0, `patch_max`=6 WHERE `entry`=176146;
+
+-- Update old Ahn'Qiraj Gate Roots pre 1.9
+-- It should not be involved in any event
+DELETE FROM `game_event_gameobject` WHERE  `guid`=66335 AND `event`=83;
+-- Guess since object is not sniffed pre 1.9, mix between classic sniff and old screenshot
+UPDATE `gameobject` SET `position_x`=-8133.61, `position_y`=1525.3, `position_z`=17.9576, `orientation`=-0.043633, `rotation2`=-0.021815, `rotation3`=0.999762, `patch_min`=0, `patch_max`=6 WHERE `id`=176147;
+
+-- Update old Ahn'Qiraj Gate Runes pre 1.9
+-- It should not be involved in any event
+DELETE FROM `game_event_gameobject` WHERE  `guid`=66336 AND `event`=83;
+-- Guess object is not sniffed sniffed pre 1.9, mix between classic sniff and old screenshot
+UPDATE `gameobject` SET `position_x`=-8132.32, `position_y`=1525.26, `position_z`=17.8036, `orientation`=-0.0261799, `rotation2`=-0.0130896, `rotation3`=0.999914, `patch_min`=0, `patch_max`=6 WHERE `id`=176148;
+
+-- Post 1.9:
+-- Ancient Door
+UPDATE `gameobject` SET `patch_min`=7, `spawn_flags`=1, `visibility_mod`=350, `state`=1 WHERE `id`=180904;
+UPDATE `gameobject_template` SET `patch`=7 WHERE `entry`=180904;
+-- AQRUNE
+UPDATE `gameobject` SET `patch_min`=7, `state`=1, `spawn_flags`=1  WHERE `id`=180898;
+UPDATE `gameobject_template` SET `patch`=7 WHERE `entry`=180898;
+-- AQROOT
+UPDATE `gameobject` SET `patch_min`=7, `state`=1, `spawn_flags`=1  WHERE `id`=180899;
+UPDATE `gameobject_template` SET `patch`=7 WHERE `entry`=180899;
+
+-- Delete custom object from game_event_gameobject, object already deleted in 20230623091047_world.sql
+DELETE FROM `game_event_gameobject` WHERE  `guid`=3997168 AND `event`=83;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR corrects the following:
- Use correct AQ gate objects for post 1.9.
- Correct coordinates for pre 1.9 AQ gate objects.
- Fixes custom gameobject_template entries AQ gate objects pre 1.9.
- Use rotation from sniff for old gong.

### Proof
<!-- Link resources as proof -->
- 1.8.0 sniff for old AQ gate.
- Guessed position for old AQ gate rune and root, based on screenshots, since it was never sniffed in 1.8.0.

Vanilla unknown date pre 1.9:
![scarab_wall](https://github.com/vmangos/core/assets/6137576/70b57816-757d-4d58-9571-1cc04cd47bca)
Patch 1.8.1:
![WoWScrnShot_121005_112707](https://github.com/vmangos/core/assets/6137576/443144e2-2233-4813-95b3-20da1585fb48)
Unknown date pre patch 1.3, outside of server view distance of root and runes:
![04](https://github.com/vmangos/core/assets/6137576/6773b01b-9437-4c7f-821b-7707a6b12fdd)

Old AQ gate in vanilla pre patch 1.9:
![nomacs_qBb9dtYhip](https://github.com/vmangos/core/assets/6137576/88d7ba85-8686-4683-8899-357543f3115c)
Old AQ gate in vmangos after this PR applied:
![WoW_U7msC7yY0x](https://github.com/vmangos/core/assets/6137576/7bb23b57-87fa-40c6-a902-20f2ff001a17)

AQ gate post 1.9 in vmangos:
![WoW_iNVoF0vr4M](https://github.com/vmangos/core/assets/6137576/2cee69ad-23f4-4827-8098-bff3dba7c755)

AQ gate 1.9 vanilla:
![WoWScrnShot_022306_184652](https://github.com/vmangos/core/assets/6137576/756f52f3-ebec-4d8c-be39-0744ad0533bf)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Add positions for AQ rune and roots post 1.11. Unsure why blizz changed it.
- [ ] Fix silithus.cpp

