### PR TITLE
Implement Nefarians AoE version of Shadow Flame

### DIFF
--- a/sql/migrations/20251222091514_world.sql
+++ b/sql/migrations/20251222091514_world.sql
@@ -1,0 +1,32 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20251222091514');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20251222091514');
+-- Add your query below.
+
+UPDATE `spell_template` SET `script_name`='spell_nefarian_shadow_flame_passive' WHERE `entry` = 22992;
+
+-- Add missing coordinates for triggered spells (CMangos)
+INSERT INTO `spell_target_position` (`id`, `target_map`, `target_position_x`, `target_position_y`, `target_position_z`, `target_orientation`, `build_min`, `build_max`) VALUES
+(22972, 469, -7538.63, -1277.56, 476.799, 0, 4375, 5875),
+(22975, 469, -7557.95, -1249.87, 476.799, 0, 4375, 5875),
+(22976, 469, -7579.59, -1218.76, 476.799, 0, 4375, 5875),
+(22978, 469, -7497.51, -1249.17, 476.798, 0, 4375, 5875),
+(22979, 469, -7519.9, -1218.85, 476.799, 0, 4375, 5875),
+(22980, 469, -7540.82, -1190.7, 476.355, 0, 4375, 5875),
+(22981, 469, -7461.41, -1226.29, 476.781, 0, 4375, 5875),
+(22982, 469, -7483.16, -1195.39, 476.799, 0, 4375, 5875),
+(22983, 469, -7504.77, -1164.43, 476.797, 0, 4375, 5875),
+(22984, 469, -7524.15, -1138.16, 473.348, 0, 4375, 5875),
+(22977, 469, -7599.83, -1190.94, 475.472, 0, 4375, 5875);
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
@@ -671,13 +671,8 @@ struct NefarianShadowFlamePassiveScript : SpellScript
 
     bool OnEffectExecute(Spell* spell, SpellEffectIndex effIdx) const final
     {
-        if (effIdx == EFFECT_INDEX_0 && spell->m_casterUnit)
-        {
-            if (spell->GetUnitTarget())
-            {
-                spell->m_casterUnit->CastSpell(spell->GetUnitTarget(), SPELL_SHADOWFLAME_TRIGGER, true);
-            }
-        }
+        if (effIdx == EFFECT_INDEX_0 && spell->m_casterUnit && spell->GetUnitTarget())
+            spell->m_casterUnit->CastSpell(spell->GetUnitTarget(), SPELL_SHADOWFLAME_TRIGGER, true);
         return true;
     }
 };

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
@@ -35,7 +35,7 @@ enum Nefarian : uint32
     SAY_HUNTER                  = 9849,
     SAY_ROGUE                   = 9856,
 
-    SPELL_SHADOWFLAME_INITIAL   = 22992, // old spell id 22972 -> wrong
+    SPELL_SHADOWFLAME_PASSIV    = 22992,
     SPELL_SHADOWFLAME           = 22539,
     SPELL_BELLOWING_ROAR        = 22686,
     SPELL_VEIL_OF_SHADOW        = 22687, // old spell id 7068 -> wrong
@@ -305,8 +305,6 @@ struct boss_nefarianAI : ScriptedAI
                         m_creature->SetInCombatWithZone();
                         m_creature->SetFly(true);
 
-                        m_creature->CastSpell(m_creature, SPELL_SHADOWFLAME_INITIAL, true); // Test speed 17 / fire damage on the initial ??? Oo
-
                         DoScriptText(SAY_AGGRO, m_creature);
 
                         m_creature->GetMotionMaster()->MovePoint(1, -7449.145f, -1320.647f, 476.795f);
@@ -329,6 +327,7 @@ struct boss_nefarianAI : ScriptedAI
                             //m_creature->GetMotionMaster()->Clear(false);
                             m_creature->GetMotionMaster()->MoveChase(pTarget);
                             SetCombatMovement(true);
+                            m_creature->CastSpell(pTarget, SPELL_SHADOWFLAME_PASSIV, true);
                         }
                         m_bTransitionDone = true;
                         break;
@@ -662,6 +661,32 @@ SpellScript* GetScript_NefarianCorruptedTotems(SpellEntry const*)
     return new NefarianCorruptedTotemsScript();
 }
 
+// 22992 - Shadow Flame
+// When Nefarian lands at the start of Phase 2 of his encounter he will use an AoE Shadowflame
+// that ignores LoS, this spell does about 1000 initial shadow damage,
+// but applies a deadly DoT if an Onyxia Scale Cloak is not equipped.
+struct NefarianShadowFlamePassiveScript : SpellScript
+{
+    static constexpr uint32 SPELL_SHADOWFLAME_TRIGGER = 22986;
+
+    bool OnEffectExecute(Spell* spell, SpellEffectIndex effIdx) const final
+    {
+        if (effIdx == EFFECT_INDEX_0 && spell->m_casterUnit)
+        {
+            if (spell->GetUnitTarget())
+            {
+                spell->m_casterUnit->CastSpell(spell->GetUnitTarget(), SPELL_SHADOWFLAME_TRIGGER, true);
+            }
+        }
+        return true;
+    }
+};
+
+SpellScript* GetScript_NefarianShadowFlamePassive(SpellEntry const*)
+{
+    return new NefarianShadowFlamePassiveScript();
+}
+
 void AddSC_boss_nefarian()
 {
     Script* pNewScript;
@@ -679,5 +704,10 @@ void AddSC_boss_nefarian()
     pNewScript = new Script;
     pNewScript->Name = "spell_nefarian_corrupted_totems";
     pNewScript->GetSpellScript = &GetScript_NefarianCorruptedTotems;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "spell_nefarian_shadow_flame_passive";
+    pNewScript->GetSpellScript = &GetScript_NefarianShadowFlamePassive;
     pNewScript->RegisterSelf();
 }

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_razorgore.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_razorgore.cpp
@@ -365,8 +365,6 @@ struct trigger_orb_of_commandAI : public ScriptedAI
         if (!m_pInstance)
             return;
 
-        DoScriptText(EMOTE_FLEE, m_creature);
-
         std::list<Creature*> lCreatureNear;
         GetCreatureListWithEntryInGrid(lCreatureNear, m_creature, { NPC_BLACKWING_LEGGIONAIRE, NPC_BLACKWING_MAGE, NPC_DEATH_TALON_DRAGONSPAWN }, 250.0f);
 
@@ -374,6 +372,7 @@ struct trigger_orb_of_commandAI : public ScriptedAI
         {
             if (it->IsAlive())
             {
+                it->MonsterTextEmote(EMOTE_FLEE, it);
                 it->SetHomePosition(-7555.55f, -1025.16f, 408.4914f, 0.65f);
                 it->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_SPAWNING | UNIT_FLAG_PACIFIED | UNIT_FLAG_SILENCED);
                 it->AI()->EnterEvadeMode();


### PR DESCRIPTION
## 🍰 Pullrequest

Implement special version of spell Shadow Flame:
When Nefarian lands at the start of Phase 2 of his encounter he will use an AoE Shadowflame ~~that ignores LoS~~, this spell does about 1000 initial shadow damage, but applies a deadly DoT if an Onyxia Scale Cloak is not equipped.

Also fixed one missplaced text in Razorgores script.

### Proof
- None

### Issues
- None

### How2Test
- Start Nefarian encounter, progress till phase 2 untill he lands, do it one time with Onyxia Clock equipped and one time without.

### Todo / Checklist
- [X] None
