### PR TITLE
Fix an issue were vmap extractor generates duplicate files on some systems

### DIFF
--- a/contrib/vmap_extractor/vmapextract/adtfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/adtfile.cpp
@@ -148,8 +148,6 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
                 while (p < buf + size)
                 {
                     fixnamen(p, strlen(p));
-                    char* s = GetPlainName(p);
-                    fixname2(s, strlen(s));
                     string path(p);                         // Store copy after name fixed
 
                     std::string fixedName;

--- a/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
+++ b/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
@@ -29,6 +29,7 @@ bool ExtractSingleModel(std::string& origPath, std::string& fixedName, StringSet
         return ch == ' ' ? '_' : ch;
         });
 
+    fixnamen((char*)s.c_str(), s.size());
     fixedName = s;
 
     std::string output(szWorkDirWmo);                       // Stores output filename (possible changed)

--- a/contrib/vmap_extractor/vmapextract/wmo.h
+++ b/contrib/vmap_extractor/vmapextract/wmo.h
@@ -73,7 +73,7 @@ struct WMODoodadData
     std::vector<WMO::MODS> Sets;
     std::unique_ptr<char[]> Paths;
     std::vector<WMO::MODD> Spawns;
-    std::unordered_set<uint16> References;
+    std::set<uint16> References;
 };
 
 class WMORoot


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Vmap extractor extract modelnames from references in adt tiles and gameobjectdisplayinfo.dbc. The referenced modelnames can differ in case sensitivity. Since linux has case sensitive filnames, this will - unlike windows - not be caught by fileexists() and 1100~ duplicate files will be generated.

This PR ensures that each modelname is referenced the same way. 

- First letter is uppercase
- First letter after a non-alpha char is uppercase
- Rest is lowercase including the filetype

Also: Doodads will now be stored in the same order in the dir_bin file.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Extract maps and vmaps on different platforms
- Diff check all files
- The only difference after this PR should be the floating points stored in dir_bin for position and rotation. At most the difference will be +-0.000001 

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
