### PR TITLE
Correct rank and petfamilyflags - Un'goro and Zul'gurub

### DIFF
--- a/sql/migrations/20241026225509_world.sql
+++ b/sql/migrations/20241026225509_world.sql
@@ -9,7 +9,7 @@ INSERT INTO `migrations` VALUES ('20241026225509');
 -- Add your query below.
 
 
--- Un'Goro gorrilas is not tameable prior to patch 1.9
+-- Un'Goro - some gorrilas is not tameable prior to patch 1.9
 
 -- Un'Goro Thunderer
 UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=6516 AND `patch`=0;

--- a/sql/migrations/20241026225509_world.sql
+++ b/sql/migrations/20241026225509_world.sql
@@ -12,17 +12,17 @@ INSERT INTO `migrations` VALUES ('20241026225509');
 -- Un'Goro - some gorrilas is not tameable prior to patch 1.9
 
 -- Un'Goro Thunderer
-UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=6516 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=6516 AND `patch`=0;
 
 -- Uhk'loc
-UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=6585 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=6585 AND `patch`=0;
 
 -- U'cha
-UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=9622 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=9622 AND `patch`=0;
 
 -- Un'Goro Stomper
 INSERT INTO `creature_template` (`entry`, `patch`, `name`, `level_min`, `level_max`, `faction`, `display_id1`, `type`, `pet_family`, `unit_class`, `health_multiplier`, `damage_multiplier`, `damage_variance`, `loot_id`, `skinning_loot_id`, `ai_name`, `movement_type`, `inhabit_type`, `static_flags1`) VALUES (6513, 7, 'Un\'Goro Stomper', 51, 52, 72, 5294, 1, 9, 1, 1.3, 1.5, 0.09, 6513, 6513, 'EventAI', 1, 1, 16);
-UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=6513 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=6513 AND `patch`=0;
 
 
 -- Zulgurub Speakers where elites prior to patch 1.11

--- a/sql/migrations/20241026225509_world.sql
+++ b/sql/migrations/20241026225509_world.sql
@@ -12,35 +12,35 @@ INSERT INTO `migrations` VALUES ('20241026225509');
 -- Un'Goro - some gorrilas is not tameable prior to patch 1.9
 
 -- Un'Goro Thunderer
-UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=6516 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE `entry`=6516 AND `patch`=0;
 
 -- Uhk'loc
-UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=6585 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE `entry`=6585 AND `patch`=0;
 
 -- U'cha
-UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=9622 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE `entry`=9622 AND `patch`=0;
 
 -- Un'Goro Stomper
 INSERT INTO `creature_template` (`entry`, `patch`, `name`, `level_min`, `level_max`, `faction`, `display_id1`, `type`, `pet_family`, `unit_class`, `health_multiplier`, `damage_multiplier`, `damage_variance`, `loot_id`, `skinning_loot_id`, `ai_name`, `movement_type`, `inhabit_type`, `static_flags1`) VALUES (6513, 7, 'Un\'Goro Stomper', 51, 52, 72, 5294, 1, 9, 1, 1.3, 1.5, 0.09, 6513, 6513, 'EventAI', 1, 1, 16);
-UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE  `entry`=6513 AND `patch`=0;
+UPDATE `creature_template` SET `pet_family`=0, `static_flags1`=0 WHERE `entry`=6513 AND `patch`=0;
 
 
 -- Zulgurub Speakers where elites prior to patch 1.11
 
 -- Vilebranch Speaker
-UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11391 AND `patch`=5;
+UPDATE `creature_template` SET `rank`=1 WHERE `entry`=11391 AND `patch`=5;
 
 -- Skullsplitter Speaker
-UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11390 AND `patch`=5;
+UPDATE `creature_template` SET `rank`=1 WHERE `entry`=11390 AND `patch`=5;
 
 -- Bloodscalp Speaker
-UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11389 AND `patch`=5;
+UPDATE `creature_template` SET `rank`=1 WHERE `entry`=11389 AND `patch`=5;
 
 -- Witherbark Speaker
-UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11388 AND `patch`=5;
+UPDATE `creature_template` SET `rank`=1, `health_multiplier`=5 WHERE `entry`=11388 AND `patch`=5;
 
 -- Sandfury Speaker
-UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11387 AND `patch`=5;
+UPDATE `creature_template` SET `rank`=1 WHERE `entry`=11387 AND `patch`=5;
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20241026225509_world.sql
+++ b/sql/migrations/20241026225509_world.sql
@@ -1,0 +1,50 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20241026225509');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20241026225509');
+-- Add your query below.
+
+
+-- Un'Goro gorrilas is not tameable prior to patch 1.9
+
+-- Un'Goro Thunderer
+UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=6516 AND `patch`=0;
+
+-- Uhk'loc
+UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=6585 AND `patch`=0;
+
+-- U'cha
+UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=9622 AND `patch`=0;
+
+-- Un'Goro Stomper
+INSERT INTO `creature_template` (`entry`, `patch`, `name`, `level_min`, `level_max`, `faction`, `display_id1`, `type`, `pet_family`, `unit_class`, `health_multiplier`, `damage_multiplier`, `damage_variance`, `loot_id`, `skinning_loot_id`, `ai_name`, `movement_type`, `inhabit_type`, `static_flags1`) VALUES (6513, 7, 'Un\'Goro Stomper', 51, 52, 72, 5294, 1, 9, 1, 1.3, 1.5, 0.09, 6513, 6513, 'EventAI', 1, 1, 16);
+UPDATE `creature_template` SET `pet_family`=0 WHERE  `entry`=6513 AND `patch`=0;
+
+
+-- Zulgurub Speakers where elites prior to patch 1.11
+
+-- Vilebranch Speaker
+UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11391 AND `patch`=5;
+
+-- Skullsplitter Speaker
+UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11390 AND `patch`=5;
+
+-- Bloodscalp Speaker
+UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11389 AND `patch`=5;
+
+-- Witherbark Speaker
+UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11388 AND `patch`=5;
+
+-- Sandfury Speaker
+UPDATE `creature_template` SET `rank`=1 WHERE  `entry`=11387 AND `patch`=5;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Updates rank and petfamily for creatures in Un'Goro and Zul'Gurub to match vanilla sniffs.

Change Un'Goro Stomper, U'cha, Uhk'loc and Un'Goro Thunderer to not be tameable prior to patch 1.9
Change Zul'gurub speakers to be elites prior to patch 1.11

### Proof
<!-- Link resources as proof -->

**Un'Goro**
ungoro_crater_1.8.1.4769_2005-10-21_03-38-32_parsed.txt
Un'Goro Stomper, U'cha, Uhk'loc and Un'Goro Thunderer has petfamilyflag is 0 in vanilla sniff. 

Note that Un'Goro Gorilla isn't in this PR as it has petfamilyflag 9 in vanilla sniff.

https://www.wowhead.com/classic/npc=6585/uhkloc#comments
https://www.wowhead.com/classic/npc=9622/ucha#comments
According to comments; Uhk'loc and U'cha was made tameable in patch 1.9. This is also the patch that had petchanges and implemented gorillas thunderstomp ability. I thereby assume that Un'Goro Stomper and Un'Goro Thunderer also was made tameable in 1.9.

**Zul'gurub**
zul_gurub_1.8.1.4769_2005-11-02_22-49-35_parsed.txt
Sandfury speaker and Vilebranch speaker found in vanilla sniff. Both were elites.

https://wowpedia.fandom.com/wiki/Patch_1.11.0#Raids_and_Dungeons
"The various clan speakers (Bloodscalp Speaker, Sandfury Speaker, etc) have had their hit points reduced considerably."

I thereby assume that all 5 speakers were elite until patch 1.11

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
