### PR TITLE
Fix Naxxramas slime damage using WMO ID instead of filename parsing

### DIFF
--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -478,7 +478,7 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE* output, WMORoot* rootWMO, bool pPrecis
                     liquidEntry = 3;        // magma
                     break;
                 case 3:
-                    if (filename.find("Stratholme_raid") != string::npos)
+                    if (rootWMO->RootWMOID == 4489) // Stratholme_raid.wmo WMOID == 4489
                     {
                         liquidEntry = 21;   // Naxxramas slime
                     }

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -991,9 +991,8 @@ void Player::OnMirrorTimerExpirationPulse(MirrorTimer::Type timer)
         case MirrorTimer::ENVIRONMENTAL:
             if (IsInMagma())
                 EnvironmentalDamage(DAMAGE_LAVA, urand(sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MIN), sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MAX)));
-            // FIXME: Need to skip slime damage in Undercity, maybe someone can find better way to handle environmental damage
-            //if (IsInSlime() && m_zoneUpdateId != 1497)
-            //    EnvironmentalDamage(DAMAGE_SLIME, urand(sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MIN), sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MAX)));
+            if (IsInSlime())
+                EnvironmentalDamage(DAMAGE_SLIME, urand(sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MIN), sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MAX)));
             break;
         case MirrorTimer::FEIGNDEATH:
             // Vanilla: kill player on feigning death for too long


### PR DESCRIPTION
## 🍰 Pullrequest
Fix Naxxramas slime damage by using WMO ID instead of filename parsing. This replaces the fragile string-based detection with a proper ID check and removes the commented-out hackfix that was preventing all slime environmental damage.

### Proof
- Code compiles successfully with the changes
- Changes follow the exact recommendation from issue reporter (@Wall-core)
- Fix uses the same pattern as other `rootWMO->` member accesses in the codebase

### Issues
- fixes #3096

### How2Test
1. **Test Naxxramas slime damage:**
   - Enter Naxxramas (Grobbulus room has slime)
   - Stand in green slime
   - Verify you take environmental damage (should use liquid type 21)

2. **Test regular slime damage:**
   - Go to any other zone with slime (e.g., certain caves)
   - Stand in slime
   - Verify you take environmental damage (should use liquid type 4)

3. **Verify the WMO fix:**
   - Run vmap_extractor on game files
   - Check that Stratholme_raid.wmo is detected by ID 4489, not filename
   - Renamed copies of the file should NOT get Naxx slime type

### Todo / Checklist
- [X] Replaced `filename.find("Stratholme_raid")` with `rootWMO->RootWMOID == 4489` check
- [X] Removed commented slime damage hackfix from Player.cpp
- [X] Code compiles without errors
- [X] Changes are minimal
- [ ] Needs in-game testing by reviewers