### PR TITLE
Clean up OPvPCapturePoint::SetCapturePointData

### DIFF
--- a/src/game/Maps/ZoneScript.cpp
+++ b/src/game/Maps/ZoneScript.cpp
@@ -147,17 +147,16 @@ bool OPvPCapturePoint::SetCapturePointData(uint32 entry, uint32 mapId, float x, 
     sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Creating capture point %u", entry);
 
     // check info existence
-    GameObjectInfo const* goinfo = sObjectMgr.GetGameObjectTemplate(entry);
-    if (!goinfo || goinfo->type != GAMEOBJECT_TYPE_CAPTURE_POINT)
-    {
-        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "OutdoorPvP: GO %u is not capture point!", entry);
-        return false;
-    }
-
     GameObjectInfo const* goInfo = sObjectMgr.GetGameObjectTemplate(entry);
     if (!goInfo)
     {
         sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Invalid GameObject entry %u in OPvPCapturePoint::SetCapturePointData!", entry);
+        return false;
+    }
+
+    if (goInfo->type != GAMEOBJECT_TYPE_CAPTURE_POINT)
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "OutdoorPvP: GO %u is not capture point!", entry);
         return false;
     }
 
@@ -181,9 +180,9 @@ bool OPvPCapturePoint::SetCapturePointData(uint32 entry, uint32 mapId, float x, 
     m_capturePointGUID = pGo->GetGUIDLow();
 
     // get the needed values from goinfo
-    m_maxValue = (float)goinfo->capturePoint.maxTime;
-    m_maxSpeed = m_maxValue / (goinfo->capturePoint.minTime ? goinfo->capturePoint.minTime : 60);
-    m_neutralValuePct = goinfo->capturePoint.neutralPercent;
+    m_maxValue = (float)goInfo->capturePoint.maxTime;
+    m_maxSpeed = m_maxValue / (goInfo->capturePoint.minTime ? goInfo->capturePoint.minTime : 60);
+    m_neutralValuePct = goInfo->capturePoint.neutralPercent;
     m_minValue = m_maxValue * float(m_neutralValuePct) / 100.0f;
 
     return true;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Removes duplicate GetGameObjectTemplate lookup.
Reorders the two sanity checks. Because 2nd sanity check was dead code, that would never trigger.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
