### PR TITLE
Remove `USE_ANTICHEAT` from cmake

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -102,7 +102,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         mkdir buildac
         cd buildac
-        cmake -D TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb -DWITH_WARNINGS=0 -DUSE_EXTRACTORS=1 -DUSE_ANTICHEAT=1 -G "Visual Studio 16 2019" -A x64 ..
+        cmake -D TBB_ROOT_DIR=$GITHUB_WORKSPACE/tbb -DWITH_WARNINGS=0 -DUSE_EXTRACTORS=1 -G "Visual Studio 16 2019" -A x64 ..
         /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe "MaNGOS.sln" //p:Platform=x64 //p:Configuration=Release //m:2
       #git bash shell
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ set(SUPPORTED_CLIENT_BUILD "CLIENT_BUILD_1_12_1" CACHE STRING "Client version th
 option(USE_STD_MALLOC "Use standard malloc instead of TBB" OFF)
 option(BUILD_FOR_HOST_CPU "Build specifically for the host CPU via `-march=native` (might not run on different machines)" ON)
 option(TBB_DEBUG "Use TBB debug librairies" OFF)
-option(USE_ANTICHEAT "Use anticheat" OFF)
 option(USE_SCRIPTS "Compile scripts" ON)
 option(USE_EXTRACTORS "Compile extractors" OFF)
 option(USE_LIBCURL "Compile with libcurl for email support" OFF)
@@ -325,13 +324,6 @@ else()
 endif()
 
 message(STATUS "Build type            : ${CMAKE_BUILD_TYPE}")
-
-if(USE_ANTICHEAT)
-  message(STATUS "Use anticheat         : Yes")
-  set(DEFINITIONS ${DEFINITIONS} USE_ANTICHEAT)
-else()
-  message(STATUS "Use anticheat         : No  (default)")
-endif()
 
 if(USE_SCRIPTS)
   message(STATUS "Build scripts         : Yes (default)")

--- a/src/game/Anticheat/Anticheat.cpp
+++ b/src/game/Anticheat/Anticheat.cpp
@@ -27,8 +27,6 @@ AnticheatManager* GetAnticheatLib()
     return AnticheatManager::instance();
 }
 
-#ifdef USE_ANTICHEAT
-
 #include "World.h"
 #include "WorldSession.h"
 
@@ -55,7 +53,7 @@ void AnticheatManager::LoadAnticheatData()
     sLog.Out(LOG_ANTICHEAT, LOG_LVL_MINIMAL, "Loading warden checks...");
     sWardenScanMgr.LoadFromDB();
     Warden::LoadScriptedScans();
-    
+
     sLog.Out(LOG_ANTICHEAT, LOG_LVL_MINIMAL, "");
     sLog.Out(LOG_ANTICHEAT, LOG_LVL_MINIMAL, "Loading warden modules...");
     sWardenModuleMgr;
@@ -179,4 +177,3 @@ void AnticheatManager::RemoveWardenSession(Warden* warden)
     m_wardenSessionsToRemove.push_back(warden);
 }
 
-#endif

--- a/src/game/Anticheat/Anticheat.h
+++ b/src/game/Anticheat/Anticheat.h
@@ -73,65 +73,14 @@ public:
     virtual void showMuted(WorldSession* session) {}
 };
 
-#ifdef USE_ANTICHEAT
 #include "WardenAnticheat/Warden.hpp"
 #include "MovementAnticheat/MovementAnticheat.h"
 #include <mutex>
 #include <thread>
-#else
-class Warden
-{
-protected: // forbid instantiation
-    Warden() = default;
-public:
-    ~Warden() = default;
-    void HandlePacket(WorldPacket&) {}
-    virtual void Update() {}
-    virtual void GetPlayerInfo(std::string&, std::string&, std::string&, std::string&, std::string&) const {}
-    bool HasUsedClickToMove() const { return false; }
-};
-
-class MovementAnticheat
-{
-public:
-    MovementAnticheat() = default;
-    ~MovementAnticheat() = default;
-
-    void Init() {}
-    void InitNewPlayer(Player* pPlayer) {}
-    void ResetJumpCounters() {}
-
-    bool IsInKnockBack() const { return false; }
-
-    uint32 Update(Player* pPlayer, uint32 diff, std::stringstream& reason) { return CHEAT_ACTION_NONE; }
-    uint32 Finalize(Player* pPlayer, std::stringstream& reason) { return CHEAT_ACTION_NONE; }
-    void AddCheats(uint32 cheats, uint32 count = 1) {}
-    void HandleCommand(ChatHandler* handler) const {}
-    void OnKnockBack(Player* pPlayer, float speedxy, float speedz, float cos, float sin) {}
-
-    void OnUnreachable(Unit* attacker) {}
-    void OnExplore(AreaEntry const* pArea) {}
-    void OnWrongAckData() {};
-    void OnFailedToAckChange() {};
-    void OnDeath() {};
-
-    /*
-    pPlayer - player who is being moved (not necessarily same as this session's player)
-    movementInfo - new movement info that was just received
-    opcode - the packet we are checking
-    */
-    uint32 HandlePositionTests(Player* /*pPlayer*/, MovementInfo& /*movementInfo*/, uint16 /*opcode*/) { return 0; }
-    uint32 HandleFlagTests(Player* /*pPlayer*/, MovementInfo& /*movementInfo*/, uint16 /*opcode*/) { return 0; }
-    bool HandleSplineDone(Player* /*pPlayer*/, MovementInfo const& /*movementInfo*/, uint32 /*splineId*/) { return true; }
-    void LogMovementPacket(bool /*isClientPacket*/, WorldPacket const& /*packet*/) {}
-    static bool IsLoggedOpcode(uint16 /*opcode*/) { return false; }
-};
-#endif
 
 class AnticheatManager
 {
 public:
-#ifdef USE_ANTICHEAT
     ~AnticheatManager();
     void LoadAnticheatData();
 
@@ -154,24 +103,6 @@ private:
     std::vector<Warden*> m_wardenSessionsToRemove;
     std::mutex m_wardenSessionsMutex;
     std::thread m_wardenUpdateThread;
-#else
-    void LoadAnticheatData() {}
-
-    Warden* CreateWardenFor(WorldSession* client, BigNumber* K)
-    {
-        return nullptr;
-    }
-    MovementAnticheat* CreateAnticheatFor(Player* player)
-    {
-        return new MovementAnticheat();
-    }
-
-    void StartWardenUpdateThread() {}
-    void StopWardenUpdateThread() {}
-    void UpdateWardenSessions() {}
-    void AddWardenSession(Warden* warden) {}
-    void RemoveWardenSession(Warden* warden) {}
-#endif
 
 public:
     // Antispam wrappers

--- a/src/game/Anticheat/WardenAnticheat/WardenModuleMgr.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenModuleMgr.cpp
@@ -90,6 +90,25 @@ WardenModuleMgr::WardenModuleMgr()
             continue;
         }
     }
+
+    bool isMissingModules = false;
+
+    if (m_winModules.empty() && sWorld.getConfig(CONFIG_BOOL_AC_WARDEN_WIN_ENABLED))
+    {
+        sLog.Out(LOG_ANTICHEAT, LOG_LVL_ERROR, "No Windows Warden module found - reduced cheat detection capabilities! Check your `Warden.ModuleDir` in config!");
+        isMissingModules = true;
+    }
+
+    if (m_macModules.empty() && sWorld.getConfig(CONFIG_BOOL_AC_WARDEN_OSX_ENABLED))
+    {
+        sLog.Out(LOG_ANTICHEAT, LOG_LVL_ERROR, "No macOS Warden module found - reduced cheat detection capabilities! Check your `Warden.ModuleDir` in config!");
+        isMissingModules = true;
+    }
+
+    if (isMissingModules)
+    {
+        sLog.WaitBeforeContinueIfNeed();
+    }
 }
 
 WardenModule const* WardenModuleMgr::GetWindowsModule() const

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-set (game_SRCS 
+set (game_SRCS
     AccountMgr.cpp
     AuraRemovalMgr.cpp
     AutoBroadCastMgr.cpp
@@ -278,6 +278,23 @@ set (game_SRCS
     AI/ScriptedPetAI.h
     AI/TotemAI.h
     Anticheat/Anticheat.h
+    Anticheat/MovementAnticheat/MovementAnticheat.cpp
+    Anticheat/MovementAnticheat/MovementAnticheat.h
+    Anticheat/WardenAnticheat/Warden.cpp
+    Anticheat/WardenAnticheat/Warden.hpp
+    Anticheat/WardenAnticheat/WardenKeyGenerator.h
+    Anticheat/WardenAnticheat/WardenMac.cpp
+    Anticheat/WardenAnticheat/WardenMac.hpp
+    Anticheat/WardenAnticheat/WardenModule.cpp
+    Anticheat/WardenAnticheat/WardenModule.hpp
+    Anticheat/WardenAnticheat/WardenModuleMgr.cpp
+    Anticheat/WardenAnticheat/WardenModuleMgr.hpp
+    Anticheat/WardenAnticheat/WardenScan.cpp
+    Anticheat/WardenAnticheat/WardenScan.hpp
+    Anticheat/WardenAnticheat/WardenScanMgr.cpp
+    Anticheat/WardenAnticheat/WardenScanMgr.hpp
+    Anticheat/WardenAnticheat/WardenWin.cpp
+    Anticheat/WardenAnticheat/WardenWin.hpp
     AuctionHouse/AuctionHouseBotMgr.h
     AuctionHouse/AuctionHouseMgr.h
     Battlegrounds/BattleGround.h
@@ -455,29 +472,6 @@ else()
       ${CMAKE_SOURCE_DIR}/src/scripts/ScriptLoader.h
   )
 endif()
-
-if(USE_ANTICHEAT)
-  list(APPEND game_SRCS
-      Anticheat/MovementAnticheat/MovementAnticheat.cpp
-      Anticheat/MovementAnticheat/MovementAnticheat.h
-      Anticheat/WardenAnticheat/Warden.cpp
-      Anticheat/WardenAnticheat/Warden.hpp
-      Anticheat/WardenAnticheat/WardenKeyGenerator.h
-      Anticheat/WardenAnticheat/WardenMac.cpp
-      Anticheat/WardenAnticheat/WardenMac.hpp
-      Anticheat/WardenAnticheat/WardenModule.cpp
-      Anticheat/WardenAnticheat/WardenModule.hpp
-      Anticheat/WardenAnticheat/WardenModuleMgr.cpp
-      Anticheat/WardenAnticheat/WardenModuleMgr.hpp
-      Anticheat/WardenAnticheat/WardenScan.cpp
-      Anticheat/WardenAnticheat/WardenScan.hpp
-      Anticheat/WardenAnticheat/WardenScanMgr.cpp
-      Anticheat/WardenAnticheat/WardenScanMgr.hpp
-      Anticheat/WardenAnticheat/WardenWin.cpp
-      Anticheat/WardenAnticheat/WardenWin.hpp
-  )
-endif()
-
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1307,7 +1307,6 @@ void WorldSession::HandleRequestPetInfoOpcode(WorldPacket& /*recv_data */)
 
 void WorldSession::HandleWardenDataOpcode(WorldPacket& recv_data)
 {
-#ifdef USE_ANTICHEAT
     if (!m_warden)
     {
         sLog.Player(GetAccountId(), LOG_ANTICHEAT, LOG_LVL_MINIMAL,
@@ -1317,5 +1316,4 @@ void WorldSession::HandleWardenDataOpcode(WorldPacket& recv_data)
 
     std::lock_guard<std::mutex> lock(m_warden->m_packetQueueMutex);
     m_warden->m_packetQueue.emplace_back(std::move(recv_data));
-#endif
 }

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1095,7 +1095,7 @@ void World::LoadConfigSettings(bool reload)
     setConfig(CONFIG_BOOL_UNLINKED_AUCTION_HOUSES, "Progression.UnlinkedAuctionHouses", true);
 
     // Movement Anticheat
-    setConfig(CONFIG_BOOL_AC_MOVEMENT_ENABLED, "Anticheat.Enable", true);
+    setConfig(CONFIG_BOOL_AC_MOVEMENT_ENABLED, "Anticheat.Enable", false);
     setConfig(CONFIG_BOOL_AC_MOVEMENT_PLAYERS_ONLY, "Anticheat.PlayersOnly", true);
     setConfig(CONFIG_BOOL_AC_MOVEMENT_NOTIFY_CHEATERS, "Anticheat.NotifyCheaters", false);
     setConfig(CONFIG_UINT32_AC_MOVEMENT_BAN_DURATION, "Anticheat.BanDuration", 86400);
@@ -1222,8 +1222,8 @@ void World::LoadConfigSettings(bool reload)
     setConfig(CONFIG_UINT32_AC_MOVEMENT_CHEAT_BOTTING_PENALTY, "Anticheat.Botting.Penalty", CHEAT_ACTION_LOG | CHEAT_ACTION_REPORT_GMS);
 
     // Warden Anticheat
-    setConfig(CONFIG_BOOL_AC_WARDEN_WIN_ENABLED, "Warden.WinEnabled", true);
-    setConfig(CONFIG_BOOL_AC_WARDEN_OSX_ENABLED, "Warden.OSXEnabled", true);
+    setConfig(CONFIG_BOOL_AC_WARDEN_WIN_ENABLED, "Warden.WinEnabled", false);
+    setConfig(CONFIG_BOOL_AC_WARDEN_OSX_ENABLED, "Warden.OSXEnabled", false);
     setConfig(CONFIG_BOOL_AC_WARDEN_PLAYERS_ONLY, "Warden.PlayersOnly", false);
     setConfig(CONFIG_UINT32_AC_WARDEN_NUM_SCANS, "Warden.NumScans", 10);
     setConfig(CONFIG_UINT32_AC_WARDEN_CLIENT_RESPONSE_DELAY, "Warden.ClientResponseDelay", 30);

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -1485,13 +1485,13 @@ Antiflood.Sanction = 8
 #
 #    Warden.WinEnabled
 #        Description: Enables Warden checks for Windows clients.
-#        Default:     1 - (Enabled)
-#                     0 - (Disabled)
+#                     1 - (Enabled)
+#        Default:     0 - (Disabled)
 #
 #    Warden.OSXEnabled
 #        Description: Enables Warden checks for OSX clients.
-#        Default:     1 - (Enabled)
-#                     0 - (Disabled)
+#                     1 - (Enabled)
+#        Default:     0 - (Disabled)
 #
 #    Warden.PlayersOnly
 #        Description: Ignore game master accounts.
@@ -1535,8 +1535,8 @@ Antiflood.Sanction = 8
 #
 ###################################################################################################
 
-Warden.WinEnabled            = 1
-Warden.OSXEnabled            = 1
+Warden.WinEnabled            = 0
+Warden.OSXEnabled            = 0
 Warden.PlayersOnly           = 0
 Warden.NumScans              = 10
 Warden.ClientResponseDelay   = 30
@@ -1551,8 +1551,8 @@ Warden.ModuleDir             = "warden_modules"
 #
 #    Anticheat.Enable
 #        Description: Enables player movement checks.
-#        Default:     1 - (Enabled)
-#                     0 - (Disabled)
+#                     1 - (Enabled)
+#        Default:     0 - (Disabled)
 #
 #    Anticheat.PlayersOnly
 #        Description: Ignore game master accounts.
@@ -2100,7 +2100,7 @@ Warden.ModuleDir             = "warden_modules"
 #
 ###################################################################################################
 
-Anticheat.Enable = 1
+Anticheat.Enable = 0
 Anticheat.PlayersOnly = 1
 Anticheat.NotifyCheaters = 0
 Anticheat.BanDuration = 86400

--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -444,14 +444,6 @@ void Log::OutFile(LogType logType, LogLevel logLevel, std::string const& str) co
     fflush(logFiles[logType]);
 }
 
-#ifndef USE_ANTICHEAT
-
-void Log::OutWarden(Warden const* /*warden*/, LogLevel /*logLevel*/, char const* /*format*/, ...)
-{
-}
-
-#endif
-
 bool Log::IsSmartLog(uint32 entry, uint32 guid) const
 {
     return m_smartlogExtraEntries.find(entry) != m_smartlogExtraEntries.end() ||


### PR DESCRIPTION
## 🍰 Pullrequest
This PR enables anti-cheat capabilities by default but disables warden by default in the config.
Its was also a bit confusing if its not build into the core but enabled in the config.

Warden exists in the core for such a long time that it can be considered as _well tested_ and stable.
Other cores also have it like this by default.
