### PR TITLE
Fix rolling a random item suffix 

### DIFF
--- a/src/game/ItemEnchantmentMgr.cpp
+++ b/src/game/ItemEnchantmentMgr.cpp
@@ -109,7 +109,7 @@ uint32 GetItemEnchantMod(uint32 entry)
     float chance = 0;
 
     EnchStoreList const& enchantList = tab->second;
-    for (const auto& ench_iter : enchantList)
+    for (auto const& ench_iter : enchantList)
     {
         chance += ench_iter.chance;
     }

--- a/src/game/ItemEnchantmentMgr.cpp
+++ b/src/game/ItemEnchantmentMgr.cpp
@@ -117,7 +117,7 @@ uint32 GetItemEnchantMod(uint32 entry)
     float const roll = rand_chance() * (chance / 100.f);
     chance = 0.f;
 
-    for (const auto& ench_iter : enchantList)
+    for (auto const& ench_iter : enchantList)
     {
         chance += ench_iter.chance;
 

--- a/src/game/ItemEnchantmentMgr.cpp
+++ b/src/game/ItemEnchantmentMgr.cpp
@@ -71,7 +71,13 @@ void LoadRandomEnchantmentsTable()
             float chance = fields[2].GetFloat();
 
             if (chance > 0.000001f && chance <= 100.0f)
+            {
                 RandomItemEnch[entry].push_back(EnchStoreItem(ench, chance));
+            }
+            else
+            {
+                sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Entry %u ench %u has chance < 0.000001 or chance > 100 (%f), skipping.", entry, ench, chance);
+            }
 
             ++count;
         }
@@ -89,7 +95,8 @@ void LoadRandomEnchantmentsTable()
 
 uint32 GetItemEnchantMod(uint32 entry)
 {
-    if (!entry) return 0;
+    if (!entry)
+        return 0;
 
     EnchantmentStore::const_iterator tab = RandomItemEnch.find(entry);
 
@@ -99,26 +106,23 @@ uint32 GetItemEnchantMod(uint32 entry)
         return 0;
     }
 
-    double dRoll = rand_chance();
-    float fCount = 0;
+    float chance = 0;
 
     EnchStoreList const& enchantList = tab->second;
     for (const auto& ench_iter : enchantList)
     {
-        fCount += ench_iter.chance;
-
-        if (fCount > dRoll) return ench_iter.ench;
+        chance += ench_iter.chance;
     }
 
-    //we could get here only if sum of all enchantment chances is lower than 100%
-    dRoll = (irand(0, (int)floor(fCount * 100) + 1)) / 100.0f;
-    fCount = 0;
+    float const roll = rand_chance() * (chance / 100.f);
+    chance = 0.f;
 
     for (const auto& ench_iter : enchantList)
     {
-        fCount += ench_iter.chance;
+        chance += ench_iter.chance;
 
-        if (fCount > dRoll) return ench_iter.ench;
+        if (chance >= roll)
+            return ench_iter.ench;
     }
 
     return 0;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes an issue where the total chance for an entry in item_enchantment_template is above 100.

The original GetItemEnchantMod() has two issues. 
If the totalchance is below 100 - sometimes a second roll will happen.
If the totalchance is above 100 - there is a risk that some suffixes will never be rolled.

This PR fixes it by summing the totalchance and using that sum for the roll.

Also added a log output for entries that are silently skipped during loading.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Before:
.debug loottable enchant 4566 1000000
46 items dropped after 1000000 attempts for item Sturdy Quarterstaff.

After:
.debug loottable enchant 4566 1000000
70 items dropped after 1000000 attempts for item Sturdy Quarterstaff.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
