### PR TITLE
Optimize CalculatePassengerOffset

### DIFF
--- a/src/game/Transports/Transport.cpp
+++ b/src/game/Transports/Transport.cpp
@@ -509,12 +509,15 @@ void GenericTransport::CalculatePassengerOffset(float& x, float& y, float& z, fl
     if (o)
         *o = MapManager::NormalizeOrientation(*o - transO);
 
+    float const dx = x - transX;
+    float const dy = y - transY;
     z -= transZ;
-    y -= transY;    // y = searchedY * std::cos(o) + searchedX * std::sin(o)
-    x -= transX;    // x = searchedX * std::cos(o) + searchedY * std::sin(o + pi)
-    float inx = x, iny = y;
-    y = (iny - inx * std::tan(transO)) / (std::cos(transO) + std::sin(transO) * std::tan(transO));
-    x = (inx + iny * std::tan(transO)) / (std::cos(transO) + std::sin(transO) * std::tan(transO));
+
+    float const sinO = std::sinf(transO);
+    float const cosO = std::cosf(transO);
+
+    x = dx * cosO + dy * sinO;
+    y = dy * cosO - dx * sinO;
 }
 
 void GenericTransport::SendOutOfRangeUpdateToMap()

--- a/src/game/Transports/Transport.cpp
+++ b/src/game/Transports/Transport.cpp
@@ -513,8 +513,8 @@ void GenericTransport::CalculatePassengerOffset(float& x, float& y, float& z, fl
     float const dy = y - transY;
     z -= transZ;
 
-    float const sinO = std::sinf(transO);
-    float const cosO = std::cosf(transO);
+    float const sinO = std::sin(transO);
+    float const cosO = std::cos(transO);
 
     x = dx * cosO + dy * sinO;
     y = dy * cosO - dx * sinO;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Simplifies the math and removes the usage of tan.

### Proof
<!-- Link resources as proof -->
If CalculatePassengerPosition() is a rotation matrix then CalculatePassengerOffset() is an inversed rotation matrix.
![image](https://github.com/user-attachments/assets/acd38507-7fc8-457f-aa57-e8a49f75aeed)

**Why not use tan()**
Tan(Pi/2) is undefined - https://www.cuemath.com/trigonometry/tan-pi-2/
![image](https://github.com/user-attachments/assets/b4939077-eb5f-4a22-af22-ffd1d841a3bf)

And even if transO might not end up being N*(pi/2) - there is still an issue:
when transO nears N*(pi/2) and tan(transO) nears infinity; we would get really large floating point numbers... and then we multiply em with deltas.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
I have run the old function and this function in parallel and compared results.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
