### PR TITLE
Add missing effect index checks in aura scripts

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
@@ -741,6 +741,9 @@ struct NefarianPolymorphAuraScript : public AuraScript
         if (!apply)
             return;
 
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
 
         // Randomly select one of three display IDs for the polymorph transform

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_nefarian.cpp
@@ -741,7 +741,7 @@ struct NefarianPolymorphAuraScript : public AuraScript
         if (!apply)
             return;
 
-        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+        if (aura->GetEffIndex() != EFFECT_INDEX_1)
             return;
 
         Unit* target = aura->GetTarget();

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
@@ -1148,6 +1148,9 @@ struct ChainsOfKelThuzadAuraScript : public AuraScript
 {
     void OnAfterApply(Aura* aura, bool apply) final
     {
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
         Player* player = target->ToPlayer();
         if (!player)

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_thaddius.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_thaddius.cpp
@@ -1096,7 +1096,7 @@ struct ThaddiusPositiveChargeAuraScript : public AuraScript
         SPELL_POSITIVE_CHARGE_AMP   = 29659
     };
 
-    void OnPeriodicTrigger(Aura* aura, Unit* caster, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& /*spellInfo*/) final
+    void OnPeriodicTrigger(Aura* /*aura*/, Unit* /*caster*/, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& /*spellInfo*/) final
     {
         // Only process in Naxxramas to avoid performance issues
         if (target->GetMap()->GetId() != MAP_NAXXRAMAS)
@@ -1113,7 +1113,7 @@ struct ThaddiusPositiveChargeAuraScript : public AuraScript
             if (pPlayer->IsDead())
                 continue;
             // 2d distance should be good enough
-            if (pPlayer->HasAura(SPELL_POSITIVE_CHARGE_APPLY) && caster->GetDistance2d(pPlayer) < 13.0f)
+            if (pPlayer->HasAura(SPELL_POSITIVE_CHARGE_APPLY) && target->GetDistance2d(pPlayer) < 13.0f)
             {
                 ++numStacks;
             }
@@ -1133,6 +1133,9 @@ struct ThaddiusPositiveChargeAuraScript : public AuraScript
     void OnAfterApply(Aura* aura, bool apply) final
     {
         if (apply)
+            return;
+
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
             return;
 
         Unit* target = aura->GetTarget();
@@ -1156,7 +1159,7 @@ struct ThaddiusNegativeChargeAuraScript : public AuraScript
         SPELL_NEGATIVE_CHARGE_AMP   = 29660
     };
 
-    void OnPeriodicTrigger(Aura* aura, Unit* caster, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& /*spellInfo*/) final
+    void OnPeriodicTrigger(Aura* /*aura*/, Unit* /*caster*/, Unit* target, WorldObject* /*targetObject*/, SpellEntry const*& /*spellInfo*/) final
     {
         // Only process in Naxxramas to avoid performance issues
         if (target->GetMap()->GetId() != MAP_NAXXRAMAS)
@@ -1168,12 +1171,12 @@ struct ThaddiusNegativeChargeAuraScript : public AuraScript
         for (auto const& it : pList)
         {
             Player* pPlayer = it.getSource();
-            if (pPlayer->GetGUID() == caster->GetGUID())
+            if (pPlayer->GetGUID() == target->GetGUID())
                 continue;
             if (pPlayer->IsDead())
                 continue;
             // 2d distance should be good enough
-            if (pPlayer->HasAura(SPELL_NEGATIVE_CHARGE_APPLY) && caster->GetDistance2d(pPlayer) < 13.0f)
+            if (pPlayer->HasAura(SPELL_NEGATIVE_CHARGE_APPLY) && target->GetDistance2d(pPlayer) < 13.0f)
             {
                 ++numStacks;
             }
@@ -1193,6 +1196,9 @@ struct ThaddiusNegativeChargeAuraScript : public AuraScript
     void OnAfterApply(Aura* aura, bool apply) final
     {
         if (apply)
+            return;
+
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
             return;
 
         Unit* target = aura->GetTarget();

--- a/src/scripts/spells/spell_item.cpp
+++ b/src/scripts/spells/spell_item.cpp
@@ -722,6 +722,9 @@ struct DiscombobulateAuraScript : public AuraScript
         if (!apply)
             return;
 
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
 
         // Discombobulate removes mount auras when applied
@@ -745,6 +748,9 @@ struct AshbringerAuraScript : public AuraScript
 
     void OnAfterApply(Aura* aura, bool apply) final
     {
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
         if (target->GetTypeId() != TYPEID_PLAYER)
             return;

--- a/src/scripts/spells/spell_special.cpp
+++ b/src/scripts/spells/spell_special.cpp
@@ -339,7 +339,7 @@ struct SilithystAuraScript : public AuraScript
 
     void OnAfterApply(Aura* aura, bool apply) final
     {
-        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+        if (aura->GetEffIndex() != EFFECT_INDEX_1)
             return;
 
         Unit* target = aura->GetTarget();
@@ -517,8 +517,14 @@ struct StoneformAuraScript : public AuraScript
 {
     void OnAfterApply(Aura* aura, bool apply) final
     {
+        // DISPEL_IMMUNITY effect moved from INDEX_2 to INDEX_0 in patch 1.7
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_6_1
+        if (aura->GetEffIndex() != EFFECT_INDEX_2)
+            return;
+#else
         if (aura->GetEffIndex() != EFFECT_INDEX_0)
             return;
+#endif
 
         Unit* target = aura->GetTarget();
 

--- a/src/scripts/spells/spell_special.cpp
+++ b/src/scripts/spells/spell_special.cpp
@@ -339,6 +339,10 @@ struct SilithystAuraScript : public AuraScript
 
     void OnAfterApply(Aura* aura, bool apply) final
     {
+        // Silithyst PvP was added in patch 1.12, FORCE_REACTION effect on INDEX_1
+#if SUPPORTED_CLIENT_BUILD < CLIENT_BUILD_1_12_1
+        return;
+#endif
         if (aura->GetEffIndex() != EFFECT_INDEX_1)
             return;
 

--- a/src/scripts/spells/spell_special.cpp
+++ b/src/scripts/spells/spell_special.cpp
@@ -298,6 +298,9 @@ struct CannibalizeAuraScript : public AuraScript
 {
     void OnAfterApply(Aura* aura, bool apply) final
     {
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
         if (!apply)
         {
@@ -336,6 +339,9 @@ struct SilithystAuraScript : public AuraScript
 
     void OnAfterApply(Aura* aura, bool apply) final
     {
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
         if (target->GetTypeId() != TYPEID_PLAYER)
             return;
@@ -426,6 +432,9 @@ struct ControllingSteamTonkAuraScript : public AuraScript
         if (apply)
             return;
 
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
         Unit* caster = aura->GetCaster();
         if (!caster || caster->GetTypeId() != TYPEID_PLAYER)
@@ -470,6 +479,9 @@ struct ShadowmeldAuraScript : public AuraScript
         if (!apply)
             return;
 
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
         if (target->GetTypeId() != TYPEID_PLAYER)
             return;
@@ -481,6 +493,9 @@ struct ShadowmeldAuraScript : public AuraScript
     void OnBeforeApply(Aura* aura, bool apply) final
     {
         if (apply)
+            return;
+
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
             return;
 
         Unit* target = aura->GetTarget();
@@ -502,6 +517,9 @@ struct StoneformAuraScript : public AuraScript
 {
     void OnAfterApply(Aura* aura, bool apply) final
     {
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         Unit* target = aura->GetTarget();
 
         // Stoneform grants immunity to Disease and Poison dispels

--- a/src/scripts/spells/spell_special.cpp
+++ b/src/scripts/spells/spell_special.cpp
@@ -340,9 +340,7 @@ struct SilithystAuraScript : public AuraScript
     void OnAfterApply(Aura* aura, bool apply) final
     {
         // Silithyst PvP was added in patch 1.12, FORCE_REACTION effect on INDEX_1
-#if SUPPORTED_CLIENT_BUILD < CLIENT_BUILD_1_12_1
-        return;
-#endif
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
         if (aura->GetEffIndex() != EFFECT_INDEX_1)
             return;
 
@@ -377,6 +375,7 @@ struct SilithystAuraScript : public AuraScript
                     pScript->HandleDropFlag(player, aura->GetId());
             }
         }
+#endif
     }
 };
 

--- a/src/scripts/spells/spell_warrior.cpp
+++ b/src/scripts/spells/spell_warrior.cpp
@@ -172,6 +172,9 @@ struct WarriorBloodFuryAuraScript : public AuraScript
     void OnBeforeApply(Aura* aura, bool apply) final
     {
 #if (SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_3_1) && (SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_8_4)
+        if (aura->GetEffIndex() != EFFECT_INDEX_0)
+            return;
+
         // Blood Fury - Add aura to decrease attack power on remove
         if (!apply && (aura->GetHolder()->GetRemoveMode() == AURA_REMOVE_BY_CANCEL || aura->GetHolder()->GetRemoveMode() == AURA_REMOVE_BY_EXPIRE))
         {


### PR DESCRIPTION
## 🍰 Pullrequest
Follow up for: https://github.com/vmangos/core/commit/f669c5038a8fcca7ad4a737ef9caf5eb0f144f26
Adds missing `GetEffIndex() != EFFECT_INDEX_0` checks to aura script callbacks to prevent logic from executing multiple times when spells have multiple effects.
Also fixed a bug in Thaddius charge auras where caster was incorrectly used for distance calculations.

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
