### PR TITLE
Fix for rogue spell "Sap" bug #2509

### DIFF
--- a/sql/migrations/20250813174400_world.sql
+++ b/sql/migrations/20250813174400_world.sql
@@ -9,7 +9,7 @@ INSERT INTO `migrations` VALUES ('20250813174400');
 -- Add your query below.
 
 
-UPDATE mangos.spell_template SET `script_name` = 'spell_rogue_sap'
+UPDATE spell_template SET `script_name` = 'spell_rogue_sap'
 WHERE entry IN (6770, 2070, 11297);
 
 

--- a/sql/migrations/20250813174400_world.sql
+++ b/sql/migrations/20250813174400_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20250813174400');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20250813174400');
+-- Add your query below.
+
+
+UPDATE mangos.spell_template SET `script_name` = 'spell_rogue_sap'
+WHERE entry IN (6770, 2070, 11297);
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -84,11 +84,7 @@ bool PetAI::_needToStop() const
         }
     }
 
-    bool isVisible = false;
-    // Prevent creature pets from chasing target that is not visible for owner
-    if (pOwner)
-        isVisible = !m_creature->GetVictim()->IsVisibleForOrDetect(pOwner, pOwner, false);
-    return !m_creature->IsValidAttackTarget(m_creature->GetVictim()) || isVisible;
+    return !m_creature->IsValidAttackTarget(m_creature->GetVictim());
 }
 
 void PetAI::_stopAttack()

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -84,7 +84,11 @@ bool PetAI::_needToStop() const
         }
     }
 
-    return !m_creature->IsValidAttackTarget(m_creature->GetVictim());
+    bool isVisible = false;
+    // Prevent creature pets from chasing target that is not visible for owner
+    if (pOwner)
+        isVisible = !m_creature->GetVictim()->IsVisibleForOrDetect(pOwner, pOwner, false);
+    return !m_creature->IsValidAttackTarget(m_creature->GetVictim()) || isVisible;
 }
 
 void PetAI::_stopAttack()

--- a/src/game/PlayerBots/BattleBotAI.cpp
+++ b/src/game/PlayerBots/BattleBotAI.cpp
@@ -838,6 +838,17 @@ void BattleBotAI::UpdateAI(uint32 const diff)
         me->ClearTarget();
 
     Unit* pVictim = me->GetVictim();
+    
+    // Prevent battelbot from chasing target entered stealth mode
+    if (pVictim && !pVictim->IsVisibleForOrDetect(me, me, false))
+    {
+        me->AttackStop();
+        me->ClearTarget();
+        me->StopMoving();
+        if (pVictim = SelectAttackTarget(pVictim))
+            AttackStart(pVictim);
+        return;
+    }
 
     if (!me->IsInCombat())
     {

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3598,7 +3598,8 @@ SpellCastResult Spell::prepare(Aura* triggeredByAura, uint32 chance)
         // set timer base at cast time
         ReSetTimer();
 
-        if (!m_IsTriggeredSpell && m_casterUnit)
+        // rogue's sap will be handled in spell script 'OnSuccessfulFinish'
+        if (!m_IsTriggeredSpell && m_casterUnit && m_spellInfo->SpellIconID != 249)
         {
             uint32 interruptFlags = AURA_INTERRUPT_ACTION_CANCELS;
 
@@ -3932,7 +3933,8 @@ void Spell::cast(bool skipCheck)
     SendSpellCooldown();
 
     // Remove any remaining invis auras on cast completion, should only be gnomish cloaking device
-    if (!m_IsTriggeredSpell && m_casterUnit)
+    // excepting rogue's sap which will be handled in 'OnSuccessfulFinish' spell script
+    if (!m_IsTriggeredSpell && m_casterUnit && m_spellInfo->SpellIconID != 249)
     {
         uint32 interruptFlags = AURA_INTERRUPT_ACTION_CANCELS_LATE;
 

--- a/src/scripts/spells/spell_rogue.cpp
+++ b/src/scripts/spells/spell_rogue.cpp
@@ -77,6 +77,31 @@ SpellScript* GetScript_RogueVanish(SpellEntry const*)
     return new RogueVanishScript();
 }
 
+// 6770, 2070, 11297 - Sap
+struct RogueSapScript : SpellScript
+{
+    void OnSuccessfulFinish(Spell* spell) const
+    {
+        Unit* pTarget = spell->GetUnitTarget();
+        if (pTarget)
+        {
+            if (spell->ShouldRemoveStealthAuras())
+            {
+                spell->GetCaster()->ToUnit()->RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
+                if (pTarget->AI())
+                    pTarget->AI()->AttackStart(spell->GetCaster()->ToUnit());
+            }
+                
+        }
+        
+    }
+};
+
+SpellScript* GetScript_RogueSap(SpellEntry const*)
+{
+    return new RogueSapScript();
+}
+
 void AddSC_rogue_spell_scripts()
 {
     Script* newscript;

--- a/src/scripts/spells/spell_rogue.cpp
+++ b/src/scripts/spells/spell_rogue.cpp
@@ -115,4 +115,9 @@ void AddSC_rogue_spell_scripts()
     newscript->Name = "spell_rogue_vanish";
     newscript->GetSpellScript = &GetScript_RogueVanish;
     newscript->RegisterSelf();
+    
+    newscript = new Script;
+    newscript->Name = "spell_rogue_sap";
+    newscript->GetSpellScript = &GetScript_RogueSap;
+    newscript->RegisterSelf();
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR is intended to fix current bug of rogue's sap spell
### Proof
<!-- Link resources as proof -->
I found recorded let's play video on YouTube where guy was leveling his rogue. Seems it was on official Blizzard server. Proof that target creature can not hit rogue at the same time when Sap is casted can be found at 48:48 in this video:
https://www.youtube.com/watch?v=hxRG8ZxY0Kk&list=PLgGT669C539nz2VHu9yY5q8va7XW6njLO&index=5

### Issues
<!-- Which Issues does this fix, which are related? -->
- fixes #2509 

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Test 1 (without "Improved Sap" talents):

1. Enter stealth mode playing rogue
2. Select some humanoid creature and cast Sap
3. Ensure that target creature doesn't hit you at the same moment of spell cast (visually or via combat log)

Test 2 (with "Improved Sap" 3/3): same steps but you will have to spam sap until you get 10% proc of stealth removing. In this case the behavior is same as in previous test.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- Perhaps it can potentially affect BattleBots.
