### PR TITLE
fix: Loot.txt and LevelUp.txt logs are always generated

### DIFF
--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -105,8 +105,8 @@ void Log::OpenWorldLogFiles()
     logFiles[LOG_RA] = OpenLogFile("LogFile.Ra", "Ra.log", log_file_timestamp, false);
     logFiles[LOG_DBERROR] = OpenLogFile("LogFile.DBError", "DBErrors.log", log_file_timestamp, true);
     logFiles[LOG_DBERRFIX] = OpenLogFile("LogFile.DBErrorFix", "DBErrorFixes.sql", log_file_timestamp, true);
-    logFiles[LOG_LOOTS] = OpenLogFile("LootsLogFile", "Loot.log", log_file_timestamp, false);
-    logFiles[LOG_LEVELUP] = OpenLogFile("LevelupLogFile", "LevelUp.log", log_file_timestamp, false);
+    logFiles[LOG_LOOTS] = OpenLogFile("LogFile.Loot", "Loot.log", log_file_timestamp, false);
+    logFiles[LOG_LEVELUP] = OpenLogFile("LogFile.LevelUp", "LevelUp.log", log_file_timestamp, false);
     logFiles[LOG_PERFORMANCE] = OpenLogFile("LogFile.Performance", "Perf.log", log_file_timestamp, false);
     logFiles[LOG_MONEY_TRADES] = OpenLogFile("LogFile.Trades", "", log_file_timestamp, false);
     logFiles[LOG_GM] = sConfig.GetBoolDefault("GmLogPerAccount", false) ?


### PR DESCRIPTION
## 🍰 Pullrequest
Loot.txt and LevelUp.txt logs are always generated from [this commit](https://github.com/vmangos/core/commit/89e918e814580087820677aea04a2c2c39fbe226#diff-93eef7c860a081602c2a653fabf9e763c4384496c22aeb72cb110c0ff2d03991R109) because the token names in the code are wrong:
* LootsLogFile => LogFile.Loot
* LevelupLogFile => LogFile.LevelUp

### Issues
- fixes #2982 

### How2Test
- set `LogFile.Loot = ""`
- see your loot log on your logs folder created and growing...
