### PR TITLE
Move creature min/max level check to objectmgr

### DIFF
--- a/sql/migrations/20250418172108_world.sql
+++ b/sql/migrations/20250418172108_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20250418172108');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20250418172108');
+-- Add your query below.
+
+-- Correct levelrange for Morbent Fel Pre 1.6
+
+UPDATE `creature_template` SET `level_max`=35 WHERE  `entry`=1200 AND `patch`=0;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -1622,9 +1622,7 @@ void ObjectMgr::CheckCreatureTemplate(CreatureInfo* cInfo)
 
     if (cInfo->level_min > cInfo->level_max)
     {
-        uint32 tmp = cInfo->level_min;
-        cInfo->level_min = cInfo->level_max;
-        cInfo->level_max = tmp;
+        std::swap(cInfo->level_min, cInfo->level_max);
         sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Creature (Entry: %u) has level_min (%u) greater than level_max (%u), values have been swapped.", cInfo->entry, cInfo->level_max, cInfo->level_min);
     }
 

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -1236,6 +1236,12 @@ void ObjectMgr::LoadCreatureInfo(Field* fields)
     pInfo->subname = fields[2].GetCppString();
     pInfo->level_min = fields[3].GetUInt32();
     pInfo->level_max = fields[4].GetUInt32();
+    if (pInfo->level_min > pInfo->level_max)
+    {
+        pInfo->level_min = fields[4].GetUInt32();
+        pInfo->level_max = fields[3].GetUInt32();
+        sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Creature (Entry: %u) has level_min (%u) greater than level_max (%u), values have been swapped.", pInfo->entry, fields[3].GetUInt32(), fields[4].GetUInt32());
+    }
     pInfo->faction = fields[5].GetUInt32();
     pInfo->npc_flags = fields[6].GetUInt32();
     pInfo->gossip_menu_id = fields[7].GetUInt32();

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -1236,12 +1236,6 @@ void ObjectMgr::LoadCreatureInfo(Field* fields)
     pInfo->subname = fields[2].GetCppString();
     pInfo->level_min = fields[3].GetUInt32();
     pInfo->level_max = fields[4].GetUInt32();
-    if (pInfo->level_min > pInfo->level_max)
-    {
-        pInfo->level_min = fields[4].GetUInt32();
-        pInfo->level_max = fields[3].GetUInt32();
-        sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Creature (Entry: %u) has level_min (%u) greater than level_max (%u), values have been swapped.", pInfo->entry, fields[3].GetUInt32(), fields[4].GetUInt32());
-    }
     pInfo->faction = fields[5].GetUInt32();
     pInfo->npc_flags = fields[6].GetUInt32();
     pInfo->gossip_menu_id = fields[7].GetUInt32();
@@ -1624,6 +1618,14 @@ void ObjectMgr::CheckCreatureTemplate(CreatureInfo* cInfo)
 
         if (cInfo->skinning_loot_id)
             sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Creature (Entry: %u) with despawn instantly flag has skinning loot assigned. It will never be lootable.", cInfo->entry);
+    }
+
+    if (cInfo->level_min > cInfo->level_max)
+    {
+        uint32 tmp = cInfo->level_min;
+        cInfo->level_min = cInfo->level_max;
+        cInfo->level_max = tmp;
+        sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Creature (Entry: %u) has level_min (%u) greater than level_max (%u), values have been swapped.", cInfo->entry, cInfo->level_max, cInfo->level_min);
     }
 
     ConvertCreatureAurasField<CreatureInfo>(cInfo, "creature_template", "Entry", cInfo->entry);

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -1703,8 +1703,8 @@ void Creature::SelectLevel(float percentHealth, float percentMana)
     CreatureInfo const* cinfo = GetCreatureInfo();
 
     // level
-    uint32 const minLevel = std::min(cinfo->level_max, cinfo->level_min);
-    uint32 const maxLevel = std::max(cinfo->level_max, cinfo->level_min);
+    uint32 const minLevel = cinfo->level_min;
+    uint32 const maxLevel = cinfo->level_max;
     uint32 const level = minLevel == maxLevel ? minLevel : urand(minLevel, maxLevel);
 
     SetLevel(level);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR moves a check for swapped creature min_level/max_level to objmgr. So it's only checked during loading.
Also added log output

Bonus fix: Corrected levelrange for Morbent Fel

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
