### PR TITLE
Fix Protector Gariel's broadcast text

### DIFF
--- a/sql/migrations/20251228022409_world.sql
+++ b/sql/migrations/20251228022409_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20251228022409');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20251228022409');
+-- Add your query below.
+
+-- Fix broadcast text not displaying for Protector Gariel.
+UPDATE `broadcast_text` SET `female_text`='' WHERE  `entry`=41;
+UPDATE `broadcast_text` SET `male_text`='Defias activity reported on the costal horizon. All clear on Sentinel Hill.' WHERE  `entry`=41;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes the broadcast text not displaying for Protector Gariel.

### Proof
<!-- Link resources as proof -->
Was already implemented, but broke from other db updates.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- closes: https://github.com/vmangos/core/issues/3182

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .go creature 89531 and wait for broadcast text

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
