### PR TITLE
Prevent division by zero in Dynamic Object LoS checks

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -3406,8 +3406,13 @@ GameObjectModel const* Map::FindDynamicObjectCollisionModel(float x1, float y1, 
     ASSERT(MaNGOS::IsValidMapCoord(x2, y2, z2));
     Vector3 const pos1 = Vector3(x1, y1, z1);
     Vector3 const pos2 = Vector3(x2, y2, z2);
-    std::shared_lock<std::shared_timed_mutex> lock(m_dynamicTreeLock);
-    return m_dynamicTree.getObjectHit(pos1, pos2);
+    GameObjectModel const* result = nullptr;
+    if (pos1 != pos2)
+    {
+        std::shared_lock<std::shared_timed_mutex> lock(m_dynamicTreeLock);
+        result = m_dynamicTree.getObjectHit(pos1, pos2);
+    }
+    return result;
 }
 
 void Map::RemoveGameObjectModel(const GameObjectModel &model)

--- a/src/game/vmap/DynamicTree.cpp
+++ b/src/game/vmap/DynamicTree.cpp
@@ -242,7 +242,7 @@ bool DynamicMapTree::getObjectHitPos(Vector3 const& pPos1, Vector3 const& pPos2,
     // valid map coords should *never ever* produce float overflow, but this would produce NaNs too:
     MANGOS_ASSERT(maxDist < std::numeric_limits<float>::max());
     // prevent NaN values which can cause BIH intersection to enter infinite loop
-    if (maxDist < 1e-10f)
+    if (maxDist < 1e-10f || pPos1 == pPos2)
     {
         pResultHitPos = pPos2;
         return false;


### PR DESCRIPTION
G3D ray assumes a distance of > 0; if object LoS is measured at a distance of zero (such as using .debug los check with no target) it will cause an infinite loop and hang the server.