### PR TITLE
Anticheat: Wallclimb - optimization

### DIFF
--- a/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
+++ b/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
@@ -16,6 +16,9 @@
 
 using namespace Geometry;
 
+float MovementAnticheat::m_wallSlope = 0.f;
+float MovementAnticheat::m_wallSlopeHigh = 0.f;
+
 char const* GetMovementCheatName(CheatType flagId)
 {
     switch (flagId)
@@ -448,6 +451,13 @@ void MovementAnticheat::ResetJumpCounters()
     m_jumpCount = 0;
     m_jumpFlagCount = 0;
     m_jumpFlagTime = 0;
+}
+
+void MovementAnticheat::InitWallClimbLimits()
+{
+    float const A = sWorld.getConfig(CONFIG_FLOAT_AC_MOVEMENT_CHEAT_WALL_CLIMB_ANGLE);
+    m_wallSlope = tan(A);
+    m_wallSlopeHigh = tan(A + 0.2f);
 }
 
 void MovementAnticheat::OnKnockBack(Player* pPlayer, float speedxy, float speedz, float cos, float sin)
@@ -1147,9 +1157,9 @@ bool MovementAnticheat::CheckWallClimb(MovementInfo const& movementInfo, uint16 
        (GetLastMovementInfo().moveFlags & NO_WALL_CLIMB_CHECK_MOVE_FLAGS) ||
        (movementInfo.moveFlags & NO_WALL_CLIMB_CHECK_MOVE_FLAGS) ||
        (me->HasFlag(UNIT_FIELD_FLAGS, NO_WALL_CLIMB_CHECK_UNIT_FLAGS)) ||
-        IsInKnockBack() || me->IsTaxiFlying() || !GetLastMovementInfo().ctime)
+       IsInKnockBack() || me->IsTaxiFlying() || !GetLastMovementInfo().ctime)
         return false;
-    
+
     float const deltaXY = GetDistance2D(GetLastMovementInfo().pos, movementInfo.pos);
     if (deltaXY < 0.5f)
         return false;
@@ -1158,13 +1168,10 @@ bool MovementAnticheat::CheckWallClimb(MovementInfo const& movementInfo, uint16 
     if (deltaZ < 1.0f)
         return false;
 
-    float const angleRad = atan(deltaZ / deltaXY);
-    //float const angleDeg = angleRad * (360 / (M_PI_F * 2));
 
-    float const maxClimbAngle = sWorld.getConfig(CONFIG_FLOAT_AC_MOVEMENT_CHEAT_WALL_CLIMB_ANGLE);
-    if (angleRad > maxClimbAngle)
+    if (deltaZ > m_wallSlope * deltaXY)
     {
-        if (angleRad > (maxClimbAngle + 0.2f))
+        if (deltaZ > m_wallSlopeHigh * deltaXY)
             return true;
 
         ASSERT(MaNGOS::IsValidMapCoord(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z));
@@ -1176,8 +1183,8 @@ bool MovementAnticheat::CheckWallClimb(MovementInfo const& movementInfo, uint16 
         TerrainInfo const* terrain = map->GetTerrain();
 
         float const hDyn = map->GetDynamicTreeHeight(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, DEFAULT_HEIGHT_SEARCH);
-        float const height1 = terrain->GetHeightStatic(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, /*vmap=*/false, DEFAULT_HEIGHT_SEARCH);
-        float const height2 = terrain->GetHeightStatic(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, /*vmap=*/true, DEFAULT_HEIGHT_SEARCH);
+        float const height1 = terrain->GetHeightStatic(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, false, DEFAULT_HEIGHT_SEARCH);
+        float const height2 = terrain->GetHeightStatic(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, true, DEFAULT_HEIGHT_SEARCH);
         float const hNoVmap = std::max(height1, hDyn);
         float const hVmap = std::max(height2, hDyn);
 

--- a/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
+++ b/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
@@ -1174,8 +1174,6 @@ bool MovementAnticheat::CheckWallClimb(MovementInfo const& movementInfo, uint16 
         if (deltaZ > m_wallSlopeHigh * deltaXY)
             return true;
 
-        ASSERT(MaNGOS::IsValidMapCoord(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z));
-
         // check height with and without vmaps and compare
         // if player is stepping over model like stairs, that can increase wall climb angle
 

--- a/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
+++ b/src/game/Anticheat/MovementAnticheat/MovementAnticheat.cpp
@@ -1167,11 +1167,21 @@ bool MovementAnticheat::CheckWallClimb(MovementInfo const& movementInfo, uint16 
         if (angleRad > (maxClimbAngle + 0.2f))
             return true;
 
+        ASSERT(MaNGOS::IsValidMapCoord(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z));
+
         // check height with and without vmaps and compare
         // if player is stepping over model like stairs, that can increase wall climb angle
-        float const height1 = me->GetMap()->GetHeight(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, false);
-        float const height2 = me->GetMap()->GetHeight(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, true);
-        if (std::abs(height1 - height2) < 0.5f)
+
+        Map* map = me->GetMap();
+        TerrainInfo const* terrain = map->GetTerrain();
+
+        float const hDyn = map->GetDynamicTreeHeight(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, DEFAULT_HEIGHT_SEARCH);
+        float const height1 = terrain->GetHeightStatic(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, /*vmap=*/false, DEFAULT_HEIGHT_SEARCH);
+        float const height2 = terrain->GetHeightStatic(movementInfo.pos.x, movementInfo.pos.y, movementInfo.pos.z, /*vmap=*/true, DEFAULT_HEIGHT_SEARCH);
+        float const hNoVmap = std::max(height1, hDyn);
+        float const hVmap = std::max(height2, hDyn);
+
+        if (std::abs(hNoVmap - hVmap) < 0.5f)
             return true;
     }
 

--- a/src/game/Anticheat/MovementAnticheat/MovementAnticheat.h
+++ b/src/game/Anticheat/MovementAnticheat/MovementAnticheat.h
@@ -72,6 +72,7 @@ class MovementAnticheat
         void Init();
         void InitNewPlayer(Player* pPlayer);
         void ResetJumpCounters();
+        static void InitWallClimbLimits();
 
         void AddCheats(uint32 cheats, uint32 count = 1);
         void StoreCheat(uint32 type, uint32 count = 1);
@@ -143,6 +144,10 @@ class MovementAnticheat
         uint32 m_bottingCheckStartTime = 0;
         uint32 m_movementPacketsCount = 0;
         TurnType m_turnType = TURN_NONE;
+
+        // Wallclimb limits - initialized from vmangos.conf 
+        static float m_wallSlope;
+        static float m_wallSlopeHigh;
 
         Player* me = nullptr; // current player object that checks run on, changes on mind control
         WorldSession* const m_session = nullptr; // session to which the cheat data belongs, does not change

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1221,6 +1221,7 @@ void World::LoadConfigSettings(bool reload)
     setConfig(CONFIG_UINT32_AC_MOVEMENT_CHEAT_BOTTING_MIN_TURNS_KEYBOARD, "Anticheat.Botting.MinTurnsKeyboard", 80);
     setConfig(CONFIG_UINT32_AC_MOVEMENT_CHEAT_BOTTING_MIN_TURNS_ABNORMAL, "Anticheat.Botting.MinTurnsAbnormal", 5);
     setConfig(CONFIG_UINT32_AC_MOVEMENT_CHEAT_BOTTING_PENALTY, "Anticheat.Botting.Penalty", CHEAT_ACTION_LOG | CHEAT_ACTION_REPORT_GMS);
+    MovementAnticheat::InitWallClimbLimits();
 
     // Warden Anticheat
     setConfig(CONFIG_BOOL_AC_WARDEN_WIN_ENABLED, "Warden.WinEnabled", false);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
**Calculation change** 
Instead of calculating atan every tick, we can eliminate it by calculating tan of the wallclimb angle once

Math proof:
atan(deltaZ / deltaXY) > sWorld.getConfig(CONFIG_FLOAT_AC_MOVEMENT_CHEAT_WALL_CLIMB_ANGLE)

tan(atan(deltaZ / deltaXY)) > tan(sWorld.getConfig(CONFIG_FLOAT_AC_MOVEMENT_CHEAT_WALL_CLIMB_ANGLE))

deltaZ / deltaXY > tan(sWorld.getConfig(CONFIG_FLOAT_AC_MOVEMENT_CHEAT_WALL_CLIMB_ANGLE))

Now we multiply both sides with deltaXY

deltaZ > tan(sWorld.getConfig(CONFIG_FLOAT_AC_MOVEMENT_CHEAT_WALL_CLIMB_ANGLE)) * deltaXY


**get map height change**
We have two calls to GetHeight(..) that calls GetDynamicTreeHeight(..) with the exact same parameters.
<img width="480" height="404" alt="image" src="https://github.com/user-attachments/assets/dbc24b50-4ffc-4fcb-ba7e-776575f2a9d4" />

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
- I personally tested it by having both old and new version of the function being called each time. I then logged positions and what caused each function to return
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
