### PR TITLE
Possible fix to XP per kill rounding/truncation issue

### DIFF
--- a/src/game/Formulas.h
+++ b/src/game/Formulas.h
@@ -94,7 +94,7 @@ namespace MaNGOS
             return 0;
         }
 
-        inline uint32 BaseGain(uint32 ownerLevel, uint32 unitLevel, uint32 mob_level)
+        inline float BaseGain(uint32 ownerLevel, uint32 unitLevel, uint32 mob_level)
         {
             uint32 const nBaseExp = 45;
             return (ownerLevel * 5 + nBaseExp) * BaseGainLevelFactor(unitLevel, mob_level);

--- a/src/game/Formulas.h
+++ b/src/game/Formulas.h
@@ -96,7 +96,7 @@ namespace MaNGOS
 
         inline float BaseGain(uint32 ownerLevel, uint32 unitLevel, uint32 mob_level)
         {
-            uint32 const nBaseExp = 45;
+            float const nBaseExp = 45;
             return (ownerLevel * 5 + nBaseExp) * BaseGainLevelFactor(unitLevel, mob_level);
         }
 


### PR DESCRIPTION
The multiplication step `(ownerlevel * 5 + nBaseExp) * BaseGainLevelFactor()` produces a `float` value, but since the return type of `BaseGain` is `uint32`, the compiler implicitly truncates the XP value when converting from `float` to `uint32`.

By changing the return type of `BaseGain` from `uint32` to `float`, this preserves the fractional XP value until the very end, when the XP value is converted to an integer using `std:nearbyint()`. 


I did very limited testing, but killing a Level 3 mob as Level 2 player did, in fact, yield `58` rather than `57` XP.

I, in no way, pretend to be an expert, and I'm happy to be educated in a different direction if this change is flawed in some way.
