### PR TITLE
Correct despawn timer for Captured Rabid Thistle Bear

### DIFF
--- a/src/scripts/kalimdor/darkshore/darkshore.cpp
+++ b/src/scripts/kalimdor/darkshore/darkshore.cpp
@@ -859,8 +859,7 @@ struct npc_rabid_thistle_bearAI : public FollowerAI
 
     void StartFollowing(Player* pPlayer)
     {
-        Captured_Timer = 180000;
-        //Captured_Timer = 10000;
+        Captured_Timer = 300000;
         StartFollow(pPlayer);
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Corrects the despawn timer for Captured Rabid Thistle Bear from 5 minutes to 8 minutes 20 seconds


### Proof
<!-- Link resources as proof -->
- [Bear is captured at 1:01:05 and despawns at 1:09:25](https://www.youtube.com/watch?v=3ujPVYvsY_Q)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/vmangos/core/issues/2947
