### PR TITLE
Exclude cpptrace and its deps from install to avoid copying lib/include

### DIFF
--- a/dep/cpptrace/CMakeLists.txt
+++ b/dep/cpptrace/CMakeLists.txt
@@ -426,7 +426,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
           DOWNLOAD_EXTRACT_TIMESTAMP TRUE
           URL "${CPPTRACE_ZSTD_URL}"
       )
-      FetchContent_MakeAvailable(zstd)
+      FetchContent_GetProperties(zstd)
+      if(NOT zstd_POPULATED)
+        FetchContent_Populate(zstd)
+        add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR} EXCLUDE_FROM_ALL)
+      endif()
     endif()
     # Libdwarf itself
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
@@ -438,7 +442,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
       GIT_TAG ${CPPTRACE_LIBDWARF_TAG}
       GIT_SHALLOW ${CPPTRACE_LIBDWARF_SHALLOW}
     )
-    FetchContent_MakeAvailable(libdwarf)
+    FetchContent_GetProperties(libdwarf)
+    if(NOT libdwarf_POPULATED)
+      FetchContent_Populate(libdwarf)
+      add_subdirectory(${libdwarf_SOURCE_DIR} ${libdwarf_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
     target_include_directories(
       dwarf
       PRIVATE
@@ -601,9 +609,10 @@ endif()
 
 # =============================================== Install ===============================================
 
-if(NOT CMAKE_SKIP_INSTALL_RULES)
-  include(cmake/InstallRules.cmake)
-endif()
+# Disabled: cpptrace is statically linked and not needed at runtime
+# if(NOT CMAKE_SKIP_INSTALL_RULES)
+#   include(cmake/InstallRules.cmake)
+# endif()
 
 # =============================================== Demo/test ===============================================
 

--- a/dep/cpptrace/README.md
+++ b/dep/cpptrace/README.md
@@ -41,3 +41,54 @@ README.md -> README_original.md
  
  # create config file that points to targets file
 ```
+
+### Disabled install rules to prevent cmake_install.cmake generation
+```diff
+--- a/dep/cpptrace/CMakeLists.txt
++++ b/dep/cpptrace/CMakeLists.txt
+@@ -598,6 +598,9 @@ endif()
+
+ # =============================================== Install ===============================================
+
+-if(NOT CMAKE_SKIP_INSTALL_RULES)
+-  include(cmake/InstallRules.cmake)
+-endif()
++# if(NOT CMAKE_SKIP_INSTALL_RULES)
++#   include(cmake/InstallRules.cmake)
++# endif()
+
+ # =============================================== Demo/test ===============================================
+```
+
+### Prevent zstd, libdwarf from installing files (EXCLUDE_FROM_ALL)
+Use `FetchContent_Populate` + `add_subdirectory(EXCLUDE_FROM_ALL)` instead of
+`FetchContent_MakeAvailable` so the subprojects are excluded from the install step.
+```diff
+--- a/dep/cpptrace/CMakeLists.txt
++++ b/dep/cpptrace/CMakeLists.txt
+@@ -424,7 +424,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
+           URL "${CPPTRACE_ZSTD_URL}"
+       )
+-      FetchContent_MakeAvailable(zstd)
++      FetchContent_GetProperties(zstd)
++      if(NOT zstd_POPULATED)
++        FetchContent_Populate(zstd)
++        add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR} EXCLUDE_FROM_ALL)
++      endif()
+     endif()
+     # Libdwarf itself
+     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+@@ -435,7 +439,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
+       GIT_TAG ${CPPTRACE_LIBDWARF_TAG}
+       GIT_SHALLOW ${CPPTRACE_LIBDWARF_SHALLOW}
+     )
+-    FetchContent_MakeAvailable(libdwarf)
++    FetchContent_GetProperties(libdwarf)
++    if(NOT libdwarf_POPULATED)
++      FetchContent_Populate(libdwarf)
++      add_subdirectory(${libdwarf_SOURCE_DIR} ${libdwarf_BINARY_DIR} EXCLUDE_FROM_ALL)
++    endif()
+     target_include_directories(
+       dwarf
+       PRIVATE
+```


### PR DESCRIPTION
## 🍰 Pullrequest
Skip install rules for cpptrace and its dependencies to avoid copying unnecessary `lib` and `include` folders.

- cpptrace: Disable install rules (statically linked, not needed at runtime)
- zstd: Use add_subdirectory(..., EXCLUDE_FROM_ALL) instead of
  FetchContent_MakeAvailable so its install rules are not executed
- libdwarf: Same change as zstd

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
