### PR TITLE
prevent negative threat

### DIFF
--- a/src/game/Threat/ThreatManager.cpp
+++ b/src/game/Threat/ThreatManager.cpp
@@ -101,6 +101,9 @@ void HostileReference::fireStatusChanged(ThreatRefStatusChangeEvent& pThreatRefS
 void HostileReference::addThreat(float pMod)
 {
     iThreat += pMod;
+    if (iThreat < 0)
+        iThreat = 0;
+
     // the threat is changed. Source and target unit have to be availabe
     // if the link was cut before relink it again
     if (!isOnline())


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Prevents threat from going negative when using threat reducing spells

### Proof
<!-- Link resources as proof -->
- Threat reducing spells was tested on classic ptr according to the bugreport i linked
- I can't think of any circumstance that would have threat going negative on official realms

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/vmangos/core/issues/2735

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a hunter
- .learn all_myspells
- Spam Disengage on any mob without doing any damage.
- Target mob and use .list threat.
- Threat will be negative. before this PR - and 0 after this PR is applied


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
