### PR TITLE
Fix Halloween quests cannot be completed

### DIFF
--- a/sql/migrations/20251103093357_world.sql
+++ b/sql/migrations/20251103093357_world.sql
@@ -1,0 +1,57 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20251103093357');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20251103093357');
+-- Add your query below.
+
+
+-- Alliance
+
+-- Fix quest Complete Quest Chicken Clucking for a Mint.
+DELETE FROM `creature_ai_scripts` WHERE `id`=511101;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(511101, 0, 0, 8, 5111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Firebrew - Complete Quest Chicken Clucking for a Mint'),
+(511101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10786, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Firebrew - Say Text');
+UPDATE `quest_template` SET `SpecialFlags`=1 WHERE `entry`=8353;
+
+-- Fix quest Complete Dancing for Marzipan.
+DELETE FROM `creature_ai_scripts` WHERE `id`=673501;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(673501, 0, 0, 8, 6735, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Saelienne - Complete Quest Dancing for Marzipan'),
+(673501, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10787, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Saelienne - Say Text');
+UPDATE `quest_template` SET `SpecialFlags`=1 WHERE `entry`=8357;
+
+-- Fix quest Complete Flexing for Nougat.
+DELETE FROM `creature_ai_scripts` WHERE `id`=674001;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(674001, 0, 0, 8, 6740, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Allison - Complete Quest Flexing for Nougat'),
+(674001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10789, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Allison - Say Text');
+UPDATE `quest_template` SET `SpecialFlags`=1 WHERE `entry`=8356;
+
+-- Fix quest Complete Dancing for Marzipan.
+DELETE FROM `creature_ai_scripts` WHERE `id`=673501;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(682601, 0, 0, 8, 6826, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Complete Quest Incoming Gumdrop'),
+(682601, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10799, 0, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Text');
+UPDATE `quest_template` SET `SpecialFlags`=1 WHERE `entry`=8355;
+
+-- Horde
+
+-- Fix quest Complete Quest Chicken Clucking for a Mint.
+DELETE FROM `creature_ai_scripts` WHERE `id`=674101;
+INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(674101, 0, 0, 8, 6741, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Norman - Complete Quest Chicken Clucking for a Mint'),
+(674101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10798, 0, 0, 0, 0, 0, 0, 0, 0, 'Innkeeper Norman - Say Text');
+UPDATE `quest_template` SET `SpecialFlags`=1 WHERE `entry`=8354;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20251103093357_world.sql
+++ b/sql/migrations/20251103093357_world.sql
@@ -33,7 +33,7 @@ INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalo
 UPDATE `quest_template` SET `SpecialFlags`=1 WHERE `entry`=8356;
 
 -- Fix quest Complete Dancing for Marzipan.
-DELETE FROM `creature_ai_scripts` WHERE `id`=673501;
+DELETE FROM `creature_ai_scripts` WHERE `id`=682601;
 INSERT INTO `creature_ai_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
 (682601, 0, 0, 8, 6826, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Complete Quest Incoming Gumdrop'),
 (682601, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10799, 0, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Text');


### PR DESCRIPTION
## 🍰 Pullrequest
This PR is based on a previous fix from @ratkosrb https://github.com/vmangos/core/commit/24463dbaeee0085727b9cff9fbc7e58f6df00d81

But is not complete, some quest cannot be completed yet...

### Quest Fixes
Alliance: 8353, 8355, 8356, 8357
Horde: 8354

### Proof
- 8353, 8354, 8355, 8356, 8357: A message appears saying that you have completed the action, but the tavern innkeeper does not allow you to complete the assigned quest.

After apply this fix horde and ally can complete all halloween event quests :jack_o_lantern: 

### Issues
- None

### How2Test
- .go 2060 -4682 26 1
- accept an assignment 8312 “Hallow's End Treats for Spoops!”
- .tele undercity
- talk with [Innkeeper Norman](https://www.wowhead.com/classic/npc=6741/innkeeper-norman) and accept an assignment 8354 “Chicken Clucking for a Mint”
- /chicken
- Same for alliance quests.

### Todo / Checklist
- [X] Everything tested and ready to review.
