### PR TITLE
Add DNS resolution timeout for realm list updates

### DIFF
--- a/src/realmd/RealmList.cpp
+++ b/src/realmd/RealmList.cpp
@@ -33,6 +33,7 @@
 #include "Database/DatabaseEnv.h"
 #include "IO/Networking/DNS.h"
 #include "IO/Networking/Utils.h"
+#include "Config/Config.h"
 
 INSTANTIATE_SINGLETON_1( RealmList );
 
@@ -167,6 +168,9 @@ void RealmList::UpdateRealms(bool init)
 {
     sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "Updating realm list...");
 
+    uint32 dnsTimeoutSeconds = sConfig.GetIntDefault("DnsResolveTimeout", 5);
+    std::chrono::seconds dnsTimeout(dnsTimeoutSeconds);
+
     std::unique_ptr<QueryResult> result = LoginDatabase.Query(
         //       0     1       2          3               4                  5       6
         "SELECT `id`, `name`, `address`, `localAddress`, `localSubnetMask`, `port`, `icon`, "
@@ -201,17 +205,18 @@ void RealmList::UpdateRealms(bool init)
                 realmflags &= (REALM_FLAG_OFFLINE|REALM_FLAG_NEW_PLAYERS|REALM_FLAG_RECOMMENDED|REALM_FLAG_SPECIFYBUILD);
             }
 
-            auto externalIpAddress = IO::Networking::DNS::ResolveDomainSingle(externalAddressString, IO::Networking::IpAddress::Type::IPv4);
+            // Use DNS resolution with timeout to prevent hanging on unreachable DNS servers
+            auto externalIpAddress = IO::Networking::DNS::ResolveDomainSingle(externalAddressString, IO::Networking::IpAddress::Type::IPv4, dnsTimeout);
             if (!externalIpAddress)
             {
-                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Could not parse externalAddress: %s for realm \"%s\" (id %d) will skip realm update.", externalAddressString.c_str(), name.c_str(), realmId);
+                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Could not resolve or parse externalAddress: %s for realm \"%s\" (id %d) - will skip realm update.", externalAddressString.c_str(), name.c_str(), realmId);
                 continue;
             }
 
-            auto localIpAddress = IO::Networking::DNS::ResolveDomainSingle(localAddressString, IO::Networking::IpAddress::Type::IPv4);
+            auto localIpAddress = IO::Networking::DNS::ResolveDomainSingle(localAddressString, IO::Networking::IpAddress::Type::IPv4, dnsTimeout);
             if (!localIpAddress)
             {
-                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Could not parse localAddress: %s for realm \"%s\" (id %d) will skip realm update.", localAddressString.c_str(), name.c_str(), realmId);
+                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Could not resolve or parse localAddress: %s for realm \"%s\" (id %d) - will skip realm update.", localAddressString.c_str(), name.c_str(), realmId);
                 continue;
             }
 

--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -110,6 +110,14 @@ ConfVersion=2024091701
 #        Default: 20
 #                 0  (Disabled)
 #
+#    DnsResolveTimeout
+#        Maximum time in seconds to wait for DNS resolution when updating realm list.
+#        If DNS resolution takes longer than this timeout, the realm will be temporarily
+#        skipped until the next update cycle (see RealmsStateUpdateDelay).
+#        This prevents the server from hanging when DNS servers are unreachable.
+#        Default: 5 (seconds)
+#                 0 (use system default - potentially blocking, not recommended)
+#
 #    WrongPass.MaxCount
 #        Number of login attemps with wrong password before the account or IP is banned
 #        Default: 0  (Never ban)
@@ -189,6 +197,7 @@ ProcessPriority = 1
 WaitAtStartupError = 5 # consider fixing your actual problem before changing this value!
 MinRealmListDelay = 1
 RealmsStateUpdateDelay = 20
+DnsResolveTimeout = 5
 WrongPass.MaxCount = 0
 WrongPass.BanTime = 600
 WrongPass.BanType = 0

--- a/src/shared/IO/Networking/DNS.cpp
+++ b/src/shared/IO/Networking/DNS.cpp
@@ -4,6 +4,11 @@
 #include "Errors.h"
 #include "Util.h"
 #include "IO/SystemErrorToString.h"
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <memory>
 
 #if defined(WIN32)
 #include <WinSock2.h>
@@ -29,11 +34,91 @@ std::string IO::Networking::DNS::GetOwnHostname()
     return hostname;
 }
 
-std::vector<IO::Networking::IpAddress> IO::Networking::DNS::ResolveDomainAll(std::string const& domainName, IpAddress::Type type)
+namespace
 {
-    MANGOS_ASSERT(type == IpAddress::Type::IPv4); // TODO: this function is only tested with IPv4. `inet_ntop` will fail
+    // Limit concurrent pending DNS resolutions to prevent thread accumulation on DNS failures
+    std::atomic<int> g_pendingDnsResolutions{0};
+    constexpr int MAX_PENDING_DNS_RESOLUTIONS = 10;
 
-    // Check if we can parse the domain as an IP
+    // Internal blocking DNS resolution (no timeout)
+    std::vector<IO::Networking::IpAddress> ResolveDomainBlocking(std::string const& domainName, IO::Networking::IpAddress::Type type)
+    {
+        MANGOS_ASSERT(type == IO::Networking::IpAddress::Type::IPv4); // TODO: this function is only tested with IPv4. `inet_ntop` will fail
+
+        // Check if we can parse the domain as an IP
+        nonstd::optional<IO::Networking::IpAddress> maybeIp = IO::Networking::IpAddress::TryParseFromString(domainName);
+        if (maybeIp)
+        {
+            IO::Networking::IpAddress const& ip = maybeIp.value();
+            MANGOS_ASSERT(ip.GetType() == type);
+            return { ip }; // The "domain" can be directly parsed as an IP
+        }
+
+        // try to resolve the domain
+        addrinfo hints = {};
+        hints.ai_family = type == IO::Networking::IpAddress::Type::IPv4 ? AF_INET :  AF_INET6;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+
+        addrinfo* dnsResult = nullptr;
+        if (::getaddrinfo(domainName.c_str(), nullptr, &hints, &dnsResult) != 0)
+        {
+            sLog.Out(LogType::LOG_NETWORK, LOG_LVL_ERROR, "IO ERROR: ::getaddrinfo(...): %s", SystemErrorToString(
+#if defined(WIN32)
+            ::WSAGetLastError()
+#else
+            errno
+#endif
+            ).c_str());
+            return {}; // error occurred, empty return
+        }
+
+        std::vector<IO::Networking::IpAddress> list;
+
+        for (addrinfo* ptr = dnsResult; ptr != nullptr; ptr = ptr->ai_next)
+        {
+            if (ptr->ai_family == AF_INET)
+            {
+                sockaddr_in* sockaddr_ipv4 = reinterpret_cast<sockaddr_in*>(ptr->ai_addr);
+                IO::Networking::IpAddress ip = IO::Networking::Internal::inet_ntop(&(sockaddr_ipv4->sin_addr));
+                list.emplace_back(ip);
+            }
+            else if (ptr->ai_family == AF_INET6)
+            {
+                // TODO: Add inet_ntop for IPv6
+                //sockaddr_in6* sockaddr_ipv6 = reinterpret_cast<sockaddr_in6*>(ptr->ai_addr);
+                //IpAddress ip = IO::Networking::Internal::inet_ntop(&(sockaddr_ipv6->sin_addr));
+                //list.emplace_back(ip);
+            }
+            else
+            {
+                MANGOS_ASSERT(false && (ptr->ai_family == AF_INET || ptr->ai_family == AF_INET6));
+            }
+        }
+
+        freeaddrinfo(dnsResult);
+
+        return list;
+    }
+
+    // Shared state for DNS resolution with timeout - must live on heap to survive thread detachment
+    struct DnsResolverState
+    {
+        std::vector<IO::Networking::IpAddress> result;
+        std::mutex mutex;
+        std::condition_variable condition;
+        std::atomic<bool> resolved{false};
+        std::exception_ptr exceptionPtr = nullptr;
+    };
+}
+
+std::vector<IO::Networking::IpAddress> IO::Networking::DNS::ResolveDomainAll(std::string const& domainName, IpAddress::Type type, std::chrono::seconds timeout)
+{
+    // If timeout is 0, use blocking version directly
+    if (timeout.count() == 0)
+        return ResolveDomainBlocking(domainName, type);
+
+    // Check if we can parse the domain as an IP (no DNS lookup needed, no timeout needed)
     nonstd::optional<IpAddress> maybeIp = IpAddress::TryParseFromString(domainName);
     if (maybeIp)
     {
@@ -42,58 +127,92 @@ std::vector<IO::Networking::IpAddress> IO::Networking::DNS::ResolveDomainAll(std
         return { ip }; // The "domain" can be directly parsed as an IP
     }
 
-    // try to resolve the domain
-    addrinfo hints = {};
-    hints.ai_family = type == IpAddress::Type::IPv4 ? AF_INET :  AF_INET6;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_protocol = IPPROTO_TCP;
-
-    addrinfo* dnsResult = nullptr;
-    if (::getaddrinfo(domainName.c_str(), nullptr, &hints, &dnsResult) != 0)
+    // Check if we have too many pending DNS resolutions (prevents thread accumulation on DNS failures)
+    int currentPending = g_pendingDnsResolutions.load();
+    if (currentPending >= MAX_PENDING_DNS_RESOLUTIONS)
     {
-        sLog.Out(LogType::LOG_NETWORK, LOG_LVL_ERROR, "IO ERROR: ::getaddrinfo(...): %s", SystemErrorToString(
-#if defined(WIN32)
-        ::WSAGetLastError()
-#else
-        errno
-#endif
-        ).c_str());
-        return {}; // error occurred, empty return
+        sLog.Out(LogType::LOG_NETWORK, LOG_LVL_ERROR,
+            "DNS resolution skipped for domain %s: too many pending resolutions (%d/%d)",
+            domainName.c_str(), currentPending, MAX_PENDING_DNS_RESOLUTIONS);
+        return {};
+    }
+    g_pendingDnsResolutions.fetch_add(1);
+
+    // Use shared_ptr for state so it survives thread detachment on timeout
+    auto state = std::make_shared<DnsResolverState>();
+
+    // Worker thread that performs the DNS resolution
+    std::thread resolverThread([state, domainName, type]()
+    {
+        try
+        {
+            std::vector<IpAddress> dnsResult = ResolveDomainBlocking(domainName, type);
+
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->result = std::move(dnsResult);
+            state->resolved.store(true);
+            state->condition.notify_one();
+        }
+        catch (...)
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->exceptionPtr = std::current_exception();
+            state->resolved.store(true);
+            state->condition.notify_one();
+        }
+
+        // Always decrement counter when thread finishes (whether joined or detached)
+        g_pendingDnsResolutions.fetch_sub(1);
+    });
+
+    // Wait for either resolution or timeout
+    std::unique_lock<std::mutex> lock(state->mutex);
+    bool resolutionCompleted = state->condition.wait_for(lock, timeout, [&state]() {
+        return state->resolved.load();
+    });
+
+    if (!resolutionCompleted)
+    {
+        // Timeout reached - detach thread, shared_ptr ensures state stays valid
+        resolverThread.detach();
+
+        sLog.Out(LogType::LOG_NETWORK, LOG_LVL_ERROR, "DNS resolution timeout after %lld seconds for domain: %s",
+            static_cast<long long>(timeout.count()), domainName.c_str());
+        return {}; // Return empty result on timeout
     }
 
-    std::vector<IpAddress> list;
+    lock.unlock();
 
-    for (addrinfo* ptr = dnsResult; ptr != nullptr; ptr = ptr->ai_next)
+    // Make sure the thread is joined before checking results
+    if (resolverThread.joinable())
+        resolverThread.join();
+
+    // Check if an exception occurred in the resolver thread
+    if (state->exceptionPtr)
     {
-        if (ptr->ai_family == AF_INET)
+        try
         {
-            sockaddr_in* sockaddr_ipv4 = reinterpret_cast<sockaddr_in*>(ptr->ai_addr);
-            IpAddress ip = IO::Networking::Internal::inet_ntop(&(sockaddr_ipv4->sin_addr));
-            list.emplace_back(ip);
+            std::rethrow_exception(state->exceptionPtr);
         }
-        else if (ptr->ai_family == AF_INET6)
+        catch (const std::exception& e)
         {
-            // TODO: Add inet_ntop for IPv6
-            //sockaddr_in6* sockaddr_ipv6 = reinterpret_cast<sockaddr_in6*>(ptr->ai_addr);
-            //IpAddress ip = IO::Networking::Internal::inet_ntop(&(sockaddr_ipv6->sin_addr));
-            //list.emplace_back(ip);
+            sLog.Out(LogType::LOG_NETWORK, LOG_LVL_ERROR, "DNS resolution exception for domain %s: %s", domainName.c_str(), e.what());
         }
-        else
+        catch (...)
         {
-            MANGOS_ASSERT(false && (ptr->ai_family == AF_INET || ptr->ai_family == AF_INET6));
+            sLog.Out(LogType::LOG_NETWORK, LOG_LVL_ERROR, "DNS resolution unknown exception for domain: %s", domainName.c_str());
         }
+        return {}; // Return empty result on exception
     }
 
-    freeaddrinfo(dnsResult);
-
-    return list;
+    return state->result;
 }
 
-nonstd::optional<IO::Networking::IpAddress> IO::Networking::DNS::ResolveDomainSingle(std::string const& domainName, IpAddress::Type type, SelectionStrategy strategy)
+nonstd::optional<IO::Networking::IpAddress> IO::Networking::DNS::ResolveDomainSingle(std::string const& domainName, IpAddress::Type type, std::chrono::seconds timeout, SelectionStrategy strategy)
 {
-    std::vector<IpAddress> allIps = ResolveDomainAll(domainName, type);
+    std::vector<IpAddress> allIps = ResolveDomainAll(domainName, type, timeout);
     if (allIps.empty())
-        return nonstd::nullopt; // No IP found
+        return nonstd::nullopt; // No IP found or timeout
 
     switch (strategy)
     {

--- a/src/shared/IO/Networking/DNS.cpp
+++ b/src/shared/IO/Networking/DNS.cpp
@@ -4,7 +4,7 @@
 #include "Errors.h"
 #include "Util.h"
 #include "IO/SystemErrorToString.h"
-#include <thread>
+#include "IO/Multithreading/CreateThread.h"
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
@@ -142,7 +142,7 @@ std::vector<IO::Networking::IpAddress> IO::Networking::DNS::ResolveDomainAll(std
     auto state = std::make_shared<DnsResolverState>();
 
     // Worker thread that performs the DNS resolution
-    std::thread resolverThread([state, domainName, type]()
+    std::thread resolverThread = IO::Multithreading::CreateThread("DnsResolver", [state, domainName, type]()
     {
         try
         {
@@ -194,7 +194,7 @@ std::vector<IO::Networking::IpAddress> IO::Networking::DNS::ResolveDomainAll(std
         {
             std::rethrow_exception(state->exceptionPtr);
         }
-        catch (const std::exception& e)
+        catch (std::exception const& e)
         {
             sLog.Out(LogType::LOG_NETWORK, LOG_LVL_ERROR, "DNS resolution exception for domain %s: %s", domainName.c_str(), e.what());
         }

--- a/src/shared/IO/Networking/DNS.h
+++ b/src/shared/IO/Networking/DNS.h
@@ -2,6 +2,7 @@
 #define MANGOS_IO_NETWORKING_DNS_H
 
 #include <vector>
+#include <chrono>
 #include "./IpAddress.h"
 
 namespace IO { namespace Networking { namespace DNS
@@ -9,8 +10,9 @@ namespace IO { namespace Networking { namespace DNS
     std::string GetOwnHostname();
 
     /// Will also work with IP addresses without touching the DNS layer
-    /// \warning Will return an empty list if unable to resolve the domain
-    std::vector<IO::Networking::IpAddress> ResolveDomainAll(std::string const& domainName, IO::Networking::IpAddress::Type type);
+    /// \param timeout Maximum time to wait for DNS resolution. Default of 0 uses system default (potentially blocking).
+    /// \warning Will return an empty list if unable to resolve the domain or if timeout is exceeded
+    std::vector<IO::Networking::IpAddress> ResolveDomainAll(std::string const& domainName, IO::Networking::IpAddress::Type type, std::chrono::seconds timeout = std::chrono::seconds{0});
 
     /// Different strategies on how to resolve multiple IPAddresses on the same domain name
     /// This can happen if, for example, a domain has multiple "A-Records" with the same name but different IPs.
@@ -24,7 +26,9 @@ namespace IO { namespace Networking { namespace DNS
     };
 
     /// Just like `ResolveDomainAll` but will return at most one IPAddress
-    nonstd::optional<IO::Networking::IpAddress> ResolveDomainSingle(std::string const& domainName, IO::Networking::IpAddress::Type type, SelectionStrategy strategy = SelectionStrategy::First);
+    /// \param timeout Maximum time to wait for DNS resolution. Default of 0 uses system default (potentially blocking).
+    /// \warning Will return nullopt if unable to resolve the domain or if timeout is exceeded
+    nonstd::optional<IO::Networking::IpAddress> ResolveDomainSingle(std::string const& domainName, IO::Networking::IpAddress::Type type, std::chrono::seconds timeout = std::chrono::seconds{0}, SelectionStrategy strategy = SelectionStrategy::First);
 }}} // namespace IO::Networking
 
 #endif // MANGOS_IO_NETWORKING_DNS_H


### PR DESCRIPTION
## 🍰 Pullrequest
Adds configurable DNS resolution timeout to prevent the realm server from hanging when DNS servers are unreachable or slow to respond.

| Scenario | Before | After |
|----------|--------|-------|
| DNS server unreachable | Server hangs indefinitely | Returns after timeout, realm temporarily skipped |
| DNS server slow (>5s) | Waits for OS timeout (30-120s) | Returns after configured timeout |
| Repeated DNS failures | Unlimited blocking threads | Limited to 10 concurrent threads |
| DNS recovers | N/A | Realm automatically returns on next update cycle |

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
