### PR TITLE
Implement evade on evade flag for creature_linking and correctly link adds for Faerlina

### DIFF
--- a/sql/migrations/20250411125645_world.sql
+++ b/sql/migrations/20250411125645_world.sql
@@ -1,0 +1,60 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20250411125645');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20250411125645');
+-- Add your query below.
+
+-- Herzul's bodguards should only spawn together with him:
+-- https://www.wowhead.com/classic/quest=852/hezrul-bloodmark#comments:id=3155347
+-- https://www.wowhead.com/classic/quest=852/hezrul-bloodmark#comments:id=2752959
+UPDATE `creature_linking` SET `flag` = 3203 WHERE `master_guid` = 13990;
+
+-- Raid trash linked to a boss can respawn if the boss hasn't been killed
+-- https://old.reddit.com/r/classicwow/comments/k1lucd/naxxramas_which_wing_provides_the_most_trashloot/
+-- Noth
+UPDATE `creature_linking` SET `flag` = 1024 WHERE `master_guid` = 88100 AND `flag` = 3072;
+-- Patchwerk
+UPDATE `creature_linking` SET `flag` = 1024 WHERE `master_guid` = 88298 AND `flag` = 3072;
+UPDATE `creature_linking` SET `flag` = 1025 WHERE `master_guid` = 88298 AND `flag` = 3073;
+-- Grobbulus
+UPDATE `creature_linking` SET `flag` = 1025 WHERE `master_guid` = 88303 AND `flag` = 3073;
+-- Anub'Rekhan
+UPDATE `creature_linking` SET `flag` = 1024 WHERE `master_guid` = 88346 AND `flag` = 3072;
+-- Instructor Razuvious
+UPDATE `creature_linking` SET `flag` = 1025 WHERE `master_guid` = 88460 AND `flag` = 3073;
+-- Gothik the Harvester
+UPDATE `creature_linking` SET `flag` = 1024 WHERE `master_guid` = 88479 AND `flag` = 3072;
+-- Maexxna
+UPDATE `creature_linking` SET `flag` = 1024 WHERE `master_guid` = 88483 AND `flag` = 3072;
+-- Grand Widow Faerlina
+UPDATE `creature_linking` SET `flag` = 1024 WHERE `master_guid` = 88496 AND `flag` = 3072;
+UPDATE `creature_linking` SET `flag` = 1025 WHERE `master_guid` = 88496 AND `flag` = 3073;
+
+-- Make Naxxramas Follower and Naxxramas Worshipper creatures in db
+INSERT INTO `creature` (`guid`, `id`, `id2`, `id3`, `id4`, `id5`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES 
+(88497, 16505, 0, 0, 0, 0, 533, 3359.75, -3621.77, 261.18, 4.54, 7200, 7200, 0, 100, 100, 0, 0, 0, 9, 10),
+(88498, 16505, 0, 0, 0, 0, 533, 3346.29, -3619.32, 261.18, 4.61, 7200, 7200, 0, 100, 100, 0, 0, 0, 9, 10),
+(88499, 16506, 0, 0, 0, 0, 533, 3350.61, -3619.74, 261.18, 4.65, 7200, 7200, 0, 100, 100, 0, 0, 0, 9, 10),
+(88500, 16506, 0, 0, 0, 0, 533, 3341.36, -3619.35, 261.18, 4.68, 7200, 7200, 0, 100, 100, 0, 0, 0, 9, 10),
+(88501, 16506, 0, 0, 0, 0, 533, 3356.69, -3621.17, 261.18, 4.38, 7200, 7200, 0, 100, 100, 0, 0, 0, 9, 10),
+(88502, 16506, 0, 0, 0, 0, 533, 3364.08, -3622.85, 261.18, 4.35, 7200, 7200, 0, 100, 100, 0, 0, 0, 9, 10);
+
+-- Link Grand Widow Faerlina, to Naxxramas Follower, Naxxramas Worshipper
+INSERT INTO `creature_linking` (`leader_guid`,`member_guid`,`flag`) VALUES 
+(88497, 88496, 19463),
+(88498, 88496, 19463),
+(88499, 88496, 19463),
+(88500, 88496, 19463),
+(88501, 88496, 19463),
+(88502, 88496, 19463);
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20250411125645_world.sql
+++ b/sql/migrations/20250411125645_world.sql
@@ -44,7 +44,7 @@ INSERT INTO `creature` (`guid`, `id`, `id2`, `id3`, `id4`, `id5`, `map`, `positi
 (88502, 16506, 0, 0, 0, 0, 533, 3364.08, -3622.85, 261.18, 4.35, 7200, 7200, 0, 100, 100, 0, 0, 0, 9, 10);
 
 -- Link Grand Widow Faerlina, to Naxxramas Follower, Naxxramas Worshipper
-INSERT INTO `creature_linking` (`leader_guid`,`member_guid`,`flag`) VALUES 
+INSERT INTO `creature_linking` (`guid`,`master_guid`,`flag`) VALUES 
 (88497, 88496, 19463),
 (88498, 88496, 19463),
 (88499, 88496, 19463),

--- a/src/game/Group/CreatureLinkingMgr.cpp
+++ b/src/game/Group/CreatureLinkingMgr.cpp
@@ -532,7 +532,8 @@ void CreatureLinkingHolder::ProcessSlave(CreatureLinkingEvent eventType, Creatur
                 else
                     pSlave->SetInCombatWith(pEnemy);
             }
-            else {
+            else if (pSlave->IsAlive())
+            {
                 pSlave->AI()->AttackStart(pEnemy);
                 if (pSource->GetMap()->IsDungeon() && pSource->HasStaticFlag(CREATURE_STATIC_FLAG_2_FORCE_RAID_COMBAT))
                     pSlave->SetInCombatWithZone();

--- a/src/game/Group/CreatureLinkingMgr.cpp
+++ b/src/game/Group/CreatureLinkingMgr.cpp
@@ -90,12 +90,12 @@ void CreatureLinkingMgr::LoadFromDB()
 
             CreatureLinkingInfo tmp;
 
-            uint32 entry = fields[0].GetUInt32();
-            tmp.mapId = fields[1].GetUInt32();
-            tmp.masterId = fields[2].GetUInt32();
-            tmp.linkingFlag = fields[3].GetUInt16();
-            tmp.searchRange = fields[4].GetUInt16();
-            tmp.masterDBGuid = 0;                        // Will be initialized for unique mobs in IsLinkingEntryValid (only for spawning dependend)
+            uint32 entry 	= fields[0].GetUInt32();
+            tmp.mapId 		= fields[1].GetUInt32();
+            tmp.masterId 	= fields[2].GetUInt32();
+            tmp.linkingFlag 	= fields[3].GetUInt16();
+            tmp.searchRange 	= fields[4].GetUInt16();
+            tmp.masterDBGuid 	= 0;                        // Will be initialized for unique mobs in IsLinkingEntryValid (only for spawning dependend)
 
             if (!IsLinkingEntryValid(entry, &tmp, true))
                 continue;
@@ -135,12 +135,12 @@ void CreatureLinkingMgr::LoadFromDB()
         Field* fields = result->Fetch();
         CreatureLinkingInfo tmp;
 
-        uint32 guid = fields[0].GetUInt32();
-        tmp.mapId = INVALID_MAP_ID;           // some invalid value, this marks the guid-linking
-        tmp.masterId = fields[1].GetUInt32();
-        tmp.linkingFlag = fields[2].GetUInt16();
-        tmp.masterDBGuid = tmp.masterId;
-        tmp.searchRange = 0;
+        uint32 guid 		= fields[0].GetUInt32();
+        tmp.mapId 		= INVALID_MAP_ID;           // some invalid value, this marks the guid-linking
+        tmp.masterId 		= fields[1].GetUInt32();
+        tmp.linkingFlag 	= fields[2].GetUInt16();
+        tmp.masterDBGuid 	= tmp.masterId;
+        tmp.searchRange 	= 0;
 
         if (!IsLinkingEntryValid(guid, &tmp, false))
             continue;
@@ -258,12 +258,12 @@ bool CreatureLinkingMgr::IsLinkingEntryValid(uint32 slaveEntry, CreatureLinkingI
 // Linked actions and corresponding flags
 enum EventMask
 {
-    EVENT_MASK_ON_AGGRO = FLAG_AGGRO_ON_AGGRO,
-    EVENT_MASK_ON_EVADE = FLAG_RESPAWN_ON_EVADE | FLAG_DESPAWN_ON_EVADE,
-    EVENT_MASK_ON_DIE = FLAG_DESPAWN_ON_DEATH | FLAG_SELFKILL_ON_DEATH | FLAG_RESPAWN_ON_DEATH | FLAG_FOLLOW,
-    EVENT_MASK_ON_RESPAWN = FLAG_RESPAWN_ON_RESPAWN | FLAG_DESPAWN_ON_RESPAWN | FLAG_FOLLOW,
-    EVENT_MASK_TRIGGER_TO = FLAG_TO_AGGRO_ON_AGGRO | FLAG_TO_RESPAWN_ON_EVADE | FLAG_FOLLOW,
-    EVENT_MASK_ON_DESPAWN = FLAG_DESPAWN_ON_DESPAWN,
+    EVENT_MASK_ON_AGGRO 	= FLAG_AGGRO_ON_AGGRO,
+    EVENT_MASK_ON_EVADE 	= FLAG_RESPAWN_ON_EVADE | FLAG_DESPAWN_ON_EVADE | FLAG_EVADE_ON_EVADE,
+    EVENT_MASK_ON_DIE 		= FLAG_DESPAWN_ON_DEATH | FLAG_SELFKILL_ON_DEATH | FLAG_RESPAWN_ON_DEATH | FLAG_FOLLOW,
+    EVENT_MASK_ON_RESPAWN 	= FLAG_RESPAWN_ON_RESPAWN | FLAG_DESPAWN_ON_RESPAWN | FLAG_FOLLOW,
+    EVENT_MASK_TRIGGER_TO 	= FLAG_TO_AGGRO_ON_AGGRO | FLAG_TO_RESPAWN_ON_EVADE | FLAG_FOLLOW,
+    EVENT_MASK_ON_DESPAWN 	= FLAG_DESPAWN_ON_DESPAWN,
 };
 
 // This functions checks if the NPC has linked NPCs for dynamic action
@@ -418,11 +418,11 @@ void CreatureLinkingHolder::DoCreatureLinkingEvent(CreatureLinkingEvent eventTyp
 
     switch (eventType)
     {
-    case LINKING_EVENT_AGGRO:   eventFlagFilter = EVENT_MASK_ON_AGGRO;   reverseEventFlagFilter = FLAG_TO_AGGRO_ON_AGGRO;   break;
-    case LINKING_EVENT_EVADE:   eventFlagFilter = EVENT_MASK_ON_EVADE;   reverseEventFlagFilter = FLAG_TO_RESPAWN_ON_EVADE; break;
-    case LINKING_EVENT_DIE:     eventFlagFilter = EVENT_MASK_ON_DIE;     reverseEventFlagFilter = 0;                        break;
-    case LINKING_EVENT_RESPAWN: eventFlagFilter = EVENT_MASK_ON_RESPAWN; reverseEventFlagFilter = FLAG_FOLLOW;              break;
-    case LINKING_EVENT_DESPAWN: eventFlagFilter = EVENT_MASK_ON_DESPAWN; reverseEventFlagFilter = 0;                        break;
+        case LINKING_EVENT_AGGRO:   eventFlagFilter = EVENT_MASK_ON_AGGRO;   reverseEventFlagFilter = FLAG_TO_AGGRO_ON_AGGRO;   break;
+        case LINKING_EVENT_EVADE:   eventFlagFilter = EVENT_MASK_ON_EVADE;   reverseEventFlagFilter = FLAG_TO_RESPAWN_ON_EVADE; break;
+        case LINKING_EVENT_DIE:     eventFlagFilter = EVENT_MASK_ON_DIE;     reverseEventFlagFilter = 0;                        break;
+        case LINKING_EVENT_RESPAWN: eventFlagFilter = EVENT_MASK_ON_RESPAWN; reverseEventFlagFilter = FLAG_FOLLOW;              break;
+        case LINKING_EVENT_DESPAWN: eventFlagFilter = EVENT_MASK_ON_DESPAWN; reverseEventFlagFilter = 0;                        break;
     }
 
     // Process Slaves (by entry)
@@ -542,6 +542,8 @@ void CreatureLinkingHolder::ProcessSlave(CreatureLinkingEvent eventType, Creatur
     case LINKING_EVENT_EVADE:
         if (flag & FLAG_DESPAWN_ON_EVADE && pSlave->IsAlive())
             pSlave->ForcedDespawn();
+        if (flag & FLAG_EVADE_ON_EVADE && pSlave->IsAlive())
+            pSlave->AI()->EnterEvadeMode();
         if (flag & FLAG_RESPAWN_ON_EVADE && !pSlave->IsAlive())
             pSlave->Respawn();
         break;

--- a/src/game/Group/CreatureLinkingMgr.h
+++ b/src/game/Group/CreatureLinkingMgr.h
@@ -45,39 +45,31 @@ class Map;
 // enum on which Events an action for linked NPCs can trigger
 enum CreatureLinkingEvent
 {
-    LINKING_EVENT_AGGRO = 0,
-    LINKING_EVENT_EVADE = 1,
-    LINKING_EVENT_DIE = 2,
-    LINKING_EVENT_RESPAWN = 3,
-    LINKING_EVENT_DESPAWN = 4,
+    LINKING_EVENT_AGGRO 	= 0,
+    LINKING_EVENT_EVADE 	= 1,
+    LINKING_EVENT_DIE 		= 2,
+    LINKING_EVENT_RESPAWN 	= 3,
+    LINKING_EVENT_DESPAWN 	= 4,
 };
 
-// enum describing possible flags action flags for NPCs linked to other NPCs
-// These flags are actually put into the database
-// FLAG_TO_ means, that in this case the linked NPC will also trigger an action for the NPC it is linked to
 enum CreatureLinkingFlags
 {
-    // Dynamic behaviour, in combat
-    FLAG_AGGRO_ON_AGGRO = 0x0001,
-    FLAG_TO_AGGRO_ON_AGGRO = 0x0002,
-    FLAG_RESPAWN_ON_EVADE = 0x0004,
-    FLAG_TO_RESPAWN_ON_EVADE = 0x0008,
-    FLAG_DESPAWN_ON_EVADE = 0x1000,
-    FLAG_DESPAWN_ON_DEATH = 0x0010,
-    FLAG_SELFKILL_ON_DEATH = 0x0020,
-    FLAG_RESPAWN_ON_DEATH = 0x0040,
-    FLAG_RESPAWN_ON_RESPAWN = 0x0080,
-    FLAG_DESPAWN_ON_RESPAWN = 0x0100,
-
-    // Dynamic behaviour, out of combat
-    FLAG_FOLLOW = 0x0200,
-    FLAG_DESPAWN_ON_DESPAWN = 0x2000,
-
-    // Passive behaviour
-    FLAG_CANT_SPAWN_IF_BOSS_DEAD = 0x0400,
-    FLAG_CANT_SPAWN_IF_BOSS_ALIVE = 0x0800,
-
-    LINKING_FLAG_INVALID = 0x4000,               // TODO adjust when other flags are implemented
+    FLAG_AGGRO_ON_AGGRO             = 0x0001,		// Aggro slave on master aggro
+    FLAG_TO_AGGRO_ON_AGGRO          = 0x0002,		// Aggro master on slave aggro
+    FLAG_RESPAWN_ON_EVADE           = 0x0004,		// Respawn slave on master evade
+    FLAG_TO_RESPAWN_ON_EVADE        = 0x0008,		// Respawn master on slave evade
+    FLAG_DESPAWN_ON_DEATH           = 0x0010,		// Despawn slave on mater death
+    FLAG_SELFKILL_ON_DEATH          = 0x0020,		// Kill slave on master death
+    FLAG_RESPAWN_ON_DEATH           = 0x0040,		// Respawn slave on master death
+    FLAG_RESPAWN_ON_RESPAWN         = 0x0080,		// Respawn slave on master respawn
+    FLAG_DESPAWN_ON_RESPAWN         = 0x0100,		// Despawn slave on master respawn
+    FLAG_FOLLOW                     = 0x0200,		// Slave moves following master's movement
+    FLAG_CANT_SPAWN_IF_BOSS_DEAD    = 0x0400,		// Slave won't spawn if master dead
+    FLAG_CANT_SPAWN_IF_BOSS_ALIVE   = 0x0800,		// Slave won't spawn if master alive	
+    FLAG_DESPAWN_ON_EVADE           = 0x1000,		// Despawn slave on master evade
+    FLAG_DESPAWN_ON_DESPAWN         = 0x2000,		// Slave despawns on master despawn
+    FLAG_EVADE_ON_EVADE             = 0x4000,		// Slave evades on master evade
+    LINKING_FLAG_INVALID            = 0x8000,       // TODO adjust when other flags are implemented
 };
 
 // Structure holding the information for an entry


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
* Implements FLAG_EVADE_ON_EVADE (taken from cmangos)
* Corrects creature_linking flags for creatures currently listed in db (many links are missing)
* Fixes a bug with Faerlina where Naxxramas Worshippers and Followers weren't linked to her.

A lot of further improvements and fixes to the boss script can be made based off of cmangos, but that's outside of this PR's scope.

### Proof
<!-- Link resources as proof -->
- Specific proofs commented in world migration.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/vmangos/core/issues/2810

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Pull one of Faerlina's adds -> She aggros
- Pull Faerlina -> Her adds aggro

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
