### PR TITLE
Fix missing loot for Jade

### DIFF
--- a/sql/migrations/20250524153727_world.sql
+++ b/sql/migrations/20250524153727_world.sql
@@ -10,7 +10,7 @@ INSERT INTO `migrations` VALUES ('20250524153727');
 
 -- Fix missing loot for Jade
 INSERT INTO creature_loot_template (entry, item, ChanceOrQuestChance, groupid, mincountOrRef, maxcount, condition_id, patch_min, patch_max) 
-VALUES (1063, 30072, 1, 0, -30072, 1, 0, 0, 10);
+VALUES (1063, 30072, 39, 0, -30072, 1, 0, 0, 10);
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20250524153727_world.sql
+++ b/sql/migrations/20250524153727_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20250524153727');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20250524153727');
+-- Add your query below.
+
+-- Fix missing loot for Jade
+INSERT INTO creature_loot_template (entry, item, ChanceOrQuestChance, groupid, mincountOrRef, maxcount, condition_id, patch_min, patch_max) 
+VALUES (1063, 30072, 1, 0, -30072, 1, 0, 0, 10);
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
[Jade](https://www.wowhead.com/classic/npc=1063/jade) is missing its random green drop loot table, only has a chance to drop trash currently. 

I ended up checking the reference_loot_template for all the items wowhead shows and it looks like it is a perfect match to 30072 which also some other npcs around that same level share as well. 

### Proof
https://www.wowhead.com/classic/npc=1063/jade

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
- Kill Jade a few times :)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
