### PR TITLE
Remove geometry::ClampOrientation

### DIFF
--- a/src/game/Geometry.h
+++ b/src/game/Geometry.h
@@ -92,15 +92,6 @@ namespace Geometry
         MaNGOS::NormalizeMapCoord(y);
     }
 
-    inline float ClampOrientation(float o)
-    {
-        while (o > M_PI_F * 2.0f)
-            o -= M_PI_F * 2.0f;
-        while (o < 0.0f)
-            o += M_PI_F * 2.0f;
-        return o;
-    }
-
     // modulos a radian orientation to the range of 0..2PI
     inline float NormalizeOrientation(float o)
     {

--- a/src/game/Maps/PathFinder.cpp
+++ b/src/game/Maps/PathFinder.cpp
@@ -558,7 +558,7 @@ bool BuildPathStep(Vector3 const& currentPos, Vector3 const& targetPos, Map cons
     for (int i = 0; i < 12; i++)
     {
         Vector3 newPos;
-        Geometry::GetNearPoint2DAroundPosition(currentPos.x, currentPos.y, newPos.x, newPos.y, STEP_SIZE, Geometry::ClampOrientation(angle + ORIENTATION_OFFSETS[i]));
+        Geometry::GetNearPoint2DAroundPosition(currentPos.x, currentPos.y, newPos.x, newPos.y, STEP_SIZE, Geometry::NormalizeOrientation(angle + ORIENTATION_OFFSETS[i]));
         newPos.z = pMap->GetHeight(newPos.x, newPos.y, currentPos.z + 0.1f, true);
 
         float const zdiff = newPos.z - currentPos.z;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Removes redundant function geometry::ClampOrientation and replaces its usage with NormalizeOrientation.

While both functions do the same thing. I dont like ClampOrientations usage of while loops.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
