### PR TITLE
Native Branch: Fix crash on related to `ThreadSpecificPtr<T>`

### DIFF
--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -36,6 +36,7 @@ set(framework_SRCS
   Policies/Singleton.h
   Policies/SingletonImp.h
   Policies/ThreadingModel.h
+  Policies/NoCopyNoMove.h
   Utilities/ByteConverter.h
   Utilities/EventProcessor.h
   Utilities/EventMap.h

--- a/src/framework/Policies/NoCopyNoMove.h
+++ b/src/framework/Policies/NoCopyNoMove.h
@@ -1,0 +1,18 @@
+#ifndef MANGOS_POLICIES_NONCOPYABLE_H
+#define MANGOS_POLICIES_NONCOPYABLE_H
+
+namespace MaNGOS { namespace Policies
+{
+    struct NoCopyNoMove {
+      protected:
+        NoCopyNoMove() = default;
+        ~NoCopyNoMove() = default;
+      public:
+        NoCopyNoMove(NoCopyNoMove const&) = delete;
+        NoCopyNoMove& operator=(NoCopyNoMove const&) = delete;
+        NoCopyNoMove(NoCopyNoMove&&) = delete;
+        NoCopyNoMove& operator=(NoCopyNoMove&&) = delete;
+    };
+}} // namespace MaNGOS::Policies
+
+#endif //MANGOS_POLICIES_NONCOPYABLE_H

--- a/src/shared/ThreadSpecificPtr.cpp
+++ b/src/shared/ThreadSpecificPtr.cpp
@@ -1,3 +1,13 @@
 #include "./ThreadSpecificPtr.h"
+#include "Errors.h"
 
-thread_local std::map<void* /* class instance */, void* /* thread specific object */> MaNGOS::thread_specific_ptr_data;
+thread_local MaNGOS::ThreadSpecificHolder MaNGOS::gtl_ThreadSpecificPtrHolder;
+
+MaNGOS::ThreadSpecificHolder::~ThreadSpecificHolder()
+{
+    for (auto it : thread_specific_ptr_data)
+    {
+        // Every reference must be deleted before the holder is deallocated, otherwise memory will leak
+        MANGOS_ASSERT(it.second == nullptr);
+    }
+}


### PR DESCRIPTION
## 🍰 Pullrequest
`thread_local` variables are deallocated before `global` variables do.
Which caused a use-after-free bug, when the a global referenced `Database` is deallocated and tries to deallocate a `ThreadSpecificPtr`.
