### PR TITLE
vmap: Rename fixnamen to FixNameCase and fixname2 to FixNameSpaces, use existing method in ExtractSingleModel.

### DIFF
--- a/contrib/vmap_extractor/vmapextract/adtfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/adtfile.cpp
@@ -45,7 +45,7 @@ char* GetPlainName(char* FileName)
     return FileName;
 }
 
-void fixnamen(char* name, size_t len)
+void FixNameCase(char* name, size_t len)
 {
     if (len < 3)
         return;
@@ -66,7 +66,7 @@ void fixnamen(char* name, size_t len)
         name[i] |= 0x20;
 }
 
-void fixname2(char* name, size_t len)
+void FixNameSpaces(char* name, size_t len)
 {
     if (len < 3)
         return;
@@ -168,8 +168,8 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
                 char* p = buf;
                 while (p < buf + size)
                 {
-                    fixnamen(p, strlen(p));
-                    string path(p);                         // Store copy after name fixed
+                    FixNameCase(p, strlen(p));
+                    std::string path(p); // Store copy after name fixed
 
                     std::string fixedName;
                     ExtractSingleModel(path, fixedName, failedPaths);
@@ -189,10 +189,12 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
                 char* p = buf;
                 while (p < buf + size)
                 {
-                    string path(p);
+                    std::string path(p);
+
                     char* s = GetPlainName(p);
-                    fixnamen(s, strlen(s));
-                    fixname2(s, strlen(s));
+                    FixNameCase(s, strlen(s));
+                    FixNameSpaces(s, strlen(s));
+
                     p = p + strlen(p) + 1;
                     WmoInstanceNames.emplace_back(s);
                 }

--- a/contrib/vmap_extractor/vmapextract/adtfile.h
+++ b/contrib/vmap_extractor/vmapextract/adtfile.h
@@ -165,8 +165,8 @@ class ADTFile
 const char* GetPlainName(const char* FileName);
 char* GetPlainName(char* FileName);
 char const* GetExtension(char const* FileName);
-void fixnamen(char* name, size_t len);
-void fixname2(char* name, size_t len);
+void FixNameCase(char* name, size_t len);
+void FixNameSpaces(char* name, size_t len);
 //void fixMapNamen(char *name, size_t len);
 
 #endif

--- a/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
+++ b/contrib/vmap_extractor/vmapextract/gameobject_extract.cpp
@@ -22,25 +22,20 @@ bool ExtractSingleModel(std::string& origPath, std::string& fixedName, StringSet
     }
     // >= 3.1.0 ADT MMDX section store filename.m2 filenames for corresponded .m2 file
     // nothing do
-	
-    // Fix a few models with spaces instead of underscores in their filenames (razorfen leanto03)
-    std::string s = GetPlainName(origPath.c_str());
-    std::transform(s.begin(), s.end(), s.begin(), [](char ch) {
-        return ch == ' ' ? '_' : ch;
-        });
 
-    fixnamen((char*)s.c_str(), s.size());
-    fixedName = s;
+    char* name = GetPlainName((char*)origPath.c_str());
+    FixNameCase(name, strlen(name));
+    FixNameSpaces(name, strlen(name)); // Fix a few models with spaces instead of underscores in their filenames (razorfen leanto03)
 
-    std::string output(szWorkDirWmo);                       // Stores output filename (possible changed)
+    std::string output(szWorkDirWmo); // Stores output filename (possible changed)
     output += "/";
-    output += fixedName;
+    output += name;
 
     if (FileExists(output.c_str()))
         return true;
 
-    Model mdl(origPath);                                    // Possible changed fname
-    if (!mdl.open(failedPaths))
+    Model mdl(origPath);
+    if (!mdl.open(failedPaths)) // Possible changed fname
         return false;
 
     return mdl.ConvertToVMAPModel(output.c_str());
@@ -71,9 +66,9 @@ void ExtractGameobjectModels()
         if (path.length() < 4)
             continue;
 
-        fixnamen((char*)path.c_str(), path.size());
+        FixNameCase((char*)path.c_str(), path.size());
         char* name = GetPlainName((char*)path.c_str());
-        fixname2(name, strlen(name));
+        FixNameSpaces(name, strlen(name));
 
         char const* ch_ext = GetExtension(name);
         if (!ch_ext)

--- a/contrib/vmap_extractor/vmapextract/model.cpp
+++ b/contrib/vmap_extractor/vmapextract/model.cpp
@@ -241,8 +241,8 @@ void Doodad::ExtractSet(WMODoodadData const& doodadData, ADT::MODF const& wmo, u
         char ModelInstName[1024];
         sprintf(ModelInstName, "%s", GetPlainName(&doodadData.Paths[doodad.NameIndex]));
         uint32 nlen = strlen(ModelInstName);
-        fixnamen(ModelInstName, nlen);
-        fixname2(ModelInstName, nlen);
+        FixNameCase(ModelInstName, nlen);
+        FixNameSpaces(ModelInstName, nlen);
         if (nlen > 3)
         {
             char const* extension = &ModelInstName[nlen - 4];
@@ -253,9 +253,8 @@ void Doodad::ExtractSet(WMODoodadData const& doodadData, ADT::MODF const& wmo, u
             }
         }
 
-        char tempname[1036];
-        sprintf(tempname, "%s/%s", szWorkDirWmo, ModelInstName);
-        FILE* input = fopen(tempname, "r+b");
+        std::string tempname = std::string(szWorkDirWmo) + "/" + ModelInstName;
+        FILE* input = fopen(tempname.c_str(), "r+b");
         if (!input)
             continue;
 

--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -135,8 +135,8 @@ bool ExtractSingleWmo(std::string& fname)
 
     char szLocalFile[1024];
     char* plain_name = GetPlainName(&fname[0]);
-    fixnamen(plain_name, strlen(plain_name));
-    fixname2(plain_name, strlen(plain_name));
+    FixNameCase(plain_name, strlen(plain_name));
+    FixNameSpaces(plain_name, strlen(plain_name));
     sprintf(szLocalFile, "%s/%s", szWorkDirWmo, plain_name);
 
     if (FileExists(szLocalFile))

--- a/contrib/vmap_extractor/vmapextract/wdtfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/wdtfile.cpp
@@ -79,9 +79,10 @@ bool WDTFile::init(char* map_id, unsigned int mapID)
                 int q = 0;
                 while (p < buf + size)
                 {
-                    string path(p);
+                    std::string path(p);
                     char* s = wdtGetPlainName(p);
-                    fixnamen(s, strlen(s));
+                    FixNameCase(s, strlen(s));
+                    // FixNameSpaces(s, strlen(s)); not needed here?
                     p = p + strlen(p) + 1;
                     m_wmoNames.push_back(s);
                 }

--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -92,8 +92,8 @@ bool WMORoot::open()
                 std::string path = ptr;
 
                 char* s = GetPlainName(ptr);
-                fixnamen(s, strlen(s));
-                fixname2(s, strlen(s));
+                FixNameCase(s, strlen(s));
+                FixNameSpaces(s, strlen(s));
 
                 uint32 doodadNameIndex = ptr - f.getPointer();
                 ptr += path.length() + 1;


### PR DESCRIPTION
## 🍰 Pullrequest
Partial port:
https://github.com/TrinityCore/TrinityCore/commit/efff24d20eadb5080727e23746f80d9113d99936
https://github.com/TrinityCore/TrinityCore/commit/4fbf78df1294be5b81d0f92f8081f81741e814ba

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [ x ] map, vmap, mmap builds work
