### PR TITLE
Native Branch: Socket Connector

### DIFF
--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -121,6 +121,8 @@ set (shared_SRCS
     IO/Networking/AsyncSocketAcceptor.h
     IO/Networking/AsyncSocketAcceptor_posix.cpp
     IO/Networking/AsyncSocketAcceptor_windows.cpp
+    IO/Networking/SocketConnector.h
+    IO/Networking/SocketConnector.cpp
     IO/Networking/NetworkError.h
     IO/Networking/NetworkError.cpp
     IO/Networking/SocketDescriptor.h

--- a/src/shared/IO/Filesystem/impl/unix/FileHandle.cpp
+++ b/src/shared/IO/Filesystem/impl/unix/FileHandle.cpp
@@ -17,7 +17,7 @@ void IO::Filesystem::FileHandle::Seek(IO::Filesystem::SeekDirection direction, i
                         : direction == SeekDirection::Current ? SEEK_CUR
                                                               : SEEK_END;
 
-    MANGOS_ASSERT(::lseek64(m_nativeFileHandle, offset, nativeDirection) != -1);
+    MANGOS_ASSERT(::lseek(m_nativeFileHandle, offset, nativeDirection) != -1);
 }
 
 uint64_t IO::Filesystem::FileHandle::GetTotalFileSize() const

--- a/src/shared/IO/Networking/AsyncSocket_posix.cpp
+++ b/src/shared/IO/Networking/AsyncSocket_posix.cpp
@@ -527,7 +527,7 @@ void IO::Networking::AsyncSocket::OnIoEvent(uint32_t event)
         {
             int error = 0;
             socklen_t errlen = sizeof(error);
-            if (::getsockopt(m_socket._nativeSocket, SOL_SOCKET, SO_ERROR, (void*)&error, &errlen) == 0)
+            if (::getsockopt(m_descriptor.GetNativeSocket(), SOL_SOCKET, SO_ERROR, (void*)&error, &errlen) == 0)
             {
                 sLog.Out(LOG_NETWORK, LOG_LVL_ERROR, "kqueue reported socket exception: Error: %s", SystemErrorToCString(error));
 

--- a/src/shared/IO/Networking/Internal.cpp
+++ b/src/shared/IO/Networking/Internal.cpp
@@ -10,7 +10,7 @@
 #include <arpa/inet.h>
 #endif
 
-/// Converts a native IN_ADDR to a IO::Networking::IpAddress
+/// Converts a native `IN_ADDR` to a `IO::Networking::IpAddress`
 IO::Networking::IpAddress IO::Networking::Internal::inet_ntop(in_addr const* nativeAddress)
 {
 #if defined(WIN32)
@@ -39,6 +39,22 @@ void IO::Networking::Internal::CloseSocket(IO::Native::SocketHandle nativeSocket
     ::closesocket(nativeSocket);
 #elif defined(__linux__) || defined(__APPLE__)
     ::close(nativeSocket);
+#else
+    #error "Unsupported platform"
+#endif
+}
+
+// Converts a `IO::Networking::IpAddress` to a native `IN_ADDR`
+void IO::Networking::Internal::inet_pton(IO::Networking::IpAddress const& ipAddress, in_addr* out_dest)
+{
+    MANGOS_ASSERT(ipAddress.getType() == IpAddress::Type::IPv4);
+
+#if defined(WIN32)
+    // We cant use `inet_pton`, because it's not supported on WinXP.
+    // But this method would basically just take the iternal representation and store it in a union anyways ¯\_(ツ)_/¯
+    out_dest->s_addr = ::htonl(ipAddress._getInternalIPv4ReprAsUint32());
+#elif defined(__linux__) || defined(__APPLE__)
+    MANGOS_ASSERT(::inet_pton(AF_INET, ipAddress.toString().c_str(), out_dest) == 1);
 #else
     #error "Unsupported platform"
 #endif

--- a/src/shared/IO/Networking/Internal.h
+++ b/src/shared/IO/Networking/Internal.h
@@ -8,8 +8,10 @@ struct in_addr;
 
 namespace IO { namespace Networking { namespace Internal
 {
-    /// Converts a native IN_ADDR to a IO::Networking::IpAddress
+    /// Converts a native `IN_ADDR` to a `IO::Networking::IpAddress`
     IO::Networking::IpAddress inet_ntop(in_addr const* nativeAddress);
+    // Converts a `IO::Networking::IpAddress` to a native `IN_ADDR`
+    void inet_pton(IO::Networking::IpAddress const& ipAddress, in_addr* out_dest);
 
     /// Closes a socket
     void CloseSocket(IO::Native::SocketHandle nativeSocket);

--- a/src/shared/IO/Networking/NetworkError.h
+++ b/src/shared/IO/Networking/NetworkError.h
@@ -10,9 +10,10 @@ namespace IO
         enum class ErrorType : int
         {
             NoError,
-            InternalError,
+            InternalError, // see m_additionalOsErrorCode
             SocketClosed,
             OnlyOneTransferPerDirectionAllowed,
+            Timeout,
         };
     public:
         explicit constexpr NetworkError(ErrorType errorType) : NetworkError(errorType, 0) {};

--- a/src/shared/IO/Networking/SocketConnector.cpp
+++ b/src/shared/IO/Networking/SocketConnector.cpp
@@ -1,0 +1,108 @@
+#include "SocketConnector.h"
+#include "Internal.h"
+
+#if defined(__linux__) || defined(__APPLE__)
+    #include <sys/socket.h>
+    #include <netinet/in.h>
+    #include <arpa/inet.h>
+    #include "IO/Utils_Unix.h"
+    #define GetNetworkError() errno
+#elif defined(WIN32)
+    #include <WinSock2.h>
+    #include <WS2tcpip.h>
+    #define GetNetworkError() ::WSAGetLastError()
+#endif
+
+#if defined(__linux__)
+    #include <sys/epoll.h>
+    #include <fcntl.h>
+#elif defined(__APPLE__)
+    #include <sys/event.h>
+    #include <unistd.h>
+#endif
+
+
+
+nonstd::expected<IO::Networking::SocketDescriptor, IO::NetworkError> IO::Networking::SocketConnector::ConnectBlocking(IO::Networking::IpEndpoint const& target, std::chrono::milliseconds timeoutMs)
+{
+    IO::Native::SocketHandle nativeSocket = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (nativeSocket == -1)
+    {
+        return nonstd::make_unexpected(IO::NetworkError(NetworkError::ErrorType::InternalError, GetNetworkError()));
+    }
+
+    ::sockaddr_in targetAddress{};
+    targetAddress.sin_family = AF_INET;
+    targetAddress.sin_port = htons(target.port);
+    IO::Networking::Internal::inet_pton(target.ip, &(targetAddress.sin_addr));
+
+    // Set socket to non-blocking mode, so the `::connect` does not block
+
+#if defined(__linux__) || defined(__APPLE__)
+    IO::NetworkError err = IO::Utils::SetFdStatusFlag(nativeSocket, O_NONBLOCK);
+    if (err)
+        return nonstd::make_unexpected(err);
+#elif defined(WIN32)
+    u_long mode = 1;
+    int ioCtlStatus = ::ioctlsocket(nativeSocket, FIONBIO, &mode);
+    if (ioCtlStatus != 0)
+        return nonstd::make_unexpected(IO::NetworkError(NetworkError::ErrorType::InternalError, GetNetworkError()));
+#endif
+
+    int result = ::connect(nativeSocket, (struct sockaddr *)&targetAddress, sizeof(targetAddress));
+    if (result == -1)
+    {
+        int lastError = GetNetworkError();
+        if (lastError !=
+#if defined(__linux__) || defined(__APPLE__)
+        EINPROGRESS
+#elif defined(WIN32)
+        WSAEWOULDBLOCK
+#endif
+        )
+        { // Oh, this is an actual error :(
+            IO::Networking::Internal::CloseSocket(nativeSocket);
+            return nonstd::make_unexpected(IO::NetworkError(NetworkError::ErrorType::InternalError, lastError));
+        }
+    }
+
+    ::timeval tv{};
+    tv.tv_sec = (long)(timeoutMs.count() / 1000L);
+    tv.tv_usec = (long)((timeoutMs.count() % 1000L) * 1000L);
+
+    ::fd_set selectFileDescriptors;
+    FD_ZERO(&selectFileDescriptors);
+    FD_SET(nativeSocket, &selectFileDescriptors);
+
+    // wait for some kind response
+    int selectStatus = ::select(nativeSocket + 1, &selectFileDescriptors, &selectFileDescriptors, &selectFileDescriptors, &tv);
+    if (selectStatus == -1)
+    { // ::select internal error
+        int lastError = GetNetworkError();
+        IO::Networking::Internal::CloseSocket(nativeSocket);
+        return nonstd::make_unexpected(IO::NetworkError(NetworkError::ErrorType::InternalError, lastError));
+    }
+
+    if (selectStatus == 0)
+    { // timeout
+        IO::Networking::Internal::CloseSocket(nativeSocket);
+        return nonstd::make_unexpected(IO::NetworkError(NetworkError::ErrorType::Timeout, 0));
+    }
+
+    int socketError = 0;
+    socklen_t socketErrorLength = sizeof(socketError);
+    int getSocketOptStatus = ::getsockopt(nativeSocket, SOL_SOCKET, SO_ERROR, (char*)&socketError, &socketErrorLength);
+    if (getSocketOptStatus != 0)
+    {
+        IO::Networking::Internal::CloseSocket(nativeSocket);
+        return nonstd::make_unexpected(IO::NetworkError(NetworkError::ErrorType::InternalError, GetNetworkError()));
+    }
+
+    if (socketError != 0)
+    {
+        IO::Networking::Internal::CloseSocket(nativeSocket);
+        return nonstd::make_unexpected(IO::NetworkError(NetworkError::ErrorType::InternalError, socketError));
+    }
+
+    return IO::Networking::SocketDescriptor(nativeSocket, target);
+}

--- a/src/shared/IO/Networking/SocketConnector.h
+++ b/src/shared/IO/Networking/SocketConnector.h
@@ -1,0 +1,67 @@
+#ifndef MANGOS_IO_NETWORKING_ASYNCSOCKETCONNECTOR_H
+#define MANGOS_IO_NETWORKING_ASYNCSOCKETCONNECTOR_H
+
+#include <chrono>
+#include "SocketDescriptor.h"
+#include "NetworkError.h"
+
+#include "nonstd/expected.hpp"
+
+namespace IO { namespace Networking
+{
+    /** Helper class to create a SocketDescriptor which connects to another server
+    \example
+
+    // Create IpEndpoint
+    auto maybeIp = IO::Networking::IpAddress::TryParseFromString("127.0.0.1");
+    MANGOS_ASSERT(maybeIp.has_value());
+    IO::Networking::IpAddress ip = maybeIp.value();
+    uint16 port = 8080;
+    IO::Networking::IpEndpoint endpoint(ip, port);
+
+    // Try to connect
+    auto maybeSocketDescriptor = IO::Networking::SocketConnector::ConnectBlocking(endpoint, std::chrono::seconds(10));
+    MANGOS_ASSERT(maybeSocketDescriptor.has_value());
+
+    // Bind socketDescriptor to AsyncSocket and initialize
+    auto socket = std::make_shared<IO::Networking::AsyncSocket>(ctx, std::move(maybeSocketDescriptor.value()));
+    MANGOS_ASSERT(!(socket->InitializeAndFixMemoryLocation()));
+
+    // Send example request
+    std::string requestString = "Hello World!!!";
+    std::vector<char> request(requestString.begin(), requestString.end());
+    socket->Write(std::move(request), [socket](IO::NetworkError const& error)
+    {
+        MANGOS_ASSERT(!error);
+
+        // Receive the response
+        auto response = std::make_shared<std::vector<char>>();
+        response->resize(1024);
+        socket->ReadSome(response->data(), response->size(), [socket, response](IO::NetworkError const& error, size_t actuallyRead)
+        {
+            MANGOS_ASSERT(!error);
+
+            std::string responseString(response->data(), actuallyRead);
+            std::cout << responseString << std::endl;
+            socket->CloseSocket();
+        });
+    });
+     */
+    class SocketConnector
+    {
+    public:
+        SocketConnector() = delete;
+
+        template <class Rep, class Period>
+        static nonstd::expected<IO::Networking::SocketDescriptor, IO::NetworkError> ConnectBlocking(IO::Networking::IpEndpoint const& target, std::chrono::duration<Rep, Period> timeout)
+        {
+            return ConnectBlocking(target, std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
+        }
+
+        /// Creates a socket and connects it to the target endpoint.
+        /// Check for errors in the return value.
+        static nonstd::expected<IO::Networking::SocketDescriptor, IO::NetworkError> ConnectBlocking(IO::Networking::IpEndpoint const& target, std::chrono::milliseconds timeoutMs);
+    };
+}} // namespace IO::Networking
+
+#endif // MANGOS_IO_NETWORKING_ASYNCSOCKETCONNECTOR_H


### PR DESCRIPTION
## 🍰 Pullrequest
This PR introduces a `SocketConnector` to the `IO::Networking` namespace, enabling developers to connect to remote hosts.

While it’s not currently used in the codebase, connecting to remote hosts is a common feature in networking libraries, beyond just accepting sockets. It's also useful for some custom projects. With the recent refactor making it easier to pass arbitrary `SocketDescriptors`, I decided to add this feature.
