### PR TITLE
Fix (potentially) undefined behaviour with std::transform and tolower/toupper

### DIFF
--- a/dep/src/g3dlite/stringutils.cpp
+++ b/dep/src/g3dlite/stringutils.cpp
@@ -11,6 +11,7 @@
 #include "G3D/stringutils.h"
 #include "G3D/BinaryInput.h"
 #include <algorithm>
+#include <cctype>
 
 #ifdef _MSC_VER
 extern "C" {    
@@ -215,14 +216,20 @@ int stringPtrCompare(
 
 std::string toUpper(const std::string& x) {
     std::string result = x;
-    std::transform(result.begin(), result.end(), result.begin(), toupper);
+    std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c)
+    {
+        return std::toupper(c);
+    });
     return result;
 }
 
 
 std::string toLower(const std::string& x) {
     std::string result = x;
-    std::transform(result.begin(), result.end(), result.begin(), tolower);
+    std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c)
+    {
+        return std::tolower(c);
+    });
     return result;
 }
 

--- a/src/shared/Util.h
+++ b/src/shared/Util.h
@@ -25,6 +25,7 @@
 #include "Common.h"
 #include "Duration.h"
 
+#include <cctype>
 #include <string>
 #include <vector>
 
@@ -335,12 +336,18 @@ inline bool isLeapYear(int year)
 
 inline void strToUpper(std::string& str)
 {
-    std::transform(str.begin(), str.end(), str.begin(), toupper);
+    std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c)
+    {
+        return std::toupper(c);
+    });
 }
 
 inline void strToLower(std::string& str)
 {
-    std::transform(str.begin(), str.end(), str.begin(), tolower);
+    std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c)
+    {
+        return std::tolower(c);
+    });
 }
 
 inline wchar_t wcharToUpper(wchar_t wchar)


### PR DESCRIPTION
## 🍰 Pull request
Fixes two potential problems with using tolower/toupper with std::transform. The first being that the argument should be converted explicitly to an unsigned char when used with iterators of type char (std::string) and second being non-addressable functions shouldn't be passed to the standard algorithms (applies to std::*).

### Proof
- https://en.cppreference.com/w/cpp/string/byte/tolower
- https://en.cppreference.com/w/cpp/string/byte/toupper
- https://devblogs.microsoft.com/oldnewthing/20241007-00/?p=110345

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
