### PR TITLE
fixing humanoids and undead being pickpocketable when they shouldnt be

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6692,8 +6692,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                 if (!target || target->GetOwnerGuid().IsPlayer())
                     return SPELL_FAILED_BAD_TARGETS;
 
-                if (!target->GetCreatureInfo()->pickpocket_loot_id &&
-                    !(target->GetCreatureTypeMask() & CREATURE_TYPEMASK_HUMANOID_OR_UNDEAD))
+                if (!target->GetCreatureInfo()->pickpocket_loot_id)
                     return SPELL_FAILED_TARGET_NO_POCKETS;
 
                 break;


### PR DESCRIPTION
## 🍰 Pullrequest
This will change so that all humanoids and undead are no longer pickpocketable, only the ones that should be (as in, those that have a corresponding entry in *pickpocketing_loot_template*). This is done by removing the check for creature type, which appears to have been errantly written so pickpocket was succesful if the type was correct but even if the creature didnt have a pickpocket loot table.

### Issues
[*All* humans and undead are pickpocketable, even if they shouldn't be #2728](https://github.com/vmangos/core/issues/2728)

### How2Test
To test pick pocket you can log in on GM account and do ``.learn 921`` and ``.learn 1787`` and then do ``.go cr "creature name"`` to teleport to the creature you want to check.

Here are a few examples of creatures that have no pickpocket-entry but are still pickpocketable currently: [Ice Thistle Yeti](https://www.wowhead.com/classic/npc=7458/ice-thistle-yeti), [Ragged Owlbeast](https://www.wowhead.com/classic/npc=7450/ragged-owlbeast), [Hungering Wraith](https://www.wowhead.com/classic/npc=1802/hungering-wraith), [Wailing Death](https://www.wowhead.com/classic/npc=1804/wailing-death). The SQL query ``SELECT * FROM pickpocketing_loot_template WHERE entry IN (7458, 7450, 1802, 1804)`` will give no results, meaning they shouldn't be pickpocketable, but if you try it ingame they actually are.

If you want more examples of humanoids and undead with no pickpocket-entry you could try this SQL query: ``SELECT entry, name FROM creature_template WHERE type IN (6,7) AND NOT EXISTS (SELECT * FROM pickpocketing_loot_template AS pplt WHERE pplt.entry = creature_template.entry)``