### PR TITLE
Fix iterator invalidation in loot notification functions

### DIFF
--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -674,30 +674,34 @@ void Loot::NotifyItemRemoved(uint8 lootIndex)
 {
     // notify all players that are looting this that the item was removed
     // convert the index to the slot the player sees
-    PlayersLooting::iterator i_next;
-    for (PlayersLooting::iterator i = m_playersLooting.begin(); i != m_playersLooting.end(); i = i_next)
+    for (PlayersLooting::iterator i = m_playersLooting.begin(); i != m_playersLooting.end(); )
     {
-        i_next = i;
-        ++i_next;
         if (Player* pl = ObjectAccessor::FindPlayer(*i))
+        {
             pl->SendNotifyLootItemRemoved(lootIndex);
+            ++i;
+        }
         else
-            m_playersLooting.erase(i);
+        {
+            i = m_playersLooting.erase(i);
+        }
     }
 }
 
 void Loot::NotifyMoneyRemoved()
 {
     // notify all players that are looting this that the money was removed
-    PlayersLooting::iterator i_next;
-    for (PlayersLooting::iterator i = m_playersLooting.begin(); i != m_playersLooting.end(); i = i_next)
+    for (PlayersLooting::iterator i = m_playersLooting.begin(); i != m_playersLooting.end(); )
     {
-        i_next = i;
-        ++i_next;
         if (Player* pl = ObjectAccessor::FindPlayer(*i))
+        {
             pl->SendNotifyLootMoneyRemoved();
+            ++i;
+        }
         else
-            m_playersLooting.erase(i);
+        {
+            i = m_playersLooting.erase(i);
+        }
     }
 }
 
@@ -708,11 +712,8 @@ void Loot::NotifyQuestItemRemoved(uint8 questIndex)
     // (other questitems can be looted by each group member)
     // bit inefficient but isnt called often
 
-    PlayersLooting::iterator i_next;
-    for (PlayersLooting::iterator i = m_playersLooting.begin(); i != m_playersLooting.end(); i = i_next)
+    for (PlayersLooting::iterator i = m_playersLooting.begin(); i != m_playersLooting.end(); )
     {
-        i_next = i;
-        ++i_next;
         if (Player* pl = ObjectAccessor::FindPlayer(*i))
         {
             QuestItemMap::const_iterator pq = m_playerQuestItems.find(pl->GetGUIDLow());
@@ -729,9 +730,12 @@ void Loot::NotifyQuestItemRemoved(uint8 questIndex)
                 if (j < pql.size())
                     pl->SendNotifyLootItemRemoved(items.size() + j);
             }
+            ++i;
         }
         else
-            m_playersLooting.erase(i);
+        {
+            i = m_playersLooting.erase(i);
+        }
     }
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Use erase() return value instead of pre-calculated next iterator to
prevent potential undefined behavior when erasing offline/disconnected players from PlayersLooting set.

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
