### PR TITLE
Strength crash prevention in Waypoint Generator incase grid unload wi…

### DIFF
--- a/src/game/Movement/WaypointMovementGenerator.cpp
+++ b/src/game/Movement/WaypointMovementGenerator.cpp
@@ -112,7 +112,7 @@ void WaypointMovementGenerator<Creature>::Reset(Creature &creature)
     if (m_isWandering)
     {
         // prevent a crash at empty waypoint path.
-        if (!i_path || i_path->empty())
+        if (!i_path || i_path->empty() || !m_lastReachedWaypoint)
             return;
 
         const WaypointNode& node = i_path->at(m_lastReachedWaypoint);


### PR DESCRIPTION
Prevents crash from grid unload/idle when creature group leader ID changes without m_lastReachedWaypoint being initialized