### PR TITLE
vmap extractor - dont save struct padding to temp files

### DIFF
--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -249,7 +249,7 @@ bool WMOGroup::open()
         {
             liquflags |= 1;
             hlq = new WMOLiquidHeader;
-            f.read(hlq, 0x1E);
+            f.read(hlq, WMOLiquidHeaderSize);
             LiquEx_size = sizeof(WMOLiquidVert) * hlq->xverts * hlq->yverts;
             LiquEx = new WMOLiquidVert[hlq->xverts * hlq->yverts];
             f.read(LiquEx, LiquEx_size);
@@ -497,7 +497,7 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE* output, WMORoot* rootWMO, bool pPrecis
         llog << ":\ntype: " << hlq->type << " (root:" << rootWMO->flags << " group:" << flags << ")\n";
         llog.close(); */
 
-        fwrite(hlq, sizeof(WMOLiquidHeader), 1, output);
+        fwrite(hlq, WMOLiquidHeaderSize, 1, output);
         // only need height values, the other values are unknown anyway
         for (uint32 i = 0; i < LiquEx_size / sizeof(WMOLiquidVert); ++i)
             fwrite(&LiquEx[i].height, sizeof(float), 1, output);

--- a/contrib/vmap_extractor/vmapextract/wmo.h
+++ b/contrib/vmap_extractor/vmapextract/wmo.h
@@ -100,12 +100,14 @@ class WMORoot
 
 struct WMOLiquidHeader
 {
-    int xverts, yverts, xtiles, ytiles;
+    int32 xverts, yverts, xtiles, ytiles;
     float pos_x;
     float pos_y;
     float pos_z;
-    short type;
+    uint16 type;
 };
+
+constexpr int32 WMOLiquidHeaderSize = sizeof(int32) /* xverts */ + sizeof(int32) /* yverts */ + sizeof(int32) /* xtiles */ + sizeof(int32) /* ytiles */ + sizeof(float) /* pos_x */ + sizeof(float) /* pos_y */ + sizeof(float) /* pos_z */ + sizeof(uint16) /* type */;
 
 struct WMOLiquidVert
 {

--- a/src/game/vmap/TileAssembler.cpp
+++ b/src/game/vmap/TileAssembler.cpp
@@ -287,12 +287,15 @@ namespace VMAP
 
     struct WMOLiquidHeader
     {
-        int xverts, yverts, xtiles, ytiles;
+        int32 xverts, yverts, xtiles, ytiles;
         float pos_x;
         float pos_y;
         float pos_z;
-        short type;
+        uint16 type;
     };
+
+    constexpr uint32 WMOLiquidHeaderSize = sizeof(int32) /* xverts */ + sizeof(int32) /* yverts */ + sizeof(int32) /* xtiles */ + sizeof(int32) /* ytiles */ + sizeof(float) /* pos_x */ + sizeof(float) /* pos_y */ + sizeof(float) /* pos_z */ + sizeof(uint16) /* type */;
+
     //=================================================================
     bool TileAssembler::convertRawFile(std::string const& pModelFilename)
     {
@@ -479,7 +482,7 @@ namespace VMAP
             READ_OR_RETURN(&blockId, 4);
             CMP_OR_RETURN(blockId, "LIQU");
             READ_OR_RETURN(&blocksize, sizeof(int));
-            READ_OR_RETURN(&hlq, sizeof(WMOLiquidHeader));
+            READ_OR_RETURN(&hlq, WMOLiquidHeaderSize);
             liquid = new WmoLiquid(hlq.xtiles, hlq.ytiles, Vector3(hlq.pos_x, hlq.pos_y, hlq.pos_z), hlq.type);
             uint32 size = hlq.xverts * hlq.yverts;
             READ_OR_RETURN(liquid->GetHeightStorage(), size * sizeof(float));


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

sizeof(WMOLiquidHeader) returns the size of the struct which is padded to 32 bytes.
WMOLiquidHeader only contains 30 bytes of data. So 2 random unused bytes are being stored in each temporary file.



### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
