### PR TITLE
Fix potential g3d assert with debug los check

### DIFF
--- a/src/game/Commands/DebugCommands.cpp
+++ b/src/game/Commands/DebugCommands.cpp
@@ -1646,6 +1646,12 @@ bool ChatHandler::HandleDebugLoSCommand(char*)
         return false;
     }
 
+    if (target->GetDistance(m_session->GetPlayer()) < 0.1f)
+    {
+        SendSysMessage("You are to close to the target.");
+        return false;
+    }
+
     float x0, y0, z0;
     float x1, y1, z1;
     m_session->GetPlayer()->GetPosition(x0, y0, z0);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
An assert can happen in G3D - when built in debug mode and distance is none or very very low.

This PR ensure that a minimum distance of 0.1

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- build in debug
- target yourself
- .debug los check

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
