### PR TITLE
Rewrite Golemagg and fix 'Golemagg's Trust'

### DIFF
--- a/sql/migrations/20241117202208_world.sql
+++ b/sql/migrations/20241117202208_world.sql
@@ -1,0 +1,28 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20241117202208');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20241117202208');
+-- Add your query below.
+
+-- Moss Covered Feet - add SPELL_ATTR_EX_AURA_UNIQUE
+INSERT INTO `spell_mod` (`Id`, `procChance`, `procFlags`, `procCharges`, `DurationIndex`, `Category`, `CastingTimeIndex`, `StackAmount`, `SpellIconID`, `activeIconID`, `manaCost`, `Attributes`, `AttributesEx`, `AttributesEx2`, `AttributesEx3`, `AttributesEx4`, `Custom`, `InterruptFlags`, `AuraInterruptFlags`, `ChannelInterruptFlags`, `Dispel`, `Stances`, `StancesNot`, `SpellVisual`, `ManaCostPercentage`, `StartRecoveryCategory`, `StartRecoveryTime`, `MaxAffectedTargets`, `MaxTargetLevel`, `DmgClass`, `rangeIndex`, `RecoveryTime`, `CategoryRecoveryTime`, `SpellFamilyName`, `SpellFamilyFlags`, `Mechanic`, `EquippedItemClass`, `Comment`) VALUES
+(6870, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 67110928, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, 'Moss Covered Feet - Add unique aura flag');
+
+-- Golemagg - add missing auras
+-- 13879 Magma Splash - Golemagg splashes magma at his attackers, dealing Fire damage over time and reducing their armor. This ability can stack.
+-- 20556 Golemagg's Trust - Golemagg's Core Ragers will deal increased damage and have 50% increased attack speed if tanked too close to Golemagg.
+-- 18943 Double Attack - Proc chance: 50%, 3s cooldown
+UPDATE `creature_template` SET `auras` = "13879 20556 18943" WHERE `entry` = 11988;
+
+DELETE FROM `script_texts` WHERE `entry` = -1409002; -- %s refuses to die while its master is in trouble. (2) -> 7865
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20241117202208_world.sql
+++ b/sql/migrations/20241117202208_world.sql
@@ -8,10 +8,6 @@ IF v = 0 THEN
 INSERT INTO `migrations` VALUES ('20241117202208');
 -- Add your query below.
 
--- Moss Covered Feet - add SPELL_ATTR_EX_AURA_UNIQUE
-INSERT INTO `spell_mod` (`Id`, `procChance`, `procFlags`, `procCharges`, `DurationIndex`, `Category`, `CastingTimeIndex`, `StackAmount`, `SpellIconID`, `activeIconID`, `manaCost`, `Attributes`, `AttributesEx`, `AttributesEx2`, `AttributesEx3`, `AttributesEx4`, `Custom`, `InterruptFlags`, `AuraInterruptFlags`, `ChannelInterruptFlags`, `Dispel`, `Stances`, `StancesNot`, `SpellVisual`, `ManaCostPercentage`, `StartRecoveryCategory`, `StartRecoveryTime`, `MaxAffectedTargets`, `MaxTargetLevel`, `DmgClass`, `rangeIndex`, `RecoveryTime`, `CategoryRecoveryTime`, `SpellFamilyName`, `SpellFamilyFlags`, `Mechanic`, `EquippedItemClass`, `Comment`) VALUES
-(6870, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 67110928, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, 'Moss Covered Feet - Add unique aura flag');
-
 -- Golemagg - add missing auras
 -- 13879 Magma Splash - Golemagg splashes magma at his attackers, dealing Fire damage over time and reducing their armor. This ability can stack.
 -- 20556 Golemagg's Trust - Golemagg's Core Ragers will deal increased damage and have 50% increased attack speed if tanked too close to Golemagg.

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1862,16 +1862,6 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                         target->HandleEmoteCommand(EMOTE_STATE_DANCE);
                         break;
                     }
-                    case 6870: // Moss Covered Feet
-                    {
-                        if (target)
-                        {
-                            m_positive = false;
-                            m_isPeriodic = true;
-                            m_modifier.periodictime = 1000;
-                        }
-                        return;
-                    }
                 }
                 break;
             }
@@ -2076,11 +2066,11 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                     if (Unit* caster = GetCaster())
                     {
                         // Azuregos
-                        // Only cast Mark of Frost on targets nearby when engaged
-                        if (caster->IsInCombat())
-                        {
+                        // TODO verify: Only cast Mark of Frost on targets nearby when engaged?
+                        // if (caster->IsInCombat())
+                        // {
                             target->CastSpell(target, 23182, true, nullptr, this);
-                        }
+                        // }
                     }
                 }
                 return;
@@ -6834,18 +6824,6 @@ void Aura::PeriodicDummyTick()
                                 // Golemagg's Trust Buff
                                 pCaster->CastSpell(itr, 20553, true, nullptr, this);
                             }
-                        }
-                    }
-                    return;
-                }
-                case 6870: // Moss Covered Feet
-                {
-                    if (target->IsInCombat())
-                    {
-                        // 5% proc chance
-                        if (urand(0, 99) < 5)
-                        {
-                            target->CastSpell(target, 6869, true, nullptr, this); // Fall Down
                         }
                     }
                     return;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1826,6 +1826,12 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                         }
                         return;
                     }
+                    case 20556: // Golemagg's Trust
+                    {
+                            m_isPeriodic = true;
+                            m_modifier.periodictime = 1000;
+                            return;
+                    }
                     case 22646:                             // Goblin Rocket Helmet
                     {
                         if (Unit* caster = GetCaster())

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1558,7 +1558,7 @@ void Aura::TriggerSpell()
                 for (auto const& it : pList)
                 {
                     Player* pPlayer = it.getSource();
-                    if (pPlayer->GetGUID() == casterGUID) continue;
+                    if (pPlayer->GetGUID() == casterGUID.GetRawValue()) continue;
                     if (!pPlayer) continue;
                     if (pPlayer->IsDead()) continue;
                     // 2d distance should be good enough
@@ -1862,6 +1862,16 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                         target->HandleEmoteCommand(EMOTE_STATE_DANCE);
                         break;
                     }
+                    case 6870: // Moss Covered Feet
+                    {
+                        if (target)
+                        {
+                            m_positive = false;
+                            m_isPeriodic = true;
+                            m_modifier.periodictime = 1000;
+                        }
+                        return;
+                    }
                 }
                 break;
             }
@@ -2062,8 +2072,18 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
             case 23183:                                     // Mark of Frost
             {
                 if (m_removeMode == AURA_REMOVE_BY_DEATH)
-                    target->CastSpell(target, 23182, true, nullptr, this);
-                    return;
+                {
+                    if (Unit* caster = GetCaster())
+                    {
+                        // Azuregos
+                        // Only cast Mark of Frost on targets nearby when engaged
+                        if (caster->IsInCombat())
+                        {
+                            target->CastSpell(target, 23182, true, nullptr, this);
+                        }
+                    }
+                }
+                return;
             }
             case 28169:                                     // Mutating Injection
             {
@@ -6793,6 +6813,41 @@ void Aura::PeriodicDummyTick()
                     if (ribbonCount > 1)
                         target->CastSpell(GetCaster(), 29175, true); // Midsummer Pole Buff
 
+                    return;
+                }
+                case 20556: // Golemagg's Trust
+                {
+                    if (Unit* pCaster = GetCaster())
+                    {
+                        if (pCaster->IsDead() && !pCaster->IsInCombat())
+                        {
+                            return;
+                        }
+                        // Golemagg's Core Ragers will deal increased damage
+                        // and have 50% increased attack speed if tanked too close to Golemagg.
+                        std::list<Creature*> addList;
+                        pCaster->GetCreatureListWithEntryInGrid(addList, 11672, 30.0f);
+                        if (!addList.empty())
+                        {
+                            for (const auto& itr : addList)
+                            {
+                                // Golemagg's Trust Buff
+                                pCaster->CastSpell(itr, 20553, true, nullptr, this);
+                            }
+                        }
+                    }
+                    return;
+                }
+                case 6870: // Moss Covered Feet
+                {
+                    if (target->IsInCombat())
+                    {
+                        // 5% proc chance
+                        if (urand(0, 99) < 5)
+                        {
+                            target->CastSpell(target, 6869, true, nullptr, this); // Fall Down
+                        }
+                    }
                     return;
                 }
             }

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1679,6 +1679,20 @@ void Spell::EffectDummy(SpellEffectIndex effIdx)
                     }
                     return;
                 }
+                case 7669: // Bethor's Potion (debuff removal spell 8320 does not work, fix it here...)
+                {
+                    // HEX_OF_RAVENCLAW_1
+                    if (m_casterUnit->HasAura(7656))
+                    {
+                        m_casterUnit->RemoveAurasDueToSpell(7656);
+                    }
+                    // HEX_OF_RAVENCLAW_2
+                    if (m_casterUnit->HasAura(7657))
+                    {
+                        m_casterUnit->RemoveAurasDueToSpell(7657);
+                    }
+                    return;
+                }
             }
 
             //All IconID Check in there

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1679,20 +1679,6 @@ void Spell::EffectDummy(SpellEffectIndex effIdx)
                     }
                     return;
                 }
-                case 7669: // Bethor's Potion (debuff removal spell 8320 does not work, fix it here...)
-                {
-                    // HEX_OF_RAVENCLAW_1
-                    if (m_casterUnit->HasAura(7656))
-                    {
-                        m_casterUnit->RemoveAurasDueToSpell(7656);
-                    }
-                    // HEX_OF_RAVENCLAW_2
-                    if (m_casterUnit->HasAura(7657))
-                    {
-                        m_casterUnit->RemoveAurasDueToSpell(7657);
-                    }
-                    return;
-                }
             }
 
             //All IconID Check in there

--- a/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_golemagg.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_golemagg.cpp
@@ -14,169 +14,136 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* ScriptData
-SDName: Boss_Golemagg
-SD%Complete: 75
-SDComment: Timers need to be confirmed, Golemagg's Trust need to be checked
-SDCategory: Molten Core
-EndScriptData */
-
-/*
-    Golemagg and his adds should evade if dogs are pulled too far away from Golemagg
-*/
-
 #include "scriptPCH.h"
 #include "molten_core.h"
+#include "Utilities/EventMap.h"
 
-enum
+enum Golemagg : uint32
 {
-    SPELL_MAGMASPLASH       = 13879,
-    SPELL_PYROBLAST         = 20228,
-    SPELL_EARTHQUAKE        = 19798,
-    SPELL_ENRAGE            = 19953,
-    SPELL_GOLEMAGG_TRUST    = 20553,
+    // Auras (set in db - creature_template)
+    // SPELL_MAGMASPLASH         = 13879,
+    // SPELL_GOLEMAGG_TRUST_AURA = 20556,
+    // SPELL_DOUBLE_ATTACK       = 18943,
 
-    // Core Rager
-    EMOTE_LOWHP             = -1409002,
-    SPELL_MANGLE            = 19820,
-    SPELL_TRASH             = 3391
+    // Spells
+    SPELL_PYROBLAST      = 20228,
+    SPELL_EARTHQUAKE     = 19798,
+    SPELL_GOLEMAGG_TRUST = 20553,
+    SPELL_ATTRACK_RAGER  = 20544,
+
+    // Events
+    EVENT_PYROBLAST      = 1,
+    EVENT_EARTHQUAKE     = 2,
+    EVENT_GOLEMAGG_TRUST = 3
 };
 
 struct boss_golemaggAI : public ScriptedAI
 {
-    boss_golemaggAI(Creature* pCreature) : ScriptedAI(pCreature)
+    explicit boss_golemaggAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
-        m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
-        Reset();
+        m_pInstance = static_cast<ScriptedInstance*>(pCreature->GetInstanceData());
+        boss_golemaggAI::Reset();
     }
 
-    ScriptedInstance* m_pInstance;
+    EventMap m_CombatEvents{};
+    ScriptedInstance* m_pInstance{};
+    std::list<ObjectGuid> m_addList;
 
-    uint32 m_uiPyroblastTimer;
-    uint32 m_uiEarthquakeTimer;
-    uint32 TickTimer;
-    bool m_bEnraged;
+    bool m_bEnraged = false;
 
     void Reset() override
     {
-        m_uiPyroblastTimer = 7 * IN_MILLISECONDS;            // These timers are probably wrong
-        m_uiEarthquakeTimer = 3 * IN_MILLISECONDS;
-        TickTimer = 10000;
         m_bEnraged = false;
+        m_CombatEvents.Reset();
+        m_addList.clear();
 
         if (m_pInstance && m_creature->IsAlive())
-            m_pInstance->SetData(TYPE_GOLEMAGG, NOT_STARTED);
-
-
-        std::list<Creature*> ChiensListe;
-        GetCreatureListWithEntryInGrid(ChiensListe, m_creature, 11672, 150.0f);
-        if (!ChiensListe.empty())
         {
-            for (const auto& itr : ChiensListe)
+            m_pInstance->SetData(TYPE_GOLEMAGG, NOT_STARTED);
+        }
+
+        std::list<Creature*> addList;
+        GetCreatureListWithEntryInGrid(addList, m_creature, NPC_CORE_RAGER, 250.0f);
+        if (!addList.empty())
+        {
+            for (const auto& itr : addList)
             {
                 if (itr->GetDeathState() == ALIVE)
+                {
                     itr->DealDamage(itr, itr->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
+                }
+
                 itr->Respawn();
             }
         }
-        //    available in creature_addon
-        //    m_creature->CastSpell(m_creature, SPELL_MAGMASPLASH, true);
     }
 
-    void Aggro(Unit* pWho) override
+    void Aggro(Unit*) override
     {
         if (m_pInstance)
+        {
             m_pInstance->SetData(TYPE_GOLEMAGG, IN_PROGRESS);
+        }
+
+        // Store add guids
+        std::list<Creature*> adds;
+        GetCreatureListWithEntryInGrid(adds, m_creature, NPC_CORE_RAGER, 150.0f);
+        m_addList.clear();
+        for (const auto& itr : adds)
+        {
+            m_addList.push_back(itr->GetObjectGuid());
+        }
+
+        ScheduleCombatEvents();
     }
 
-    void JustDied(Unit* pKiller) override
+    void EnterEvadeMode() override
+    {
+        KillAdds(true);
+        ScriptedAI::EnterEvadeMode();
+    }
+
+    void JustDied(Unit*) override
     {
         if (m_pInstance)
+        {
             m_pInstance->SetData(TYPE_GOLEMAGG, DONE);
+        }
+
+        KillAdds(false);
     }
 
-    void UpdateAI(uint32 const uiDiff) override
+    void KillAdds(bool respawn)
     {
-        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
-            return;
-
-        // Pyroblast
-        if (m_uiPyroblastTimer < uiDiff)
+        if (!m_addList.empty())
         {
-            if (Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
+            for (const auto& itr : m_addList)
             {
-                if (DoCastSpellIfCan(pTarget, SPELL_PYROBLAST) == CAST_OK)
-                    m_uiPyroblastTimer = (3 + rand() % 4) * IN_MILLISECONDS;
-            }
-        }
-        else
-            m_uiPyroblastTimer -= uiDiff;
-
-        // Enrage
-        if (!m_bEnraged && m_creature->GetHealthPercent() < 10.0f)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_ENRAGE) == CAST_OK)
-                m_bEnraged = true;
-        }
-
-        if (TickTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_GOLEMAGG_TRUST) == CAST_OK)
-                TickTimer = 2000;
-        }
-        else TickTimer -= uiDiff;
-
-        // Earthquake
-        if (m_bEnraged)
-        {
-            if (m_uiEarthquakeTimer < uiDiff)
-            {
-                if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_EARTHQUAKE) == CAST_OK)
-                    m_uiEarthquakeTimer = 3 * IN_MILLISECONDS;
-            }
-            else
-                m_uiEarthquakeTimer -= uiDiff;
-        }
-
-
-        DoMeleeAttackIfReady();
-    }
-};
-
-struct mob_core_ragerAI : public ScriptedAI
-{
-    mob_core_ragerAI(Creature* pCreature) : ScriptedAI(pCreature)
-    {
-        m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
-        Reset();
-    }
-
-    ScriptedInstance* m_pInstance;
-    uint32 m_uiMangleTimer;
-    uint32 TickTimer;
-
-    void Reset() override
-    {
-        TickTimer = 1000;
-        m_uiMangleTimer = 7 * IN_MILLISECONDS;               // These times are probably wrong
-    }
-
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
-    {
-        if (m_pInstance)
-        {
-            if (Creature* pGolemagg = m_pInstance->instance->GetCreature(m_pInstance->GetData64(DATA_GOLEMAGG)))
-            {
-                if (pGolemagg->IsAlive())
+                if (auto coreRager = m_creature->GetMap()->GetCreature(itr))
                 {
-                    if (m_creature->GetHealthPercent() < 50.0f)
+                    coreRager->DisappearAndDie();
+                    if (respawn)
                     {
-                        DoScriptText(EMOTE_LOWHP, m_creature);
-                        m_creature->SetHealth(m_creature->GetMaxHealth());
+                        coreRager->Respawn();
                     }
                 }
-                else
-                    m_creature->DisappearAndDie();
+            }
+        }
+    }
+
+    void DamageTaken(Unit*, uint32& uiDamage) override
+    {
+        if (!m_bEnraged)
+        {
+            // At 10% health, Golemagg will Earthquake,
+            // dealing Physical damage to all players every couple seconds.
+            if (m_creature->GetHealthPercent() < 10.f)
+            {
+                if (DoCastSpellIfCan(m_creature, SPELL_ATTRACK_RAGER) == CAST_OK)
+                {
+                    m_bEnraged = true;
+                    m_CombatEvents.ScheduleEvent(EVENT_EARTHQUAKE, Seconds(5));
+                }
             }
         }
     }
@@ -184,26 +151,70 @@ struct mob_core_ragerAI : public ScriptedAI
     void UpdateAI(uint32 const uiDiff) override
     {
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
+        {
             return;
-
-        // Mangle
-        if (m_uiMangleTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_MANGLE) == CAST_OK)
-                m_uiMangleTimer = 10 * IN_MILLISECONDS;
         }
-        else
-            m_uiMangleTimer -= uiDiff;
 
-        if (TickTimer < uiDiff)
-        {
-            TickTimer = 1000;
-            if (!m_creature->HasAura(SPELL_TRASH) && !(bool)(rand() % 10))
-                m_creature->CastSpell(m_creature, SPELL_TRASH, true);
-        }
-        else TickTimer -= uiDiff;
+        m_CombatEvents.Update(uiDiff);
+        UpdateEvents();
 
         DoMeleeAttackIfReady();
+    }
+
+    void ScheduleCombatEvents()
+    {
+        m_CombatEvents.ScheduleEvent(EVENT_PYROBLAST,      Seconds(7));
+        m_CombatEvents.ScheduleEvent(EVENT_GOLEMAGG_TRUST, Seconds(10));
+    }
+
+    void UpdateEvents()
+    {
+        while (const uint32 eventId = m_CombatEvents.ExecuteEvent())
+        {
+            switch (eventId)
+            {
+                case EVENT_PYROBLAST:
+                {
+                    // Golemagg Pyroblasts a random player,
+                    // dealing Fire damage and leaving an additional Fire DOT on them.
+                    if (Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
+                    {
+                        if (DoCastSpellIfCan(pTarget, SPELL_PYROBLAST) == CAST_OK)
+                        {
+                            m_CombatEvents.Repeat(Seconds(7));
+                            return;
+                        }
+                    }
+
+                    // Cast Failed: Try again in 1s
+                    m_CombatEvents.Repeat(Seconds(1));
+                    return;
+                }
+                case EVENT_EARTHQUAKE:
+                {
+                    if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_EARTHQUAKE) == CAST_OK)
+                    {
+                        m_CombatEvents.Repeat(Seconds(5));
+                        return;
+                    }
+
+                    // Cast Failed: Try again in 1s
+                    m_CombatEvents.Repeat(Seconds(1));
+                    return;
+                }
+                case EVENT_GOLEMAGG_TRUST:
+                {
+                    if (DoCastSpellIfCan(m_creature, SPELL_GOLEMAGG_TRUST) == CAST_OK)
+                    {
+                        m_CombatEvents.Repeat(Seconds(2));
+                        return;
+                    }
+                    // Cast Failed: Try again in 1s
+                    m_CombatEvents.Repeat(Seconds(1));
+                    return;
+                }
+            }
+        }
     }
 };
 
@@ -211,6 +222,138 @@ CreatureAI* GetAI_boss_golemagg(Creature* pCreature)
 {
     return new boss_golemaggAI(pCreature);
 }
+
+enum CoreRager : uint32
+{
+    // Spells
+    // SPELL_TRASH    = 3391, // Custom?
+    SPELL_MANGLE      = 19820,
+    SPELL_FULL_HEAL   = 17683,
+
+    // Texts
+    EMOTE_LOWHP       = 7865,
+
+    // Events
+    EVENT_MANGLE      = 1,
+    EVENT_TRASH       = 2,
+    EVENT_CHECK_LEASH = 3
+};
+
+struct mob_core_ragerAI : public ScriptedAI
+{
+    explicit mob_core_ragerAI(Creature* pCreature) : ScriptedAI(pCreature)
+    {
+        m_pInstance = static_cast<ScriptedInstance*>(pCreature->GetInstanceData());
+        Reset();
+    }
+
+    EventMap m_CombatEvents{};
+    ScriptedInstance* m_pInstance{};
+
+    void Reset() override
+    {
+        m_CombatEvents.Reset();
+    }
+
+    void Aggro(Unit*) override
+    {
+        ScheduleCombatEvents();
+    }
+
+    void DamageTaken(Unit*, uint32& uiDamage) override
+    {
+        if (!m_pInstance)
+        {
+            return;
+        }
+
+        if (m_pInstance->GetData(TYPE_GOLEMAGG) == DONE)
+        {
+            return;
+        }
+
+        if (m_creature->HealthBelowPctDamaged(50, uiDamage))
+        {
+            uiDamage = 0;
+            DoScriptText(EMOTE_LOWHP, m_creature);
+            SpellCastResult result = DoCastSpellIfCan(m_creature->GetVictim(), SPELL_FULL_HEAL);
+            if (result != CAST_OK)
+            {
+                m_creature->SetHealth(m_creature->GetMaxHealth());
+            }
+        }
+    }
+
+    void UpdateAI(uint32 const uiDiff) override
+    {
+        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
+        {
+            return;
+        }
+
+        m_CombatEvents.Update(uiDiff);
+        UpdateEvents();
+
+        DoMeleeAttackIfReady();
+    }
+
+    void ScheduleCombatEvents()
+    {
+        // m_CombatEvents.ScheduleEvent(EVENT_TRASH,    Seconds(1));
+        m_CombatEvents.ScheduleEvent(EVENT_MANGLE,      Seconds(7));
+        m_CombatEvents.ScheduleEvent(EVENT_CHECK_LEASH, Seconds(3));
+    }
+
+    void UpdateEvents()
+    {
+        while (const uint32 eventId = m_CombatEvents.ExecuteEvent())
+        {
+            switch (eventId)
+            {
+                /*
+                case EVENT_TRASH:
+                {
+                    if (!m_creature->HasAura(SPELL_TRASH))
+                    {
+                        m_creature->CastSpell(m_creature, SPELL_TRASH, true);
+                    }
+
+                    m_CombatEvents.Repeat(Seconds(urand(1, 10)));
+                    return;
+                }
+                */
+                case EVENT_MANGLE:
+                {
+                    if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_MANGLE) == CAST_OK)
+                    {
+                        m_CombatEvents.Repeat(Seconds(10));
+                        return;
+                    }
+
+                    // Cast Failed: Try again in 1s
+                    m_CombatEvents.Repeat(Seconds(1));
+                    return;
+                }
+                case EVENT_CHECK_LEASH:
+                {
+                    if (Creature* pGolemagg = m_pInstance->instance->GetCreature(m_pInstance->GetData64(DATA_GOLEMAGG)))
+                    {
+                        if (m_creature->GetDistance2d(pGolemagg) > 100.f)
+                        {
+                            if (auto pGolemaggAI = dynamic_cast<boss_golemaggAI*>(pGolemagg->AI()))
+                            {
+                                pGolemaggAI->EnterEvadeMode();
+                            }
+                        }
+                    }
+
+                    m_CombatEvents.Repeat(Seconds(3));
+                    return;
+                }
+            }
+        }
+    }
+};
 
 CreatureAI* GetAI_mob_core_rager(Creature* pCreature)
 {


### PR DESCRIPTION
## 🍰 Pullrequest
Some fixes I've made for the [RaspyWoW](https://www.raspywow.com/) project.
Update: removed unverified changes.

Implemented missing handling for spells:
- ~~Moss Covered Feet~~
- Golemagg's Trust
- ~~Bethor's Potion~~

~~Fixed implementation of spell:~~
- ~~Mark of Frost~~

Script of Golemagg is fully rewritten, with Golemagg's Trust now being implemented and also added the missing leash handling for his adds.

30 yards buff reach: [wowhead](https://www.wowhead.com/classic/spell=20553/golemaggs-trust)
100 yards leash distance: [Azerothcore](https://github.com/azerothcore/azerothcore-wotlk/blob/106cbe7fdf7d3b7b4906d04cafc40e61ff62d002/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_golemagg.cpp#L182)

### Proof
- None

### How2Test
- None

### Todo / Checklist
- [ ] spell timers?
- [ ] aura 18943 correct?