### PR TITLE
Remove leftover locale for deleted gameobject.

### DIFF
--- a/sql/migrations/20251118094735_world.sql
+++ b/sql/migrations/20251118094735_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20251118094735');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20251118094735');
+-- Add your query below.
+
+-- Remove leftover locale for deleted gameobject.
+DELETE FROM `locales_gameobject` WHERE `entry`=182509;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
This removes the leftover locale for gameobject `182509` which got deleted in https://github.com/vmangos/core/commit/74fa106e570d1ee68328b576c94f50282a8ae52d.

Gets rid of the startup error/warning:
```
ERROR: Table `locales_gameobject` has data for nonexistent gameobject entry 182509, skipped.
```

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
