### PR TITLE
Check Item Level for Heavy Armor Kit after Patch 1.7

### DIFF
--- a/sql/migrations/20250308172541_world.sql
+++ b/sql/migrations/20250308172541_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20250308172541');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20250308172541');
+-- Add your query below.
+
+UPDATE `spell_template` SET `script_name` = "spell_heavy_armor_kit" WHERE `entry` = 2833 AND `build` = 4695;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7887,7 +7887,8 @@ SpellCastResult Spell::CheckItems()
                 if (!targetItem)
                     return SPELL_FAILED_ITEM_GONE;
 
-                if (targetItem->GetProto()->ItemLevel < m_spellInfo->baseLevel)
+                // Special case for Heavy Armor Kit enchant since baseLevel is 0 in spell_template
+                if (targetItem->GetProto()->ItemLevel < m_spellInfo->baseLevel || (m_spellInfo->Id = 2833 && targetItem->GetProto()->ItemLevel < 15 && sWorld.GetWowPatch() >= WOW_PATCH_107))
                     return SPELL_FAILED_LOWLEVEL;
 
                 // Not allow enchant in trade slot for some enchant type

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7888,7 +7888,7 @@ SpellCastResult Spell::CheckItems()
                     return SPELL_FAILED_ITEM_GONE;
 
                 // Special case for Heavy Armor Kit enchant since baseLevel is 0 in spell_template
-                if (targetItem->GetProto()->ItemLevel < m_spellInfo->baseLevel || (m_spellInfo->Id = 2833 && targetItem->GetProto()->ItemLevel < 15 && sWorld.GetWowPatch() >= WOW_PATCH_107))
+                if (targetItem->GetProto()->ItemLevel < m_spellInfo->baseLevel || (m_spellInfo->Id == 2833 && targetItem->GetProto()->ItemLevel < 15 && sWorld.GetWowPatch() >= WOW_PATCH_107))
                     return SPELL_FAILED_LOWLEVEL;
 
                 // Not allow enchant in trade slot for some enchant type

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7887,8 +7887,7 @@ SpellCastResult Spell::CheckItems()
                 if (!targetItem)
                     return SPELL_FAILED_ITEM_GONE;
 
-                // Special case for Heavy Armor Kit enchant since baseLevel is 0 in spell_template
-                if (targetItem->GetProto()->ItemLevel < m_spellInfo->baseLevel || (m_spellInfo->Id == 2833 && targetItem->GetProto()->ItemLevel < 15 && sWorld.GetWowPatch() >= WOW_PATCH_107))
+                if (targetItem->GetProto()->ItemLevel < m_spellInfo->baseLevel)
                     return SPELL_FAILED_LOWLEVEL;
 
                 // Not allow enchant in trade slot for some enchant type

--- a/src/scripts/spells/spell_item.cpp
+++ b/src/scripts/spells/spell_item.cpp
@@ -16,6 +16,23 @@
 
 #include "scriptPCH.h"
 
+// 2833 - Heavy Armor Kit
+struct HeavyArmorKitScript : public SpellScript
+{
+    SpellCastResult OnCheckCast(Spell* spell, bool strict) const final
+    {
+        Item* targetItem = spell->m_targets.getItemTarget();
+        if (targetItem->GetProto()->ItemLevel < 15)
+            return SPELL_FAILED_LOWLEVEL;
+        return SPELL_CAST_OK;
+    }
+};
+
+SpellScript* GetScript_HeavyArmorKit(SpellEntry const*)
+{
+    return new HeavyArmorKitScript();
+}
+
 // 8063 - Deviate Fish
 struct DeviateFishScript : public SpellScript
 {
@@ -134,6 +151,11 @@ SpellScript* GetScript_NoggenfoggerElixir(SpellEntry const*)
 void AddSC_item_spell_scripts()
 {
     Script* newscript;
+
+    newscript = new Script;
+    newscript->Name = "spell_heavy_armor_kit";
+    newscript->GetSpellScript = &GetScript_HeavyArmorKit;
+    newscript->RegisterSelf();
 
     newscript = new Script;
     newscript->Name = "spell_deviate_fish";


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
No longer allows Heavy Armor Kits to work on items with an item level lower than 15 from patch 1.7 onward.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/vmangos/core/issues/2388

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Server on patch 1.7 or later
- .additem 4265
- Attempt to use it on an item with an item level lower than 15
- Spell fizzles because the target item is too low level

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
