### PR TITLE
Fix boolean logic in HostileReference::updateOnlineStatus()

### DIFF
--- a/src/game/Threat/ThreatManager.cpp
+++ b/src/game/Threat/ThreatManager.cpp
@@ -140,8 +140,8 @@ void HostileReference::updateOnlineStatus()
     // target is no player or not gamemaster
     // target is not in flight
     if (isValid() &&
-            ((getTarget()->GetTypeId() != TYPEID_PLAYER || !((Player*)getTarget())->IsGameMaster()) ||
-             !getTarget()->IsTaxiFlying()))
+            (getTarget()->GetTypeId() != TYPEID_PLAYER || !((Player*)getTarget())->IsGameMaster()) &&
+            !getTarget()->IsTaxiFlying())
         online = true;
 
     setAccessibleState(accessible);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Code only evaluated isTaxiFlying if the player was a GM

Example: is valid, is a player, not a gm, is flying
`(isValid() &&
            ((getTarget()->GetTypeId() != TYPEID_PLAYER || !((Player*)getTarget())->IsGameMaster()) ||
             !getTarget()->IsTaxiFlying()))

Simplified:

(true &&
            ((false || true) ||
             false))
`
Result is true - even though the player is flying.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
