### PR TITLE
CI: Improve database readiness check in workflows.

### DIFF
--- a/.github/workflows/db_check.yml
+++ b/.github/workflows/db_check.yml
@@ -25,8 +25,19 @@ jobs:
         sudo docker pull mysql
         sudo docker run --name mysqldb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:5.6 --max_allowed_packet=128M
         sudo docker start mysqldb
-        until nc -z localhost 3306 ; do sleep 5 ; echo "Waiting for database availability..." ; done
-
+        echo "Waiting for database availability..."
+        max_attempts=30
+        attempt=0
+        until docker exec mysqldb mysqladmin -u root -proot ping --silent &> /dev/null; do
+          attempt=$((attempt+1))
+          if [ $attempt -gt $max_attempts ]; then
+            echo "Database failed to become ready in time!"
+            exit 1
+          fi
+          echo "Waiting for database to be ready... (attempt $attempt/$max_attempts)"
+          sleep 5
+        done
+        echo "Database is ready!"
 
     - name: Checkout update sql
       uses: actions/checkout@v4

--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -28,8 +28,19 @@ jobs:
         sudo docker pull mysql
         sudo docker run --name mysqldb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:5.6 --max_allowed_packet=128M
         sudo docker start mysqldb
-        until nc -z localhost 3306 ; do sleep 5 ; echo "Waiting for database availability..." ; done
-
+        echo "Waiting for database availability..."
+        max_attempts=30
+        attempt=0
+        until docker exec mysqldb mysqladmin -u root -proot ping --silent &> /dev/null; do
+          attempt=$((attempt+1))
+          if [ $attempt -gt $max_attempts ]; then
+            echo "Database failed to become ready in time!"
+            exit 1
+          fi
+          echo "Waiting for database to be ready... (attempt $attempt/$max_attempts)"
+          sleep 5
+        done
+        echo "Database is ready!"
 
     - name: Checkout update sql
       uses: actions/checkout@v4


### PR DESCRIPTION
## 🍰 Pullrequest
This is an improvement over the simple database readiness check introduced in #2511 that should hopefully (finally) fix the issue with the sometimes [failing workflow runs](https://github.com/vmangos/core/actions/runs/14005031345/job/39217762032).

Compared to the previous check, this one not only verifies that the MySQL server is accepting connections but also that it is ready to process SQL commands.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
