### PR TITLE
Prevent crash in MoveMap.cpp

### DIFF
--- a/src/game/Maps/MoveMap.cpp
+++ b/src/game/Maps/MoveMap.cpp
@@ -181,8 +181,6 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
         return false;
     }
 
-    MANGOS_ASSERT(data);
-
     size_t result = fread(data, fileHeader.size, 1, file);
     if (!result)
     {

--- a/src/game/Maps/MoveMap.cpp
+++ b/src/game/Maps/MoveMap.cpp
@@ -174,6 +174,13 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
     }
 
     unsigned char* data = (unsigned char*)dtAlloc(fileHeader.size, DT_ALLOC_PERM);
+    if (!data)
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Failed to load mmap %03u%02i%02i.mmtile", mapId, x, y);
+        fclose(file);
+        return false;
+    }
+
     MANGOS_ASSERT(data);
 
     size_t result = fread(data, fileHeader.size, 1, file);


### PR DESCRIPTION
Adds crash protection if mmap fails to load.

Happened today while updating Chrome with server running, likely some form of memory corruption which caused a failure to load the mmap properly before passing it on. This adds checks to instead return if data is null.