### PR TITLE
forsaken skills

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1457,6 +1457,9 @@ void Aura::TriggerSpell()
         {
             case 7054:
                 spellRandom = urand(0, 14) + 7038;
+                if (spellRandom == 7052)
+                    spellRandom = 7053;
+
                 target->CastSpell(target, spellRandom, true, nullptr, this);
                 return;
                 break;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1115,8 +1115,6 @@ void Aura::TriggerSpell()
     uint32 auraId = auraSpellInfo->Id;
     Unit* target = GetTarget();
 
-    uint32 spellRandom;
-
     // not in banished state
     if (triggerTarget->HasUnitState(UNIT_STAT_ISOLATED))
         return;
@@ -1456,13 +1454,14 @@ void Aura::TriggerSpell()
         switch (auraId)
         {
             case 7054:
-                spellRandom = urand(0, 14) + 7038;
+            {
+                uint32 spellRandom = urand(0, 14) + 7038;
                 if (spellRandom == 7052)
                     spellRandom = 7053;
 
                 target->CastSpell(target, spellRandom, true, nullptr, this);
                 return;
-                break;
+            }
             case 8892:  // Goblin Rocket Boots
             case 13141: // Gnomish Rocket Boots
                 // FIXME: Confirm that the chance for rocket boots to explode in retail is actually meant to be 1% per-tick or 1/5 overall

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1456,6 +1456,7 @@ void Aura::TriggerSpell()
             case 7054:
             {
                 uint32 spellRandom = urand(0, 14) + 7038;
+                // spellRandom contains a random number from 7038 to 7052. But the available spells range from 7038 to 7051 and 7053. So we increase 7052 to 7053
                 if (spellRandom == 7052)
                     spellRandom = 7053;
 
@@ -6662,6 +6663,7 @@ void Aura::PeriodicDummyTick()
                 case 7054:
                 {
                     uint32 spellRandom = urand(0, 14) + 7038;
+                    // spellRandom contains a random number from 7038 to 7052. But the available spells range from 7038 to 7051 and 7053. So we increase 7052 to 7053
                     if (spellRandom == 7052)
                         spellRandom = 7053;
 

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6660,6 +6660,9 @@ void Aura::PeriodicDummyTick()
                 case 7054:
                 {
                     uint32 spellRandom = urand(0, 14) + 7038;
+                    if (spellRandom == 7052)
+                        spellRandom = 7053;
+
                     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "7054 %u", spellRandom);
 
                     target->CastSpell(target, spellRandom, true, nullptr, this);

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6663,8 +6663,6 @@ void Aura::PeriodicDummyTick()
                     if (spellRandom == 7052)
                         spellRandom = 7053;
 
-                    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "7054 %u", spellRandom);
-
                     target->CastSpell(target, spellRandom, true, nullptr, this);
                     // Possibly need cast one of them (but
                     // 7038 Forsaken Skill: Swords


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Allows spell [7054 forsaken-skills](https://www.wowhead.com/classic/spell=7054/forsaken-skills) to proc [7053 forsaken-skill-shadow](https://www.wowhead.com/classic/spell=7053/forsaken-skill-shadow)

### Proof
<!-- Link resources as proof -->
- From the comments following the code, it looks like 7053 was mistaken for 7052
- I have verified that all 15 spells exist in the clients from 1.2.4 to 1.12.1 - and spell 7052 exists in none of them

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
A different approach of fixing this, could be by using PickRandomValue(). 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
