### PR TITLE
Remove unused auction house bot configuration options.

### DIFF
--- a/src/game/AuctionHouse/AuctionHouseBotMgr.cpp
+++ b/src/game/AuctionHouse/AuctionHouseBotMgr.cpp
@@ -66,9 +66,6 @@ void AuctionHouseBotMgr::Load()
     /* CONFIG */
     m_config                 = std::make_unique<AuctionHouseBotConfig>();
     m_config->enable         = sConfig.GetBoolDefault("AHBot.Enable", false);
-    m_config->ahid           = sConfig.GetIntDefault("AHBot.ah.id", 7);
-    m_config->botguid        = sConfig.GetIntDefault("AHBot.bot.guid", 1123);
-    m_config->botaccount     = sConfig.GetIntDefault("AHBot.bot.account", 32377);
     m_config->ahfid          = sConfig.GetIntDefault("AHBot.ah.fid", 120);
     m_config->itemcount      = sConfig.GetIntDefault("AHBot.itemcount", 2);
 
@@ -92,7 +89,7 @@ void AuctionHouseBotMgr::Update(bool force /* = false */)
     if (!(m_config->enable || force))
         return;
 
-    if (m_items.empty() ||  /*m_config->botguid==0 ||*/ m_config->botaccount == 0)
+    if (m_items.empty())
     {
         sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "AHBot::Update() : Bad config or empty table.");
         return;

--- a/src/game/AuctionHouse/AuctionHouseBotMgr.h
+++ b/src/game/AuctionHouse/AuctionHouseBotMgr.h
@@ -20,11 +20,7 @@ struct AuctionHouseBotEntry
 struct AuctionHouseBotConfig
 {
     uint32 itemcount;
-    uint32 ahid;
     uint32 ahfid;
-
-    uint64 botguid;
-    uint32 botaccount;
 
     bool enable;
 };

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -2892,28 +2892,26 @@ CharDelete.KeepDays = 30
 #
 #    AHBot.Enable
 #        Enable AH bot.
+#        The AH bot will automatically create listings based on the data in the 'auctionhousebot' table.
 #        Default: 0 - off
 #                 1 - on
 #
-#    AHBot.ah.id
-#        The ID of the auction house from AuctionHouse.dbc into which to put items.
-#        Default: 7 - Blackwater Auction House
-#
 #    AHBot.ah.fid
-#        The faction template ID of the virtual auctioneer.
-#        Default: 120 - Booty Bay
+#        The faction template ID used for the AH bot.
+#        This determines which auction house(s) listings are put into.
+#        Default: 120 - Neutral (Booty Bay, Gadgetzan and Everlook)
+#                  55 - Alliance (Ironforge, Stormwind and Teldrassil)
+#                  29 - Horde (Orgrimmar, Thunderbluff and Undercity)
 #
 #    AHBot.itemcount
-#        How many items to put into the auction house.
+#        How many listings to put into the auction house at most.
+#        The AH bot will add items until this number of listings is reached in the auction house (this includes potential player listings).
 #        Default: 50
 #
 ###################################################################################################################
 AHBot.Enable = 0
-AHBot.ah.id = 7
 AHBot.ah.fid = 120
 AHBot.itemcount = 50
-#AHBot.bot.guid = 1123
-#AHBot.bot.account = 32377
 
 ###################################################################################################################
 # PLAYER BOTS


### PR DESCRIPTION
## 🍰 Pullrequest
This removes the unused auction house bot configuration options `AHBot.ah.id`, `AHBot.bot.guid` and `AHBot.bot.account`.

I believe `AHBot.ah.id` will generally not be needed anymore since the auction house(s) is/are now determined through `AHBot.ah.fid` instead.

And while `AHBot.bot.guid` and `AHBot.bot.account` could be used to display a seller name for the listings added by the bot, the code for this is missing/incomplete and thus these configuration options are confusing for users. In addition, if this were to be implemented, a single setting (for the character ID) should probably suffice (instead of having to provide a character ID and an account ID).

The PR also improves the comments for the leftover options to make it a bit clearer how to configure the auction house bot.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Start the server with `AHBot.Enable = 1`
- Observe that the AH bot still works correctly

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
