### PR TITLE
Explicitly set time period on Windows

### DIFF
--- a/src/mangosd/WorldRunnable.cpp
+++ b/src/mangosd/WorldRunnable.cpp
@@ -32,6 +32,7 @@
 #include "MapManager.h"
 #include "BattleGroundMgr.h"
 #include "Master.h"
+#include "TimePeriod.h"
 
 #include "Database/DatabaseEnv.h"
 
@@ -52,6 +53,9 @@ void WorldRunnable::operator()()
 
     Master::ArmAnticrash();
     uint32 anticrashRearmTimer = 0;
+
+    // Set the platform's timer period
+    const auto scoped_tp = set_time_period(std::chrono::milliseconds(1));
 
     // Aim for WORLD_SLEEP_CONST update times
     // If we update slower, update again immediately.

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -66,6 +66,7 @@ set (shared_SRCS
     Database/SQLStorageImpl.h
     Multithreading/Messager.h
     SRP6/SRP6.h
+    TimePeriod.h
     nonstd/optional.hpp
     ByteBuffer.cpp
     Common.cpp
@@ -99,6 +100,7 @@ set (shared_SRCS
     Database/SQLStorage.cpp
     Multithreading/Messager.cpp
     SRP6/SRP6.cpp
+    TimePeriod.cpp
 )
 
 if(USE_LIBCURL)

--- a/src/shared/TimePeriod.cpp
+++ b/src/shared/TimePeriod.cpp
@@ -1,0 +1,40 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "TimePeriod.h"
+
+#ifdef _WIN32
+	#include <Windows.h>
+	#pragma comment(lib, "Winmm.lib")
+#endif
+
+// That's right, this only does something on Windows
+ScopedTimerPeriod set_time_period(const std::chrono::milliseconds ms)
+{
+#ifdef _WIN32
+    auto count = ms.count();
+    const auto result = timeBeginPeriod(count);
+
+    ScopedTimerPeriod sf(result == TIMERR_NOERROR, [count]
+    {
+      timeEndPeriod(count);
+    });
+
+	return sf;
+#else
+	return { true, [] {} };
+#endif
+}

--- a/src/shared/TimePeriod.h
+++ b/src/shared/TimePeriod.h
@@ -1,0 +1,52 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef _TIMEPERIOD_H
+#define _TIMEPERIOD_H
+
+#include <chrono>
+#include <functional>
+#include <utility>
+
+/*
+ * Allows for setting the timer period, ensuring that
+ * it's reset to its original value when leaving scope
+ */
+class ScopedTimerPeriod final
+{
+    public:
+        using Callback = std::function<void()>;
+
+        ScopedTimerPeriod(bool success, Callback cb): success_(success), cb_(std::move(cb)) {}
+
+	    bool success() const
+        {
+            return success_;
+        }
+
+        ~ScopedTimerPeriod()
+        {
+            cb_();
+        }
+
+    private:
+        Callback cb_;
+        bool success_;
+};
+
+ScopedTimerPeriod set_time_period(std::chrono::milliseconds ms);
+
+#endif


### PR DESCRIPTION
## 🍰 Pull request
The core uses sleep to control update timing. On modern versions of Windows, timing granularity is set per process rather than globally. This means that each process which needs fine-grained timers (this includes sleep) should be setting the time period themselves. If a process doesn't do this, calling sleep with smaller values may cause the process to sleep for longer than expected (likely ~15ms minimum).

The implementation uses RAII to reset the timer period once the core shuts down. This isn't strictly required as it'll be reset when the process exists but is considered good etiquette. The #ifdefs are limited to the implementation rather than clogging up the function.

### Proof
- https://randomascii.wordpress.com/2020/10/04/windows-timer-resolution-the-great-rule-change/
- https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod

Specifically:
`Starting with Windows 10, version 2004, this function no longer affects global timer resolution. ... For processes which have not called this function, Windows does not guarantee a higher resolution than the default system resolution.`

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
