### PR TITLE
Pin Windows runner images to Windows Server 2022.

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,8 +19,8 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
-    
+    runs-on: windows-2022
+
     steps:
     #git checkout
     - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
         ACE_VERSION: 7.0.9
         ACE_VERSION2: 7_0_9
         TBB_VERSION: 2020.3
-        
+
       run: |
         #directory variables
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers

--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -44,7 +44,7 @@ jobs:
         os: [ubuntu-latest]
         compiler: [gcc, clang]
         include:
-          - os: windows-latest
+          - os: windows-2022
 
     steps:
 
@@ -60,7 +60,7 @@ jobs:
         sudo apt-get -qq install build-essential cmake libace-dev libmysql++-dev libtbb-dev libcurl4-openssl-dev openssl
       #windows dependencies
     - name: windows dependencies
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2022'
       #Sets versions for ACE/TBB
       env:
         ACE_VERSION: 7.0.9
@@ -97,7 +97,7 @@ jobs:
         make install
     #windows
     - name: windows build & install
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2022'
       run: |
         # Build ACE
         export ACE_ROOT=$GITHUB_WORKSPACE/ACE_wrappers


### PR DESCRIPTION
`windows-latest` currently references Windows Server 2022, but [will be migrated to Windows Server 2025 in September](https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/#windows-latest-image-label-migration).

Since using Windows Server 2025 will likely break things (yet again) without further changes to the workflow configurations, adjusting them to use `windows-2022` explicitly instead for now should keep things working (until someone finds the time to make the necessary adjustments to be able to use Windows Server 2025).

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
