### PR TITLE
Fix idol of the moon bonus damage

### DIFF
--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -1369,10 +1369,19 @@ float SpellCaster::SpellDamageBonusDone(Unit const* pVictim, SpellEntry const* s
             {
                 case 4418: // Increased Shock Damage
                 case 4554: // Increased Lightning Damage
-                case 4555: // Improved Moonfire
                 {
                     DoneTotal += i->GetModifier()->m_amount;
                     break;
+                }
+                case 4555: // Improved Moonfire (Idol of the moon)
+                {
+                    uint32 divisor = 800;
+                    if (damagetype == DOT)
+                    {
+                        divisor = 100 * spellProto->GetAuraMaxTicks();
+                    }
+
+                    DoneTotal += i->GetModifier()->m_amount * pdamage / divisor;
                 }
             }
         }

--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -1375,6 +1375,10 @@ float SpellCaster::SpellDamageBonusDone(Unit const* pVictim, SpellEntry const* s
                 }
                 case 4555: // Improved Moonfire (Idol of the moon)
                 {
+                    // Idol of the moon was bugged during vanilla 1.12
+                    // Following math is based on reported numbers from classic and an old post on allakhazam and wowhead classic
+                    // Direct damage bonus = 17/8 % and Dot damage bonus = 17/tickcount %
+                    // Further information and discussion can be found at vmangos PR #2802
                     uint32 divisor = 800;
                     if (damagetype == DOT)
                     {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changes how Idol of the moon bonus damage is calculated. 
Note: I can't find any evidence that this idol added 17% as stated by the item tooltip - more info linked further below.

Before this PR:

- add +17 damage

After this PR:

- add 17/8 % to direct basedamage part of moonfire
- add 17 % to **total** tick basedamage 

For rank 10 moonfire this equals to: 
- ~4.5 damage per tick
- 4.14375 to 4.485 damage to direct damage. That averages to 4.314375

### Proof
<!-- Link resources as proof -->
[Patch 1.12.1 Known Issues
](https://www.bluetracker.gg/wow/topic/us-en/28306354-patch-1121-known-issues/)
Spell damage awarded from Idol of the Moon is inconsistent with it's tooltip.

Posted on Druid classic discord: https://discord.com/channels/253205420225724416/253206622522834945/743124572475490316
![image](https://github.com/user-attachments/assets/6426ee3e-c620-4174-af36-953e87b6feb6)
Image represents Rank 10 moonfire direct damage. From my interpretation that looks like 4-5 damage difference. No raw data available.

From [wowhead comments](https://www.wowhead.com/classic/item=23197/idol-of-the-moon#comments): 
![image](https://github.com/user-attachments/assets/4c17c2af-e012-4918-ad30-9e5bdc9b9410)
(note: edited for easier readability)
This equals an increase by 4.325 damage - since the tests mention crits, we can deduce that this is the direct damage part. 

![image](https://github.com/user-attachments/assets/a7361ea7-929f-45aa-9236-5d8d3044835d)
Tick damage.

### Counterproof

There are also comments on druid classic discord that mention its 20 + 20 damage. 20 direct damage and 4 x 5 dot damage. None of those comments are backed up by evidence, and seems to be a constant copy/pasta response based on initial testing. Since the direct damage portion of the spell varies by 36 damage - tests with low samplesize could be missleading.

![image](https://github.com/user-attachments/assets/1ba6fa40-796e-4928-ae0e-91daca2c0591)
Mentions of a GM talking about how this spell could negate other bonusses. I can't deduce any math formula that would negate the "Improve Moonfire" talents and give the expected results.

It's **not** possible to test this ERA PTR, since Blizzard changed the item to its TBC version which adds +33 damage.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- Tick damage is still 0.5 lower per tick, than what has been reported on the sources I could find. But it's so close to 17% divided by ticks, that I decided to stick with that.