### PR TITLE
Move reagent vendors in feathermoon stronghold and camp mojache to patch 1.3

### DIFF
--- a/sql/migrations/20250504130011_world.sql
+++ b/sql/migrations/20250504130011_world.sql
@@ -1,0 +1,24 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20250504130011');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20250504130011');
+-- Add your query below.
+
+-- 1.3.0 Patchnotes: Reagent Vendors have been added to Feathermoon Stronghold and Camp Mojache in Feralas.
+-- Tarhus <Reagent Vendor> and Jadenvis Seawatcher <Reagent Vendor>
+UPDATE `creature_template` SET `patch`=1 WHERE  `entry`=3700 AND `patch`=0;
+UPDATE `creature_template` SET `patch`=1 WHERE  `entry`=3500 AND `patch`=0;
+
+UPDATE `creature` SET `patch_min`=1 WHERE  `guid`=50234;
+UPDATE `creature` SET `patch_min`=1 WHERE  `guid`=50967;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Move reagent vendors in Feathermoon Stronghold and Camp Mojache to patch 1.3

### Proof
<!-- Link resources as proof -->
[https://wowpedia.fandom.com/wiki/Patch_1.3.0#World_Environment](https://wowpedia.fandom.com/wiki/Patch_1.3.0#World_Environment)
Reagent Vendors have been added to Feathermoon Stronghold and Camp Mojache in Feralas.

[https://web.archive.org/web/20050528235051/http://wow.allakhazam.com/news/sdetail5329.html](https://web.archive.org/web/20050528235051/http://wow.allakhazam.com/news/sdetail5329.html)
Tarhus added to new mobs on March 22, 2005 - Patch 1.3.0 was released March 7, 2005.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
