### PR TITLE
Add missing spell IsIgnoringCasterAndTargetRestrictions check

### DIFF
--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -191,7 +191,9 @@ SpellMissInfo SpellCaster::SpellHitResult(Unit* pVictim, SpellEntry const* spell
     else
         schoolMask = spell->GetSpellSchoolMask();
 
-    if (pVictim != this && pVictim->IsImmuneToDamage(schoolMask, spell))
+    if (pVictim != this
+        && !spell->IsIgnoringCasterAndTargetRestrictions()
+        && pVictim->IsImmuneToDamage(schoolMask, spell))
         return SPELL_MISS_IMMUNE;
 
     // Try victim reflect spell


### PR DESCRIPTION
## 🍰 Pullrequest
Add missing check for spells that should ignore target immunity checks.

### Proof
- None

### Issues
- None

### How2Test
- [Blackwing Spellbinder](https://www.wowhead.com/classic/npc=12457/blackwing-spellbinder) has a spell immunity aura.
- cast a spell on him, which uses flag SPELL_ATTR_EX_IGNORE_CASTER_AND_TARGET_RESTRICTIONS
- spell should not be resisted

### Todo / Checklist
- [X] None
