### PR TITLE
Convert more spells to AuraScript

### DIFF
--- a/sql/migrations/20260102184203_world.sql
+++ b/sql/migrations/20260102184203_world.sql
@@ -1,0 +1,35 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260102184203');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260102184203');
+-- Add your query below.
+
+UPDATE `spell_template` SET `script_name`='spell_shadowmeld' WHERE `entry` = 20580;
+UPDATE `spell_template` SET `script_name`='spell_stoneform' WHERE `entry` = 20594;
+UPDATE `spell_template` SET `script_name`='spell_discombobulate' WHERE `entry` = 4060;
+UPDATE `spell_template` SET `script_name`='spell_warrior_sweeping_strikes' WHERE `entry` = 12292;
+UPDATE `spell_template` SET `script_name`='spell_warrior_blood_fury' WHERE `entry` = 23234;
+UPDATE `spell_template` SET `script_name`='spell_nefarian_polymorph' WHERE `entry` = 23603;
+UPDATE `spell_template` SET `script_name`='spell_ashbringer' WHERE `entry` = 28282;
+UPDATE `spell_template` SET `script_name`='spell_silithyst' WHERE `entry` = 29519;
+UPDATE `spell_template` SET `script_name`='spell_controlling_steam_tonk' WHERE `entry` = 24937;
+UPDATE `spell_template` SET `script_name`='spell_chains_of_kelthuzad' WHERE `entry` = 28410;
+UPDATE `spell_template` SET `script_name`='spell_shaman_mana_tide' WHERE `entry` = 16191;
+UPDATE `spell_template` SET `script_name`='spell_hunter_frost_trap_aura' WHERE `entry` = 13810;
+UPDATE `spell_template` SET `script_name`='spell_warlock_curse_of_idiocy' WHERE `entry` = 1010;
+UPDATE `spell_template` SET `script_name`='spell_activate_mg_turret' WHERE `entry` = 25026;
+UPDATE `spell_template` SET `script_name`='spell_flamethrower' WHERE `entry` = 25027;
+UPDATE `spell_template` SET `script_name`='spell_thaddius_positive_charge_aura' WHERE `entry` = 28059;
+UPDATE `spell_template` SET `script_name`='spell_thaddius_negative_charge_aura' WHERE `entry` = 28084;
+UPDATE `spell_template` SET `script_name`='spell_cannibalize_aura' WHERE `entry` = 20578;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -671,11 +671,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder *holder)
         if (pCurrChar->m_deathState != ALIVE)
         {
             // not blizz like, we must correctly save and load player instead...
-            if (pCurrChar->GetRace() == RACE_NIGHTELF)
-                pCurrChar->CastSpell(pCurrChar, 20584, true);   // auras SPELL_AURA_INCREASE_SPEED(+speed in wisp form), SPELL_AURA_INCREASE_SWIM_SPEED(+swim speed in wisp form), SPELL_AURA_TRANSFORM (to wisp form)
-            pCurrChar->CastSpell(pCurrChar, 8326, true);        // auras SPELL_AURA_GHOST, SPELL_AURA_INCREASE_SPEED(why?), SPELL_AURA_INCREASE_SWIM_SPEED(why?)
-
-            pCurrChar->SetWaterWalking(true);
+            pCurrChar->ApplyGhostForm();
         }
     }
 

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -2067,6 +2067,8 @@ class Player final: public Unit
         void ResurrectPlayer(float restore_percent, bool applySickness = false);
         void BuildPlayerRepop();
         void RepopAtGraveyard();
+        void ApplyGhostForm();
+        void RemoveGhostForm();
         void ScheduleRepopAtGraveyard();
 
         // Nostalrius : Phasing

--- a/src/game/Spells/SpellAuras.h
+++ b/src/game/Spells/SpellAuras.h
@@ -160,6 +160,7 @@ class SpellAuraHolder
         bool IsWeaponBuffCoexistableWith(SpellAuraHolder const* ref) const;
         bool IsNeedVisibleSlot(Unit const* caster) const;
         bool IsRemovedOnShapeLost() const { return m_isRemovedOnShapeLost; }
+        void SetRemovedOnShapeLost(bool removed) { m_isRemovedOnShapeLost = removed; }
         bool IsInUse() const { return m_in_use;}
         bool IsDeleted() const { return m_deleted;}
         bool IsEmptyHolder() const;

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
@@ -733,6 +733,45 @@ AuraScript* GetScript_NefarianClassCallMage(SpellEntry const*)
     return new NefarianClassCallMageAuraScript();
 }
 
+// 23603 - Nefarian Class Call Mage - Polymorph (Transform Display-ID)
+struct NefarianPolymorphAuraScript : public AuraScript
+{
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        if (!apply)
+            return;
+
+        Unit* target = aura->GetTarget();
+
+        // Randomly select one of three display IDs for the polymorph transform
+        uint32 display_id = 0;
+        int rand = urand(0, 2);
+        switch (rand)
+        {
+            case 0:
+                display_id = 1060;
+                break;
+            case 1:
+                display_id = 4473;
+                break;
+            case 2:
+                display_id = 7898;
+                break;
+        }
+
+        if (display_id)
+        {
+            target->SetDisplayId(display_id);
+            target->SetTransformScale(1.0f);
+        }
+    }
+};
+
+AuraScript* GetScript_NefarianPolymorph(SpellEntry const*)
+{
+    return new NefarianPolymorphAuraScript();
+}
+
 void AddSC_boss_nefarian()
 {
     Script* pNewScript;
@@ -770,5 +809,10 @@ void AddSC_boss_nefarian()
     pNewScript = new Script;
     pNewScript->Name = "spell_nefarian_class_call_mage";
     pNewScript->GetAuraScript = &GetScript_NefarianClassCallMage;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "spell_nefarian_polymorph";
+    pNewScript->GetAuraScript = &GetScript_NefarianPolymorph;
     pNewScript->RegisterSelf();
 }

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
@@ -16,6 +16,7 @@
 
 #include "scriptPCH.h"
 #include "naxxramas.h"
+#include "AI/PlayerAI.h"
 
 enum KelthuzadData
 {
@@ -1142,6 +1143,29 @@ SpellScript* GetScript_KelThuzadVoidBlast(SpellEntry const*)
     return new KelThuzadVoidBlastScript();
 }
 
+// 28410 - Chains of Kel'Thuzad
+struct ChainsOfKelThuzadAuraScript : public AuraScript
+{
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        Unit* target = aura->GetTarget();
+        if (target->GetTypeId() != TYPEID_PLAYER)
+            return;
+
+        Player* player = target->ToPlayer();
+        if (apply && player->m_AI)
+        {
+            // Enable positive spells for charmed players (allows healing/buffing while charmed)
+            player->m_AI->enablePositiveSpells = true;
+        }
+    }
+};
+
+AuraScript* GetScript_ChainsOfKelThuzad(SpellEntry const*)
+{
+    return new ChainsOfKelThuzadAuraScript();
+}
+
 void AddSC_boss_kelthuzad()
 {
     Script* NewScript;
@@ -1179,5 +1203,10 @@ void AddSC_boss_kelthuzad()
     NewScript = new Script;
     NewScript->Name = "spell_kelthuzad_void_blast";
     NewScript->GetSpellScript = &GetScript_KelThuzadVoidBlast;
+    NewScript->RegisterSelf();
+
+    NewScript = new Script;
+    NewScript->Name = "spell_chains_of_kelthuzad";
+    NewScript->GetAuraScript = &GetScript_ChainsOfKelThuzad;
     NewScript->RegisterSelf();
 }

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
@@ -1149,10 +1149,10 @@ struct ChainsOfKelThuzadAuraScript : public AuraScript
     void OnAfterApply(Aura* aura, bool apply) final
     {
         Unit* target = aura->GetTarget();
-        if (target->GetTypeId() != TYPEID_PLAYER)
+        Player* player = target->ToPlayer();
+        if (!player)
             return;
 
-        Player* player = target->ToPlayer();
         if (apply && player->m_AI)
         {
             // Enable positive spells for charmed players (allows healing/buffing while charmed)

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_thaddius.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_thaddius.cpp
@@ -1087,6 +1087,130 @@ CreatureAI* GetAI_boss_thaddius(Creature* pCreature)
     return new boss_thaddiusAI(pCreature);
 }
 
+// 28059 - Positive Charge (Thaddius)
+struct ThaddiusPositiveChargeAuraScript : public AuraScript
+{
+    enum
+    {
+        SPELL_POSITIVE_CHARGE_APPLY = 28059,
+        SPELL_POSITIVE_CHARGE_AMP   = 29659
+    };
+
+    void OnPeriodicTrigger(Aura* aura, Unit* caster, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& /*spellInfo*/) final
+    {
+        // Only process in Naxxramas to avoid performance issues
+        if (target->GetMap()->GetId() != MAP_NAXXRAMAS)
+            return;
+
+        int numStacks = 0;
+        // Finding the amount of other players within 13yd that has the same polarity
+        Map::PlayerList const& pList = target->GetMap()->GetPlayers();
+        for (auto const& it : pList)
+        {
+            Player* pPlayer = it.getSource();
+            if (!pPlayer)
+                continue;
+            if (pPlayer->GetGUID() == target->GetGUID())
+                continue;
+            if (pPlayer->IsDead())
+                continue;
+            // 2d distance should be good enough
+            if (pPlayer->HasAura(SPELL_POSITIVE_CHARGE_APPLY) && caster->GetDistance2d(pPlayer) < 13.0f)
+            {
+                ++numStacks;
+            }
+        }
+        if (numStacks > 0)
+        {
+            if (!target->HasAura(SPELL_POSITIVE_CHARGE_AMP))
+                target->AddAura(SPELL_POSITIVE_CHARGE_AMP);
+            target->GetAura(SPELL_POSITIVE_CHARGE_AMP, EFFECT_INDEX_0)->GetHolder()->SetStackAmount(numStacks);
+        }
+        else
+        {
+            target->RemoveAurasDueToSpell(SPELL_POSITIVE_CHARGE_AMP);
+        }
+    }
+
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        if (apply)
+            return;
+
+        Unit* target = aura->GetTarget();
+        // Remove amplify effect on remove
+        if (target->HasAura(SPELL_POSITIVE_CHARGE_AMP))
+            target->RemoveAurasDueToSpell(SPELL_POSITIVE_CHARGE_AMP);
+    }
+};
+
+AuraScript* GetScript_ThaddiusPositiveChargeAura(SpellEntry const*)
+{
+    return new ThaddiusPositiveChargeAuraScript();
+}
+
+// 28084 - Negative Charge (Thaddius)
+struct ThaddiusNegativeChargeAuraScript : public AuraScript
+{
+    enum
+    {
+        SPELL_NEGATIVE_CHARGE_APPLY = 28084,
+        SPELL_NEGATIVE_CHARGE_AMP   = 29660
+    };
+
+    void OnPeriodicTrigger(Aura* aura, Unit* caster, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& /*spellInfo*/) final
+    {
+        // Only process in Naxxramas to avoid performance issues
+        if (target->GetMap()->GetId() != MAP_NAXXRAMAS)
+            return;
+
+        int numStacks = 0;
+        // Finding the amount of other players within 13yd that has the same polarity
+        Map::PlayerList const& pList = target->GetMap()->GetPlayers();
+        for (auto const& it : pList)
+        {
+            Player* pPlayer = it.getSource();
+            if (!pPlayer)
+                continue;
+            if (pPlayer->GetGUID() == caster->GetGUID())
+                continue;
+            if (pPlayer->IsDead())
+                continue;
+            // 2d distance should be good enough
+            if (pPlayer->HasAura(SPELL_NEGATIVE_CHARGE_APPLY) && caster->GetDistance2d(pPlayer) < 13.0f)
+            {
+                ++numStacks;
+            }
+        }
+        if (numStacks > 0)
+        {
+            if (!target->HasAura(SPELL_NEGATIVE_CHARGE_AMP))
+                target->AddAura(SPELL_NEGATIVE_CHARGE_AMP);
+            target->GetAura(SPELL_NEGATIVE_CHARGE_AMP, EFFECT_INDEX_0)->GetHolder()->SetStackAmount(numStacks);
+        }
+        else
+        {
+            target->RemoveAurasDueToSpell(SPELL_NEGATIVE_CHARGE_AMP);
+        }
+    }
+
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        if (apply)
+            return;
+
+        Unit* target = aura->GetTarget();
+        // Remove amplify effect on remove
+        if (target->HasAura(SPELL_NEGATIVE_CHARGE_AMP))
+            target->RemoveAurasDueToSpell(SPELL_NEGATIVE_CHARGE_AMP);
+    }
+};
+
+AuraScript* GetScript_ThaddiusNegativeChargeAura(SpellEntry const*)
+{
+    return new ThaddiusNegativeChargeAuraScript();
+}
+
 // 28062 - Positive Charge (Thaddius)
 struct ThaddiusPositiveChargeScript : public SpellScript
 {
@@ -1185,5 +1309,15 @@ void AddSC_boss_thaddius()
     pNewScript = new Script;
     pNewScript->Name = "spell_thaddius_magnetic_pull";
     pNewScript->GetSpellScript = &GetScript_ThaddiusMagneticPull;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "spell_thaddius_positive_charge_aura";
+    pNewScript->GetAuraScript = &GetScript_ThaddiusPositiveChargeAura;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "spell_thaddius_negative_charge_aura";
+    pNewScript->GetAuraScript = &GetScript_ThaddiusNegativeChargeAura;
     pNewScript->RegisterSelf();
 }

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_thaddius.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_thaddius.cpp
@@ -1108,8 +1108,6 @@ struct ThaddiusPositiveChargeAuraScript : public AuraScript
         for (auto const& it : pList)
         {
             Player* pPlayer = it.getSource();
-            if (!pPlayer)
-                continue;
             if (pPlayer->GetGUID() == target->GetGUID())
                 continue;
             if (pPlayer->IsDead())
@@ -1170,8 +1168,6 @@ struct ThaddiusNegativeChargeAuraScript : public AuraScript
         for (auto const& it : pList)
         {
             Player* pPlayer = it.getSource();
-            if (!pPlayer)
-                continue;
             if (pPlayer->GetGUID() == caster->GetGUID())
                 continue;
             if (pPlayer->IsDead())

--- a/src/scripts/spells/spell_hunter.cpp
+++ b/src/scripts/spells/spell_hunter.cpp
@@ -134,6 +134,25 @@ SpellScript* GetScript_HunterCounterAttack(SpellEntry const*)
     return new HunterCounterAttackScript();
 }
 
+// 13810 - Frost Trap Aura
+struct HunterFrostTrapAuraScript : public AuraScript
+{
+    void OnPeriodicTrigger(Aura* aura, Unit* /*caster*/, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& /*spellInfo*/) final
+    {
+        Unit* caster = aura->GetCaster();
+        if (!caster)
+            return;
+
+        // Talent 'Entrapment' for example (chance to root)
+        caster->ProcDamageAndSpell(ProcSystemArguments(target, PROC_FLAG_ON_TRAP_ACTIVATION, PROC_FLAG_NONE, PROC_EX_NORMAL_HIT, 1, 1, BASE_ATTACK, aura->GetSpellProto()));
+    }
+};
+
+AuraScript* GetScript_HunterFrostTrapAura(SpellEntry const*)
+{
+    return new HunterFrostTrapAuraScript();
+}
+
 void AddSC_hunter_spell_scripts()
 {
     Script* newscript;
@@ -161,5 +180,10 @@ void AddSC_hunter_spell_scripts()
     newscript = new Script;
     newscript->Name = "spell_hunter_counterattack";
     newscript->GetSpellScript = &GetScript_HunterCounterAttack;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_hunter_frost_trap_aura";
+    newscript->GetAuraScript = &GetScript_HunterFrostTrapAura;
     newscript->RegisterSelf();
 }

--- a/src/scripts/spells/spell_shaman.cpp
+++ b/src/scripts/spells/spell_shaman.cpp
@@ -46,6 +46,28 @@ SpellScript* GetScript_ShamanFlametongueProcDummy(SpellEntry const*)
     return new ShamanFlametongueProcDummyScript();
 }
 
+// 16191 - Mana Tide
+struct ShamanManaTideAuraScript : public AuraScript
+{
+    void OnPeriodicTrigger(Aura* aura, Unit* /*caster*/, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& spellInfo) final
+    {
+        // Cast custom spell with dithered amount instead of default trigger
+        uint32 triggerSpellId = aura->GetSpellProto()->EffectTriggerSpell[aura->GetEffIndex()];
+        if (triggerSpellId)
+        {
+            int32 ditheredAmount = dither(aura->GetModifier()->m_amount);
+            target->CastCustomSpell(target, triggerSpellId, ditheredAmount, {}, {}, true, nullptr, aura);
+            // Prevent default cast
+            spellInfo = nullptr;
+        }
+    }
+};
+
+AuraScript* GetScript_ShamanManaTide(SpellEntry const*)
+{
+    return new ShamanManaTideAuraScript();
+}
+
 void AddSC_shaman_spell_scripts()
 {
     Script* newscript;
@@ -53,5 +75,10 @@ void AddSC_shaman_spell_scripts()
     newscript = new Script;
     newscript->Name = "spell_shaman_flametongue_proc_dummy";
     newscript->GetSpellScript = &GetScript_ShamanFlametongueProcDummy;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_shaman_mana_tide";
+    newscript->GetAuraScript = &GetScript_ShamanManaTide;
     newscript->RegisterSelf();
 }

--- a/src/scripts/spells/spell_special.cpp
+++ b/src/scripts/spells/spell_special.cpp
@@ -415,10 +415,10 @@ struct ControllingSteamTonkAuraScript : public AuraScript
 {
     enum
     {
-        SPELL_DAMAGED_TONK              = 27771,
-        SPELL_STUN                      = 9179,
-        SPELL_UNROOT                    = 24935,
-        GAMEOBJECT_TONK_CONTROL_CONSOLE = 180524
+        SPELL_DAMAGED_TONK      = 27771,
+        SPELL_STUN              = 9179,
+        SPELL_UNROOT            = 24935,
+        GO_TONK_CONTROL_CONSOLE = 180524
     };
 
     void OnAfterApply(Aura* aura, bool apply) final
@@ -443,7 +443,7 @@ struct ControllingSteamTonkAuraScript : public AuraScript
         player->RemoveAurasDueToSpell(SPELL_UNROOT);
 
         // Reset Tonk Control Console
-        if (GameObject* pConsole = player->FindNearestGameObject(GAMEOBJECT_TONK_CONTROL_CONSOLE, INTERACTION_DISTANCE))
+        if (GameObject* pConsole = player->FindNearestGameObject(GO_TONK_CONTROL_CONSOLE, INTERACTION_DISTANCE))
         {
             pConsole->SetGoState(GO_STATE_READY);
             pConsole->SetLootState(GO_READY);

--- a/src/scripts/spells/spell_special.cpp
+++ b/src/scripts/spells/spell_special.cpp
@@ -273,24 +273,246 @@ SpellScript* GetScript_OpeningBattlegroundBanner(SpellEntry const*)
     return new OpeningBattlegroundBannerScript();
 }
 
-enum
-{
-    SPELL_CANNIBALIZE_EFFECT = 20578,
-};
-
 // 20577 - Cannibalize
-struct CannibalizeScript : public SpellScript
+struct CannibalizeSpellScript : public SpellScript
 {
+    enum
+    {
+        SPELL_CANNIBALIZE_AURA = 20578,
+    };
+
     void OnSuccessfulFinish(Spell* spell) const final
     {
         if (spell->m_casterUnit && (spell->GetUnitTarget() || spell->GetCorpseTarget()))
-            spell->m_casterUnit->CastSpell(spell->m_casterUnit, SPELL_CANNIBALIZE_EFFECT, true);
+            spell->m_casterUnit->CastSpell(spell->m_casterUnit, SPELL_CANNIBALIZE_AURA, true);
     }
 };
 
 SpellScript* GetScript_Cannibalize(SpellEntry const*)
 {
-    return new CannibalizeScript();
+    return new CannibalizeSpellScript();
+}
+
+// 20578 - Cannibalize Aura
+struct CannibalizeAuraScript : public AuraScript
+{
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        Unit* target = aura->GetTarget();
+        if (!apply)
+        {
+            // Remove cannibalize animation when aura is removed
+            target->HandleEmoteCommand(EMOTE_STATE_NONE);
+        }
+    }
+
+    void OnPeriodicTickEnd(Aura* aura) final
+    {
+        // Set cannibalize animation during periodic ticks
+        Unit* target = aura->GetTarget();
+        if (!target->IsAlive())
+            return;
+
+        Powers pt = target->GetPowerType();
+        if (int32(pt) == aura->GetMiscValue())
+            target->HandleEmoteCommand(EMOTE_STATE_CANNIBALIZE);
+    }
+};
+
+AuraScript* GetScript_CannibalizeAura(SpellEntry const*)
+{
+    return new CannibalizeAuraScript();
+}
+
+// 29519 - Silithyst
+struct SilithystAuraScript : public AuraScript
+{
+    enum
+    {
+        ZONE_SILITHUS       = 1377,
+        SPELL_ALLIANCE_BUFF = 29894,
+        SPELL_HORDE_BUFF    = 29895
+    };
+
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        Unit* target = aura->GetTarget();
+        if (target->GetTypeId() != TYPEID_PLAYER)
+            return;
+
+        Player* player = target->ToPlayer();
+
+        // Only works in Silithus
+        if (player->GetZoneId() != ZONE_SILITHUS)
+            return;
+
+        if (apply)
+        {
+            // Cast team-specific buff when aura is applied
+            uint32 buffSpell = (player->GetTeam() == ALLIANCE) ? SPELL_ALLIANCE_BUFF : SPELL_HORDE_BUFF;
+            player->CastSpell(player, buffSpell, true);
+        }
+        else
+        {
+            // Remove team-specific buff when aura is removed
+            uint32 buffSpell = (player->GetTeam() == ALLIANCE) ? SPELL_ALLIANCE_BUFF : SPELL_HORDE_BUFF;
+            player->RemoveAurasDueToSpell(buffSpell);
+
+            // Outdoor PVP Silithus: Loss of Silithyst Buff
+            if (aura->GetHolder()->GetRemoveMode() == AURA_REMOVE_BY_CANCEL ||
+                aura->GetHolder()->GetRemoveMode() == AURA_REMOVE_BY_DEATH ||
+                aura->GetHolder()->GetRemoveMode() == AURA_REMOVE_BY_DISPEL)
+            {
+                if (ZoneScript* pScript = player->GetZoneScript())
+                    pScript->HandleDropFlag(player, aura->GetId());
+            }
+        }
+    }
+};
+
+AuraScript* GetScript_Silithyst(SpellEntry const*)
+{
+    return new SilithystAuraScript();
+}
+
+// 25026 - Activate MG Turret
+// 25027 - Flamethrower
+struct DarkmoonFaireManaConsumptionAuraScript : public AuraScript
+{
+    enum
+    {
+        MANA_COST_PER_TICK = 10
+    };
+
+    void OnPeriodicTrigger(Aura* aura, Unit* /*caster*/, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& spellInfo) final
+    {
+        if (target->GetPower(POWER_MANA) >= MANA_COST_PER_TICK)
+        {
+            target->ModifyPower(POWER_MANA, -MANA_COST_PER_TICK);
+            target->SendEnergizeSpellLog(target, aura->GetId(), -MANA_COST_PER_TICK, POWER_MANA);
+        }
+        else
+        {
+            // Remove aura if not enough mana and prevent trigger spell
+            target->RemoveAurasDueToSpell(aura->GetId());
+            spellInfo = nullptr;
+        }
+    }
+};
+
+AuraScript* GetScript_ActivateMGTurret(SpellEntry const*)
+{
+    return new DarkmoonFaireManaConsumptionAuraScript();
+}
+
+AuraScript* GetScript_Flamethrower(SpellEntry const*)
+{
+    return new DarkmoonFaireManaConsumptionAuraScript();
+}
+
+// 24937 - Using Control Console
+struct ControllingSteamTonkAuraScript : public AuraScript
+{
+    enum
+    {
+        SPELL_DAMAGED_TONK              = 27771,
+        SPELL_STUN                      = 9179,
+        SPELL_UNROOT                    = 24935,
+        GAMEOBJECT_TONK_CONTROL_CONSOLE = 180524
+    };
+
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        if (apply)
+            return;
+
+        Unit* target = aura->GetTarget();
+        Unit* caster = aura->GetCaster();
+        if (!caster || caster->GetTypeId() != TYPEID_PLAYER)
+            return;
+
+        Player* player = caster->ToPlayer();
+
+        // Cast Damaged Tonk on target (the tonk)
+        target->CastSpell(target, SPELL_DAMAGED_TONK, true);
+
+        // Cast 3 sec Stun on self (the player)
+        player->CastSpell(player, SPELL_STUN, true);
+
+        // Unroot player
+        player->RemoveAurasDueToSpell(SPELL_UNROOT);
+
+        // Reset Tonk Control Console
+        if (GameObject* pConsole = player->FindNearestGameObject(GAMEOBJECT_TONK_CONTROL_CONSOLE, INTERACTION_DISTANCE))
+        {
+            pConsole->SetGoState(GO_STATE_READY);
+            pConsole->SetLootState(GO_READY);
+            pConsole->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
+        }
+    }
+};
+
+AuraScript* GetScript_ControllingSteamTonk(SpellEntry const*)
+{
+    return new ControllingSteamTonkAuraScript();
+}
+
+// 20580 - Shadowmeld (Night Elf Racial)
+struct ShadowmeldAuraScript : public AuraScript
+{
+    enum
+    {
+        SPELL_ELUSIVENESS = 21009 // Elusiveness - visual effect applied during Shadowmeld
+    };
+
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        if (!apply)
+            return;
+
+        Unit* target = aura->GetTarget();
+        if (target->GetTypeId() != TYPEID_PLAYER)
+            return;
+
+        // Cast Elusiveness visual effect when Shadowmeld is applied
+        target->CastSpell(target, SPELL_ELUSIVENESS, true, nullptr, aura);
+    }
+
+    void OnBeforeApply(Aura* aura, bool apply) final
+    {
+        if (apply)
+            return;
+
+        Unit* target = aura->GetTarget();
+        if (target->GetTypeId() != TYPEID_PLAYER)
+            return;
+
+        // Remove Elusiveness visual effect when Shadowmeld is removed
+        target->RemoveAurasDueToSpell(SPELL_ELUSIVENESS);
+    }
+};
+
+AuraScript* GetScript_Shadowmeld(SpellEntry const*)
+{
+    return new ShadowmeldAuraScript();
+}
+
+// 20594 - Stoneform (Dwarf Racial)
+struct StoneformAuraScript : public AuraScript
+{
+    void OnAfterApply(Aura* aura, bool apply) final
+    {
+        Unit* target = aura->GetTarget();
+
+        // Stoneform grants immunity to Disease and Poison dispels
+        target->ApplySpellDispelImmunity(aura->GetSpellProto(), DISPEL_DISEASE, apply);
+        target->ApplySpellDispelImmunity(aura->GetSpellProto(), DISPEL_POISON, apply);
+    }
+};
+
+AuraScript* GetScript_Stoneform(SpellEntry const*)
+{
+    return new StoneformAuraScript();
 }
 
 void AddSC_special_spell_scripts()
@@ -365,5 +587,40 @@ void AddSC_special_spell_scripts()
     newscript = new Script;
     newscript->Name = "spell_cannibalize";
     newscript->GetSpellScript = &GetScript_Cannibalize;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_cannibalize_aura";
+    newscript->GetAuraScript = &GetScript_CannibalizeAura;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_shadowmeld";
+    newscript->GetAuraScript = &GetScript_Shadowmeld;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_stoneform";
+    newscript->GetAuraScript = &GetScript_Stoneform;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_silithyst";
+    newscript->GetAuraScript = &GetScript_Silithyst;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_controlling_steam_tonk";
+    newscript->GetAuraScript = &GetScript_ControllingSteamTonk;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_activate_mg_turret";
+    newscript->GetAuraScript = &GetScript_ActivateMGTurret;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "spell_flamethrower";
+    newscript->GetAuraScript = &GetScript_Flamethrower;
     newscript->RegisterSelf();
 }


### PR DESCRIPTION
## 🍰 Pullrequest
Converted many hardcoded spells from the core to the new AuraScript system.
Additionally, the ghost form logic has been refactored into dedicated Player functions.

## Converted Spells:

#### Racial Abilities
- **20580 - Shadowmeld** (Night Elf): Applies/removes Elusiveness visual effect
- **20594 - Stoneform** (Dwarf): Grants Disease and Poison dispel immunity
- **20577 - Cannibalize** (Undead): Handles emote animation and effect spell casting

Warrior Spells
- **12292 - Sweeping Strikes**: Prevents removal on shapeshift
- **23234 - Blood Fury**: Applies debuff on removal

Hunter Spells
- **13810 - Frost Trap Aura**: Handles proc system for talents like Entrapment

Shaman Spells
- **16191 - Mana Tide**: Custom spell casting with dithered amount

Warlock Spells
- **1010 - Curse of Idiocy**: Conditional triggering based on stat reduction

Item Spells
- **4060 - Discombobulate**: Removes mount auras on application
- **28282 - Ashbringer**: Special reputation handling for Scarlet Crusade

PvP Spells
- **29519 - Silithyst**: Zone-specific buff application and flag handling

Darkmoon Faire Spells
- **25026 - Activate MG Turret**: Mana consumption per tick
- **25027 - Flamethrower**: Mana consumption per tick
- **24937 - Controlling Steam Tonk**: Cleanup logic on aura removal

Boss Spells
- **23603 - Nefarian Polymorph**: Random display ID selection
- **28410 - Chains of Kel'Thuzad**: Enables positive spells for charmed players
- **28059 - Thaddius Positive Charge**: Stack calculation based on nearby players
- **28084 - Thaddius Negative Charge**: Stack calculation based on nearby players

### Proof
- None

### Issues
- The ghost form refactoring fixes a bug where the logic was race-based instead of spell-based.

### How2Test
- All converted spells maintain their original behavior while being more maintainable and modular.

### Todo / Checklist
- [X] None
