### PR TITLE
Set pacified timer on Majordomo after tele

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_majordomo_executus.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_majordomo_executus.cpp
@@ -291,7 +291,7 @@ struct boss_majordomoAI : public ScriptedAI
     void DomoTP()
     {
         // Summon new copy of Majordomo at Ragnaros Event position
-        if (Creature* Domo = m_creature->SummonCreature(m_creature->GetEntry(), 847.103f, -816.153f, -229.775f, 4.344f, TEMPSUMMON_TIMED_DESPAWN, (2 * 60 * 60 * 1000)))
+        if (Creature* Domo = m_creature->SummonCreature(m_creature->GetEntry(), 847.103f, -816.153f, -229.775f, 4.344f, TEMPSUMMON_TIMED_DESPAWN, (2 * 60 * 60 * 1000), false, 5000))
         {
             Domo->SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
             Domo->SetFactionTemplateId(FACTION_FRIENDLY);


### PR DESCRIPTION
Fixes an issue where players can .tele to Ragnaros and stand on top of Majordomos spawn point to aggro him before his flags are set.