### PR TITLE
CalculateForDebuffLimit() - Remove unreachable cases and improve comments

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -8042,7 +8042,12 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 19755: // Frightalon
         case 19784: // Dark Iron Bomb
         case 19872: // Calm Dragonkin
-        case 19975: // Entangling Roots (Rank 1-6) (Proc from Nature's Grasp)
+        case 19975: // Entangling Roots (Rank 1) (Proc from Nature's Grasp)
+        case 19974: // Entangling Roots (Rank 2) (Proc from Nature's Grasp)
+        case 19973: // Entangling Roots (Rank 3) (Proc from Nature's Grasp)
+        case 19972: // Entangling Roots (Rank 4) (Proc from Nature's Grasp)
+        case 19971: // Entangling Roots (Rank 5) (Proc from Nature's Grasp)
+        case 19970: // Entangling Roots (Rank 6) (Proc from Nature's Grasp)
         case 20066: // Repentance
         case 20586: // Windreaper
         case 24375: // War Stomp

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -7984,18 +7984,16 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 4069: // Big Iron Bomb
         case 4507: // Target Dummy Spawn Effect
         case 5246: // Intimidating Shout
-        case 5530: // Mace Stun Effect
+        case 5530: // Mace Stun Effect (Rank 1)
         case 6358: // Seduction
         case 6788: // Weakened Soul
         case 9672: // Frostbolt (npc spell)
-        case 339: // Entangling Roots
-        case 2908: // Soothe Animal
-        case 8056: // Frost Shock
-        case 8122: // Psychic Scream
-        case 605: // Mind Control
-        case 6770: // Sap (Rank 1)
-        case 2070: // Sap (Rank 2)
-        case 11297: // Sap (rank 3)
+        case 339: // Entangling Roots (Ranks 1 to 6)
+        case 2908: // Soothe Animal (Ranks 1 to 3)
+        case 8056: // Frost Shock (Ranks 1 to 4)
+        case 8122: // Psychic Scream (Ranks 1 to 4)
+        case 605: // Mind Control (Ranks 1 to 3)
+        case 6770: // Sap (Ranks 1 to 3)
         case 18202: // Rend (item spell)
         case 18075: // Rend (item spell)
         case 17511: // Poison
@@ -8005,21 +8003,21 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 17407: // Wound
         case 17196: // Seeping Willow
         case 16406: // Rend (item spell)
-        case 14914: // Holy Fire
+        case 14914: // Holy Fire (Ranks 1 to 8)
         case 21162: // Fireball (item spell)
-        case 13752: // Faerie Fire (item spell)
+        case 13752: // Faerie Fire (Rank 2) (item spell)
         case 12328: // Death Wish
         case 13526: // Corrosive Poison
         case 13318: // Rend (item spell)
-        case 11366: // Pyroblast
-        case 133: // Fireball
+        case 11366: // Pyroblast (Ranks 1 to 8)
+        case 133: // Fireball (Ranks 1 to 12)
         case 12721: // Deep Wound
         case 24388: // Brain Damage
         case 21159: // Fireball (item spell)
         case 21151: // Gutgore Ripper
         case 12421: // Mithril Frag Bomb
         case 12562: // The Big One
-        case 118: // Polymorph
+        case 118: // Polymorph (Ranks 1 to 4)
         case 13237: // Goblin Mortar
         case 13327: // Reckless Charge
         case 13747: // Slow
@@ -8030,21 +8028,21 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 14309: // Freezing Trap Effect (Rank 3)
         case 15235: // Crystal Yield
         case 15487: // Silence
-        case 8034: // Frost Brand Attack
+        case 8034: // Frostbrand Attack (Ranks 1 to 5)
         case 16454: // Searing Blast
         case 17153: // Rend (item spell)
-        case 5484: // Howl of Terror
+        case 5484: // Howl of Terror (Ranks 1 to 2)
         case 18093: // Pyroclasm
         case 18118: // Aftermath
         case 18223: // Curse of Exhaustion
-        case 710: // Banish
+        case 710: // Banish (Ranks 1 to 2)
         case 18798: // Freeze
         case 19229: // Improved Wing Clip
         case 19410: // Improved Concussive Shot
         case 19755: // Frightalon
         case 19784: // Dark Iron Bomb
         case 19872: // Calm Dragonkin
-        case 19970: // Entangling Roots
+        case 19975: // Entangling Roots (Rank 1-6) (Proc from Nature's Grasp)
         case 20066: // Repentance
         case 20586: // Windreaper
         case 24375: // War Stomp
@@ -8053,21 +8051,17 @@ void SpellAuraHolder::CalculateForDebuffLimit()
             return;
         // Category 1 below
         case 1833: // Cheap Shot
-        case 5917: // Fumble
+        case 5917: // Fumble (Rank 1)
         case 7922: // Charge Stun
         case 9658: // Flame Buffet
         case 10578: // Fireball (item spell)
-        case 2096: // Mind Vision
-        case 453: // Mind Soothe
-        case 1714: // Curse of Tongues
-        case 11103: // Impact (Rank 1)
-        case 12357: // Impact (Rank 2)
-        case 12358: // Impact (Rank 3)
-        case 12359: // Impact (Rank 4)
-        case 12360: // Impact (Rank 5)
-        case 11113: // Blast Wave
-        case 2974: // Wing Clip
-        case 3043: // Scorpid Sting
+        case 2096: // Mind Vision (Ranks 1 to 2)
+        case 453: // Mind Soothe (Ranks 1 to 3)
+        case 1714: // Curse of Tongues (Ranks 1 to 2)
+        case 11103: // Impact (Ranks 1 to 5)
+        case 11113: // Blast Wave (Ranks 1 to 5)
+        case 2974: // Wing Clip (Ranks 1 to 3)
+        case 3043: // Scorpid Sting (Ranks 1 to 4)
         case 16413: // Fireball (item spell)
         case 16415: // Fireball (item spell)
         case 17330: // Poison
@@ -8078,11 +8072,11 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 18469: // Counterspell - Silenced
         case 18498: // Shield Bash - Silenced
         case 19821: // Arcane Bomb
-        case 20184: // Judgement of Justice
+        case 20184: // Judgement of Justice (Rank 1)
         case 20511: // Intimidating Shout
         case 22639: // Eskhandar's Rake
         case 23023: // Conflagration
-        case 28272: // Polymorph Pig
+        case 28272: // Polymorph: Pig
             m_visibleSlotLimitScore = 1;
             return;
         // Category 2 below
@@ -8091,27 +8085,24 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 26017: // Vindication (Rank 2)
         case 26018: // Vindication (Rank 3)
         case 23605: // Spell Vulnerability
-        case 702: // Curse of Weakness
+        case 702: // Curse of Weakness (Ranks 1 to 6)
         case 11374: // Gift of Arthas
-        case 8921: // Moonfire
-        case 18265: // Siphon Life
-        case 980: // Curse of Agony
-        case 13797: // Immolation Trap Effect
-        case 1978: // Serpent Sting
+        case 8921: // Moonfire (Ranks 1 to 10)
+        case 18265: // Siphon Life (Ranks 1 to 4)
+        case 980: // Curse of Agony (Ranks 1 to 6)
+        case 13797: // Immolation Trap Effect (Ranks 1 to 5)
+        case 1978: // Serpent Sting (Ranks 1 to 9)
         case 21992: // Thunderfury
-        case 2818: // Deadly Poison
-        case 348: // Immolate
+        case 2818: // Deadly Poison (Ranks 1 to 5)
+        case 348: // Immolate (Ranks 1 to 8)
         case 23577: // Expose Weakness
         case 17315: // Puncture Armor
         case 16928: // Armor Shatter
-        case 17877: // Shadowburn
+        case 17877: // Shadowburn (Ranks 1 to 6)
         case 23415: // Improved Blessing of Protection
-        case 9035: // Hex of Weakness
-        case 2944: // Devouring Plague
-        case 24640: // Scorpid Poison (Rank 1)
-        case 24583: // Scorpid Poison (Rank 2)
-        case 24586: // Scorpid Poison (Rank 3)
-        case 24587: // Scorpid Poison (Rank 4)
+        case 9035: // Hex of Weakness (Ranks 1 to 6)
+        case 2944: // Devouring Plague (Ranks 1 to 6)
+        case 24640: // Scorpid Poison (Ranks 1 to 4)
         case 12766: // Poison Cloud
         case 2943: // Touch of Weakness (Rank 1)
         case 19249: // Touch of Weakness (Rank 2)
@@ -8119,12 +8110,12 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 19252: // Touch of Weakness (Rank 4)
         case 19253: // Touch of Weakness (Rank 5)
         case 19254: // Touch of Weakness (Rank 6)
-        case 8050: // Flame Shock
-        case 172: // Corruption
+        case 8050: // Flame Shock (Ranks 1 to 6)
+        case 172: // Corruption (Ranks 1 to 7)
         case 16528: // Numbing Pain
-        case 15258: // Shadow Vulnerability
+        case 15258: // Shadow Vulnerability (Rank 1)
         case 13003: // Shrink Ray
-        case 589: // Shadow Word: Pain
+        case 589: // Shadow Word: Pain (Ranks 1 to 8)
         case 12654: // Ignite
             m_visibleSlotLimitScore = 2;
             return;
@@ -8138,57 +8129,47 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 4068: // Iron Grenade
         case 5116: // Concussive Shot
         case 5209: // Challenging Roar
-        case 5782: // Fear
-        case 770: // Faerie Fire
-        case 16857: // Faerie Fire (Feral)
-        case 120: // Cone of Cold
-        case 10: // Blizzard
-        case 2120: // Flamestrike
-        case 122: // Frost Nova
-        case 853: // Hammer of Justice
-        case 5760: // Mind-numbing Poison
-        case 8692: // Mind-numbing Poison II
-        case 11398: // Mind-numbing Poison III
-        case 1120: // Drain Soul
-        case 5740: // Rain of Fire
-        case 689: // Drain Life
-        case 5138: // Drain Mana
-        case 704: // Curse of Reclessness
-        case 1490: // Curse of the Elements
+        case 5782: // Fear (Ranks 1 to 3)
+        case 770: // Faerie Fire (Ranks 1 to 4)
+        case 16857: // Faerie Fire (Feral) (Ranks 1 to 4)
+        case 120: // Cone of Cold (Ranks 1 to 5)
+        case 10: // Blizzard (Ranks 1 to 6)
+        case 2120: // Flamestrike (Ranks 1 to 6)
+        case 122: // Frost Nova (Ranks 1 to 4)
+        case 853: // Hammer of Justice (Ranks 1 to 4)
+        case 5760: // Mind-numbing Poison (Rank 1)
+        case 8692: // Mind-numbing Poison II (Rank 2)
+        case 11398: // Mind-numbing Poison III (Rank 3)
+        case 1120: // Drain Soul (Ranks 1 to 4)
+        case 5740: // Rain of Fire (Ranks 1 to 4)
+        case 689: // Drain Life (Ranks 1 to 6)
+        case 5138: // Drain Mana (Ranks 1 to 4)
+        case 704: // Curse of Recklessness (Ranks 1 to 4)
+        case 1490: // Curse of the Elements (Ranks 1 to 3)
         case 12323: // Piercing Howl
-        case 11071: // Forstbite (Rank 1)
-        case 12496: // Frostbite (Rank 2)
-        case 12497: // Frostbite (Rank 3)
+        case 11071: // Frostbite (Ranks 1 to 3)
         case 12543: // Hi-Explosive Bomb
-        case 12798: // Revenge
+        case 12798: // Revenge Stun (Rank 1)
         case 12809: // Concussion Blow
-        case 13218: // Wound Poison
+        case 13218: // Wound Poison (Ranks 1 to 4)
         case 13810: // Frost Trap Aura
-        case 3034: // Viper Sting
-        case 1510: // Volley
-        case 13812: // Explosive Trap Effect
-        case 1130: // Hunter's Mark
+        case 3034: // Viper Sting (Ranks 1 to 3)
+        case 1510: // Volley (Ranks 1 to 3)
+        case 13812: // Explosive Trap Effect (Ranks 1 to 3)
+        case 1130: // Hunter's Mark (Ranks 1 to 4)
         case 15286: // Vampiric Embrace
-        case 15268: // Blackout (Rank 1)
-        case 15323: // Blackout (Rank 2)
-        case 15324: // Blackout (Rank 3)
-        case 15325: // Blackout (Rank 4)
-        case 15326: // Blackout (Rank 5)
-        case 15407: // Mind Flay
+        case 15268: // Blackout (Ranks 1 to 5)
+        case 15407: // Mind Flay (Ranks 1 to 6)
         case 16922: // Starfire Stun
-        case 17364: // Stormstrike
-        case 16914: // Hurricane
-        case 17794: // Shadow Vulnerability (Rank 1)
-        case 17798: // Shadow Vulnerability (Rank 2)
-        case 17797: // Shadow Vulnerability (Rank 3)
-        case 17799: // Shadow Vulnerability (Rank 4)
-        case 17800: // Shadow Vulnerability (Rank 5)
-        case 6789: // Death Coil
-        case 17862: // Curse of Shadow
+        case 17364: // Stormstrike (Rank 1)
+        case 16914: // Hurricane (Ranks 1 to 3)
+        case 17794: // Shadow Vulnerability (Ranks 1 to 5)
+        case 6789: // Death Coil (Ranks 1 to 3)
+        case 17862: // Curse of Shadow (Ranks 1 to 2)
         case 18656: // Corruption (item spell)
-        case 2637: // Hibernate
+        case 2637: // Hibernate (Ranks 1 to 3)
         case 19185: // Entrapment
-        case 10797: // Starshards
+        case 10797: // Starshards (Ranks 1 to 7)
         case 19503: // Scatter Shot
         case 19675: // Feral Charge Effect
         case 19769: // Thorium Grenade
@@ -8206,22 +8187,19 @@ void SpellAuraHolder::CalculateForDebuffLimit()
         case 20186: // Judgement of Wisdom (Rank 1)
         case 20354: // Judgement of Wisdom (Rank 2)
         case 20355: // Judgement of Wisdom (Rank 3)
-        case 20549: // War Stomp
+        case 20549: // War Stomp (Racial)
         case 20253: // Intercept Stun (Rank 1)
         case 20614: // Intercept Stun (Rank 2)
         case 20615: // Intercept Stun (Rank 3)
         case 20116: // Consecration (-1.8)
-        case 26573: // Consecration (1.9+)
+        case 26573: // Consecration (1.9+) (Ranks 1 to 5)
         case 21152: // Earthshaker
         case 22959: // Fire Vulnerability
         case 23454: // Stun
         case 23694: // Improved Hamstring
-        case 24423: // Screech (Rank 1)
-        case 24577: // Screech (Rank 2)
-        case 24578: // Screech (Rank 3)
-        case 24579: // Screech (Rank 4)
-        case 5570: // Insect Swarm
-        case 116: // Frostbolt
+        case 24423: // Screech (Ranks 1 to 4)
+        case 5570: // Insect Swarm (Ranks 1 to 5)
+        case 116: // Frostbolt (Ranks 1 to 11)
         case 25999: // Boar Charge
             m_visibleSlotLimitScore = 3;
             return;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

This pull request cleans up the spell case handling to be more maintainable:

1. Remove cases that cannot be triggered because their spell IDs fallback to a different spell ID through GetFirstSpellInChain().
2. Update spell name in comments to match the names in spell_template exactly for better clarity and easier lookup.
3. Add rank information in comments when a case affects multiple spell ranks.
4. Add missing ranks 1–5 of Entangling Roots (Nature's Grasp proc). Rank 6 was already handled in the code, but earlier ranks were missing. I **assume** the missing ranks was a oversight.

**Example on cases removed - and explanation:**
Before

> case 11103: // Impact (Rank 1)
> case 12357: // Impact (Rank 2)
> case 12358: // Impact (Rank 3)
> case 12359: // Impact (Rank 4)
> case 12360: // Impact (Rank 5)

After

> case 11103: // Impact (Rank 1-5)

Only 11103 is needed, as all other ranks for that spell fallback to it through GetFirstSpellInChain().

### Proof
<!-- Link resources as proof -->
I parsed all spells through GetFirstSpellInChain() to identify unreachable cases. 
Then I did a 2nd parse to update rank comments.

Tested with 1.12.1 and 1.7.1 DBCs.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
