### PR TITLE
Fix 1.6.1.4544 build.

### DIFF
--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2214,7 +2214,7 @@ public:
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_6_1
         ChatHandler::BuildChatPacket(*data, CHAT_MSG_BG_SYSTEM_NEUTRAL, text, LANG_UNIVERSAL, CHAT_TAG_NONE, i_senderGuid);
 #else
-        ChatHandler::BuildChatPacket(*data, CHAT_MSG_SYSTEM, text, LANG_UNIVERSAL, CHAT_TAG_NONE, i_senderGuid
+        ChatHandler::BuildChatPacket(*data, CHAT_MSG_SYSTEM, text, LANG_UNIVERSAL, CHAT_TAG_NONE, i_senderGuid);
 #endif
         data_list.push_back(data);
     }


### PR DESCRIPTION
## 🍰 Pullrequest
This fixes building with `1.6.1.4544` support which was broken due to the syntax error here (missing `);` at the end of the line) that got introduced in https://github.com/vmangos/core/commit/0c63f28dce9983e29e156bc7bd832ae2111d96dd:
https://github.com/vmangos/core/blob/0c63f28dce9983e29e156bc7bd832ae2111d96dd/src/game/World.cpp#L2217

### Proof
<!-- Link resources as proof -->
- See example of broken https://github.com/vmangos/core/commit/0c63f28dce9983e29e156bc7bd832ae2111d96dd build [here](https://github.com/mserajnik/vmangos-deploy/actions/runs/13785277667/job/38551768503#step:10:2425)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Build with `1.6.1.4544` support and observe it compiles

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
