### PR TITLE
Fix instance data memory leak

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/molten_core/instance_molten_core.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/molten_core/instance_molten_core.cpp
@@ -58,6 +58,8 @@ struct instance_molten_core : ScriptedInstance
 
     uint64 GOUseGuidList[7];
 
+    std::string strInstData;
+
     void Initialize() override
     {
         memset(&m_auiEncounter, 0, sizeof(m_auiEncounter));
@@ -392,9 +394,8 @@ struct instance_molten_core : ScriptedInstance
                    << RuneActive[2] << " " << RuneActive[3] << " " << RuneActive[4] << " "
                    << RuneActive[5] << " " << RuneActive[6];
 
-        // TODO: Fuite de memoire. Mais empeche un crash.
-        std::string* strInstData = new std::string(saveStream.str());
-        return strInstData->c_str();
+        strInstData = saveStream.str();
+        return strInstData.c_str();
     }
 
     uint32 GetData(uint32 uiType) override


### PR DESCRIPTION
Not sure why this was being done this way but it's a Nostalrius era addition. Changed to handle instance data strings the same way as most other instances.