### PR TITLE
Fix 'Seal of Righteousness' spell id used for paladin player creation.

### DIFF
--- a/sql/migrations/20250124162238_world.sql
+++ b/sql/migrations/20250124162238_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20250124162238');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20250124162238');
+-- Add your query below.
+
+-- Player creation spells (paladin 'Seal of Righteousness')
+UPDATE `playercreateinfo_spell` SET `spell`=20154 WHERE `class`=2 AND `spell`=21084;
+
+-- PLayer creation actions (paladin 'Seal of Righteousness')
+UPDATE `playercreateinfo_action` SET `action`=20154 WHERE `class`=2 AND `action`=21084 AND `type`=0;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
There are two version of the rank 1 'Seal of Righteousness' spell, currently vmangos uses the wrong one for paladin player creation.
Correct behaviour should be:
- start with spell 20154
- upon learning 'Judgement' ([10321](https://www.wowhead.com/classic/spell=10321/judgement)), 21084 is also learnt replacing the previous spell.

### Proof
<!-- Link resources as proof -->
- checked on classic era
- looks to be a common problem on emulators (https://github.com/Frostshake/TrinityCoreClassic-Issues/issues/20#issuecomment-2612969383)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create level 1 paladin, observe 'Seal of Righteousness' tooltip
- Apply proposed migration
- Create another level 1 paladin, observe tooltip now different
- increase character to level 4, and learn 'Judgement' from trainer
- Observe 'Seal of Righteousness' also updated.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
