### PR TITLE
Fix parsing of a log-related parameter

### DIFF
--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -588,7 +588,7 @@ DebuffLimit = 0
 #        GM Log file of gm commands
 #        Default: "" (Disable)
 #
-#    LogFile.CriticalCommands
+#    LogFile.GmCriticalCommands
 #        Log file for commands marked as critical, when used on own character (same IP for example)
 #        Default: "gm_critical.log"
 #                 "" - Empty name for disable

--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -111,7 +111,7 @@ void Log::OpenWorldLogFiles()
     logFiles[LOG_MONEY_TRADES] = OpenLogFile("LogFile.Trades", "", log_file_timestamp, false);
     logFiles[LOG_GM] = sConfig.GetBoolDefault("GmLogPerAccount", false) ?
         OpenLogFile("LogFile.Gm", "", log_file_timestamp, false) : nullptr;
-    logFiles[LOG_GM_CRITICAL] = OpenLogFile("LogFile.CriticalCommands", "gm_critical.log", log_file_timestamp, false);
+    logFiles[LOG_GM_CRITICAL] = OpenLogFile("LogFile.GmCriticalCommands", "gm_critical.log", log_file_timestamp, false);
     logFiles[LOG_ANTICHEAT] = OpenLogFile("LogFile.Anticheat", "Anticheat.log", log_file_timestamp, false);
     logFiles[LOG_SCRIPTS] = OpenLogFile("LogFile.Scripts", "Scripts.log", log_file_timestamp, false);
     logFiles[LOG_MOVEMENT] = OpenLogFile("LogFile.Movement", "Movement.log", log_file_timestamp, false);


### PR DESCRIPTION
## 🍰 Pullrequest

In the mangosd configuration, the parameter`GmCriticalCommands` has been parsed as `CriticalCommands`. The following commit fixes it.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
