### PR TITLE
Don't perform multiple searches within instanceGroups

### DIFF
--- a/src/game/AI/CreatureAI.cpp
+++ b/src/game/AI/CreatureAI.cpp
@@ -206,11 +206,11 @@ void CreatureAI::ClearTargetIcon()
     std::unordered_set<Group*> instanceGroups;
 
     // Clear target icon for every unique group in instance
-    for (const auto& player : players)
+    for (auto const& player : players)
     {
         if (Group* pGroup = player.getSource()->GetGroup())
         {
-            const auto& result = instanceGroups.insert(pGroup);
+            auto const& result = instanceGroups.insert(pGroup);
 
             if (result.second)
             {

--- a/src/game/AI/CreatureAI.cpp
+++ b/src/game/AI/CreatureAI.cpp
@@ -212,7 +212,7 @@ void CreatureAI::ClearTargetIcon()
         {
             const auto& result = instanceGroups.insert(pGroup);
 
-            if (result->second)
+            if (result.second)
             {
                 pGroup->ClearTargetIcon(m_creature->GetObjectGuid());
             }

--- a/src/game/AI/CreatureAI.cpp
+++ b/src/game/AI/CreatureAI.cpp
@@ -27,6 +27,7 @@
 #include "ObjectMgr.h"
 #include "ScriptMgr.h"
 #include "Group.h"
+#include <unordered_set>
 
 CreatureAI::CreatureAI(Creature* creature) :
     m_creature(creature), m_bUseAiAtControl(false),
@@ -202,16 +203,17 @@ void CreatureAI::ClearTargetIcon()
     if (players.isEmpty())
         return;
 
-    std::set<Group*> instanceGroups;
+    std::unordered_set<Group*> instanceGroups;
 
     // Clear target icon for every unique group in instance
     for (const auto& player : players)
     {
         if (Group* pGroup = player.getSource()->GetGroup())
         {
-            if (instanceGroups.find(pGroup) == instanceGroups.end())
+            const auto& result = instanceGroups.insert(pGroup);
+
+            if (result->second)
             {
-                instanceGroups.insert(pGroup);
                 pGroup->ClearTargetIcon(m_creature->GetObjectGuid());
             }
         }


### PR DESCRIPTION
Insertion causes a lookup before returning false if the value isn't in the set, so performing a search before an insertion is duplicating work that will end up being done again. It's more efficient to try to insert and then clear the icons if the insertion was successful.

Also switched to unordered_set as it'll perform better for this mostly read 'heavy' scenario.

Included the header rather than relying on the container being transitively included as was the case for `set`. Will make no difference to compilation speed if it's already included. 