### PR TITLE
Fix for BattleBotAI chasing target entered stealth

### DIFF
--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -84,11 +84,7 @@ bool PetAI::_needToStop() const
         }
     }
 
-    bool isVisible = false;
-    // Prevent creature pets from chasing target that is not visible for owner
-    if (pOwner)
-        isVisible = !m_creature->GetVictim()->IsVisibleForOrDetect(pOwner, pOwner, false);
-    return !m_creature->IsValidAttackTarget(m_creature->GetVictim()) || isVisible;
+    return !m_creature->IsValidAttackTarget(m_creature->GetVictim());
 }
 
 void PetAI::_stopAttack()

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -84,7 +84,11 @@ bool PetAI::_needToStop() const
         }
     }
 
-    return !m_creature->IsValidAttackTarget(m_creature->GetVictim());
+    bool isVisible = false;
+    // Prevent creature pets from chasing target that is not visible for owner
+    if (pOwner)
+        isVisible = !m_creature->GetVictim()->IsVisibleForOrDetect(pOwner, pOwner, false);
+    return !m_creature->IsValidAttackTarget(m_creature->GetVictim()) || isVisible;
 }
 
 void PetAI::_stopAttack()

--- a/src/game/PlayerBots/BattleBotAI.cpp
+++ b/src/game/PlayerBots/BattleBotAI.cpp
@@ -838,6 +838,17 @@ void BattleBotAI::UpdateAI(uint32 const diff)
         me->ClearTarget();
 
     Unit* pVictim = me->GetVictim();
+    
+    // Prevent battelbot from chasing target entered stealth mode
+    if (pVictim && !pVictim->IsVisibleForOrDetect(me, me, false))
+    {
+        me->AttackStop();
+        me->ClearTarget();
+        me->StopMoving();
+        if (pVictim = SelectAttackTarget(pVictim))
+            AttackStart(pVictim);
+        return;
+    }
 
     if (!me->IsInCombat())
     {


### PR DESCRIPTION
## 🍰 Pullrequest
Battlebots and player pets keep chasing victim target after it enters stealth mode and is not visible for them anymore. For example, if you are playing as a rogue on the battleground and aggro a bot, then upon successful entry into stealth mode the bot will see you regardless of the distance. The same behavior occurs with player pets. The pull request adds code that checks visibility of victim targets.



### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
-->
- Enter battleground as a rogue/cat druid
- Aggro some battlebot and try to leave combat state preparing to enter stealth (or immidiately enter stealth being out of combat when bot targets you)
- Enter stealth and ensure bot can't see/attack/target/chase you.