### PR TITLE
Refactor and Improve Battleground Queue Management.

### DIFF
--- a/src/game/Battlegrounds/BattleGroundMgr.h
+++ b/src/game/Battlegrounds/BattleGroundMgr.h
@@ -106,6 +106,11 @@ class BattleGroundQueue
         QueuedPlayersMap m_queuedPlayers;
 
     private:
+        void RemoveOfflinePlayer();
+        bool HasPlayersInQueue(BattleGroundBracketId bracketId);
+        void CheckFreeSlots(BattleGroundTypeId bgTypeId, BattleGroundBracketId bracketId);
+        bool CheckCreateNewBg(BattleGroundTypeId bgTypeId, BattleGroundBracketId bracketId);
+
         // we need constant add to begin and constant remove / add from the end, therefore deque suits our problem well
         typedef std::vector<GroupQueueInfo*> GroupsQueueType;
 


### PR DESCRIPTION
## 🍰 Pullrequest
Refactor the battleground queue management by splitting the logic into distinct functions for better separation of concerns and readability.

Also fixes an edge case:
After a new battleground is created (when minimum player count is reached on both sides), the system re-runs `CheckFreeSlots()` to ensure any remaining players in the queue are considered for this fresh instance. This resolves a bug where players could be left waiting even though a new battleground had just opened.

### Todo / Checklist
- [ ] Is it intended that the queue for AV is always shuffled? (See TODO)