### PR TITLE
Fix floating-point drift in PLAYER_FIELD_MOD_DAMAGE_DONE_PCT modifiers

### DIFF
--- a/src/game/Objects/Object.cpp
+++ b/src/game/Objects/Object.cpp
@@ -1232,9 +1232,24 @@ void Object::ApplyModInt32Value(uint16 index, int32 val, bool apply)
 
 void Object::ApplyModSignedFloatValue(uint16 index, float  val, bool apply)
 {
-    float cur = GetFloatValue(index);
-    cur += (apply ? val : -val);
-    SetFloatValue(index, cur);
+    const float cur = GetFloatValue(index);
+    const float delta = apply ? val : -val;
+    float next = cur + delta;
+
+    // Normalize floating-point drift for per-school damage modifiers
+    if (index >= PLAYER_FIELD_MOD_DAMAGE_DONE_PCT &&
+        index <  PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + MAX_SPELL_SCHOOL)
+    {
+        // Within 2 ULPs of 1.0 (FLT_EPSILON is 1 ULP near 1.0)
+        if (std::fabs(next - 1.0f) <= 2.0f * FLT_EPSILON)
+            next = 1.0f;
+    }
+
+    // Prevent NaN or infinity propagation
+    if (!std::isfinite(next))
+        next = cur;
+
+    SetFloatValue(index, next);
 }
 
 void Object::ApplyModPositiveFloatValue(uint16 index, float  val, bool apply)


### PR DESCRIPTION
## 🍰Pullrequest

This PR fixes floating-point drift in the per-school damage done percentage modifiers (PLAYER_FIELD_MOD_DAMAGE_DONE_PCT[school]) when modified via **Object::ApplyModSignedFloatValue**.
These fields are 1.0-based multipliers. When temporary effects repeatedly add and remove small percentage values (e.g., talents, consumables, procs), floating-point rounding error can accumulate and cause the stored value to drift away from the expected neutral baseline of 1.0f.

This leads to situations where, after all modifiers are removed, the final value may be slightly below or above 1.0 (e.g., 0.99999994 instead of 1.0).
This results in tiny unintended buffs/nerfs and, more visibly, **client sheet desync:** the character sheet may display “100%” in red, indicating a hidden modifier still being applied.

Seen in: #1236 

This PR normalizes values that end up within 2 ULPs of 1.0f back to exactly 1.0f, and prevents NaN/Inf propagation.
The correction is only applied to the known 1.0-based array range.

### Proof
Reproducible by repeatedly applying/removing small damage % auras and observing drift from 1.0 in PLAYER_FIELD_MOD_DAMAGE_DONE_PCT. 

### Issues
None (fix is self-contained). Primarily resolves a correctness and UI desync issue.

### How2Test

1. Create a Warrior with **Enrage (Rank 1)** talented.
2. Trigger Enrage (e.g., take a critical hit).
   - Character sheet shows **+5% damage** in green.
3. Cancel Enrage.
   - **Before the fix:** damage returns to 100% but appears **red**, indicating hidden modifier drift.
   - **After the fix:** damage returns to **clean white 100%**, with no hidden modifier remaining.


### Todo / Checklist
None
