### PR TITLE
Warden: Detect OpenGL renderer in .pinfo

### DIFF
--- a/src/game/Anticheat/WardenAnticheat/Warden.hpp
+++ b/src/game/Anticheat/WardenAnticheat/Warden.hpp
@@ -181,7 +181,7 @@ class Warden
         virtual void SetCharEnumPacket(WorldPacket&& packet) = 0;
 
         virtual void GetPlayerInfo(std::string& clock, std::string& fingerprint, std::string& hypervisors,
-            std::string& endscene, std::string& proxifier) const = 0;
+            std::string& renderer, std::string& proxifier) const = 0;
 
         std::vector<WorldPacket> m_packetQueue;
         std::mutex m_packetQueueMutex;

--- a/src/game/Anticheat/WardenAnticheat/WardenMac.hpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenMac.hpp
@@ -55,7 +55,7 @@ class WardenMac final : public Warden
         virtual void SetCharEnumPacket(WorldPacket&& packet);
 
         virtual void GetPlayerInfo(std::string& clock, std::string& fingerprint, std::string& hypervisors,
-            std::string& endscene, std::string& proxifier) const {}
+            std::string& renderer, std::string& proxifier) const {}
 };
 
 #endif /*!__WARDENMAC_HPP_*/

--- a/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
@@ -48,6 +48,9 @@
 
 namespace
 {
+// An offset not yet reverse-engineered. To be determined.
+uint32 constexpr tbd = static_cast<uint32>(-1);
+
 // fixed offsets for classic client(s):
 static constexpr struct ClientOffsets
 {
@@ -73,6 +76,7 @@ static constexpr struct ClientOffsets
 
     // EndScene memory scan
     uint32 g_theGxDevicePtr;
+    uint32 g_gxDevicePtr_OfsApiKind;
     uint32 OfsDevice2;
     uint32 OfsDevice3;
     uint32 OfsDevice4;
@@ -93,7 +97,7 @@ static constexpr struct ClientOffsets
         0x226E0,
         0xBEC94C,
         0xC60AD0,
-        0xB804E0, 0x3890, 0x0, 0xA8,
+        0xB804E0, tbd, 0x3890, 0x0, 0xA8,
         0xC598DC, 0x228, 0x08,
         0xBBEFC8
     },
@@ -104,7 +108,7 @@ static constexpr struct ClientOffsets
         0x22580,
         0xC01BBC,
         0xC74844,
-        0xB95818, 0x38A0, 0x0, 0xA8,
+        0xB95818, tbd, 0x38A0, 0x0, 0xA8,
         0xC6EBF4, 0x228, 0x08,
         0xBD4260
     },
@@ -115,7 +119,7 @@ static constexpr struct ClientOffsets
         0x226A0,
         0xC213E4,
         0xC9470C,
-        0xBB4E98, 0x38A0, 0x0, 0xA8,
+        0xBB4E98, tbd, 0x38A0, 0x0, 0xA8,
         0xC8E64C, 0x228, 0x08,
         0xBF3A94
     },
@@ -126,7 +130,7 @@ static constexpr struct ClientOffsets
         0x2BDF0,
         0xC6F4CC,
         0xCE4BD0,
-        0xC02F48, 0x38A8, 0x0, 0xA8,
+        0xC02F48, tbd, 0x38A8, 0x0, 0xA8,
         0xCDCB8C, 0x228, 0x08,
         0xC41B44
     },
@@ -137,7 +141,7 @@ static constexpr struct ClientOffsets
         0x2C010,
         0xC7B2A4,
         0xCF0BC8,
-        0xC0ED38, 0x38A8, 0x0, 0xA8,
+        0xC0ED38, 0x1FC, 0x38A8, 0x0, 0xA8,
         0xCE897C, 0x228, 0x08,
         0xC4D890
     },
@@ -148,7 +152,7 @@ static constexpr struct ClientOffsets
         0x2C010,
         0xC7B2A4,
         0xCF0BC8,
-        0xC0ED38, 0x38A8, 0x0, 0xA8,
+        0xC0ED38, tbd, 0x38A8, 0x0, 0xA8,
         0xCE897C, 0x228, 0x08,
         0xC4D890
     },
@@ -159,7 +163,7 @@ static constexpr struct ClientOffsets
         0x2C010,
         0xC7F9C4,
         0xCF52E8,
-        0xC133E0, 0x38A8, 0x0, 0xA8,
+        0xC133E0, tbd, 0x38A8, 0x0, 0xA8,
         0xCED09C, 0x228, 0x08,
         0xC51FB0
     }
@@ -1001,7 +1005,8 @@ void WardenWin::LoadScriptedScans()
     }, sizeof(uint8) + sizeof(uint8) + sizeof(uint32) + sizeof(uint8), sizeof(uint8) + sizeof(uint32),
     "EndScene locate stage 2", ScanFlags::OffsetsInitialized, 0, UINT16_MAX);
 
-    sWardenScanMgr.AddWindowsScan(std::make_shared<WindowsScan>(
+    // Check whenever the user is using OpenGL or Direct3D
+    auto const endSceneLocate15 = std::make_shared<WindowsScan>(
     // builder
     [](Warden const* warden, std::vector<std::string>&, ByteBuffer& scan)
     {
@@ -1013,11 +1018,65 @@ void WardenWin::LoadScriptedScans()
 
         scan << static_cast<uint8>(wardenWin->GetModule()->opcodes[READ_MEMORY] ^ wardenWin->GetXor())
              << static_cast<uint8>(0)
-             << offsets->g_theGxDevicePtr
+             << wardenWin->m_endSceneAddress + offsets->g_gxDevicePtr_OfsApiKind
              << static_cast<uint8>(sizeof(uint32));
     },
     // checker
     [endSceneLocate2](Warden const* warden, ByteBuffer& buff)
+    {
+        auto const wardenWin = const_cast<WardenWin*>(reinterpret_cast<WardenWin const*>(warden));
+
+        auto const result = buff.read<uint8>();
+
+        if (!!result)
+        {
+            sLog.OutWarden(wardenWin, LOG_LVL_BASIC, "Failed to read g_theGxDevicePtr->renderingApiKind");
+            return true;
+        }
+
+        uint32 rendering_api_int = buff.read<uint32>();
+        nonstd::optional<ClientRenderingApi> rendering_api {};
+        switch (rendering_api_int) // sanity check user provided value (might be invalid)
+        {
+            case 0:
+                rendering_api = ClientRenderingApi::OpenGL;
+                break;
+            case 1:
+                rendering_api = ClientRenderingApi::Direct3D;
+                break;
+        }
+        if (!rendering_api.has_value())
+        {
+            sLog.OutWarden(wardenWin, LOG_LVL_BASIC, "Failed to determine API rendering type");
+            return true;
+        }
+        wardenWin->m_renderingApi = rendering_api;
+
+        // immediately request second stage
+        wardenWin->EnqueueScans({ endSceneLocate2 });
+
+        return false;
+    }, sizeof(uint8) + sizeof(uint8) + sizeof(uint32) + sizeof(uint8), sizeof(uint8) + sizeof(uint32),
+    "EndScene locate stage 1.5", ScanFlags::OffsetsInitialized | ScanFlags::InitialLogin, 0, UINT16_MAX);
+
+    // stage 1: Resolve g_theGxDevicePtr next stages will dereference a pointer chain to find the endSceneAddress (a common hooking pointer for bots)
+    auto const endSceneLocate1 = std::make_shared<WindowsScan>(
+    // builder
+    [](Warden const* warden, std::vector<std::string>&, ByteBuffer& scan)
+    {
+        auto const wardenWin = reinterpret_cast<WardenWin const*>(warden);
+        auto const offsets = GetClientOffets(wardenWin->m_clientBuild);
+
+        if (!offsets)
+            return;
+
+        scan << static_cast<uint8>(wardenWin->GetModule()->opcodes[READ_MEMORY] ^ wardenWin->GetXor())
+            << static_cast<uint8>(0)
+            << offsets->g_theGxDevicePtr
+            << static_cast<uint8>(sizeof(uint32));
+    },
+    // checker
+    [endSceneLocate15, endSceneLocate2](Warden const* warden, ByteBuffer& buff)
     {
         auto const wardenWin = const_cast<WardenWin*>(reinterpret_cast<WardenWin const*>(warden));
 
@@ -1030,6 +1089,9 @@ void WardenWin::LoadScriptedScans()
             return true;
         }
 
+        // We are executing the chain again. endSceneAddress is not fully resolved at this point.
+        wardenWin->m_endSceneFound = false;
+        wardenWin->m_renderingApi.reset();
         buff.read(reinterpret_cast<uint8*>(&wardenWin->m_endSceneAddress), sizeof(wardenWin->m_endSceneAddress));
 
         // if for some reason we get nullptr, abort
@@ -1039,14 +1101,24 @@ void WardenWin::LoadScriptedScans()
             return true;
         }
 
-        // immediately request second stage
-        wardenWin->EnqueueScans({ endSceneLocate2 });
+        auto const offsets = GetClientOffets(wardenWin->m_clientBuild);
+
+        // immediately request next scan in this chain. Either 1.5 (which checks OpenGL/DirectX) or step 2
+        if (offsets->g_gxDevicePtr_OfsApiKind == tbd) // tbd = to be determined
+        {
+            wardenWin->EnqueueScans({ endSceneLocate2 });
+        }
+        else
+        {
+            wardenWin->EnqueueScans({ endSceneLocate15 });
+        }
 
         return false;
-    },
-    sizeof(uint8) + sizeof(uint8) + sizeof(uint32) + sizeof(uint8),
-    sizeof(uint8) + sizeof(uint32),
-    "EndScene locate stage 1", ScanFlags::OffsetsInitialized | ScanFlags::InitialLogin, 0, UINT16_MAX));
+    }, sizeof(uint8) + sizeof(uint8) + sizeof(uint32) + sizeof(uint8), sizeof(uint8) + sizeof(uint32),
+    "EndScene locate stage 1", ScanFlags::OffsetsInitialized | ScanFlags::InitialLogin, 0, UINT16_MAX);
+
+    // Add the first scan of the GX checking-chain
+    sWardenScanMgr.AddWindowsScan(endSceneLocate1);
 
     sWardenScanMgr.AddWindowsScan(std::make_shared<WindowsModuleScan>("prxdrvpe.dll",
     // checker
@@ -1198,6 +1270,25 @@ WardenWin::WardenWin(WorldSession* session, BigNumber const& K) :
     m_proxifierFound(false), m_hypervisors(""), m_endSceneFound(false), m_endSceneAddress(0), m_offsetsInitialized(false)
 {
     memset(&m_sysInfo, 0, sizeof(m_sysInfo));
+}
+
+std::string const& ClientRenderingApiToString(ClientRenderingApi client_rendering_api)
+{
+    switch (client_rendering_api)
+    {
+    case ClientRenderingApi::Direct3D:
+    {
+        static std::string txt = "Direct3D";
+        return txt;
+    }
+    case ClientRenderingApi::OpenGL:
+    {
+        static std::string txt = "OpenGL";
+        return txt;
+    }
+    default:
+        MANGOS_ASSERT(false);
+    }
 }
 
 // read the dx9 EndScene binary code to look for bad stuff
@@ -1388,7 +1479,7 @@ void WardenWin::SetCharEnumPacket(WorldPacket&& packet)
 }
 
 void WardenWin::GetPlayerInfo(std::string& clock, std::string& fingerprint, std::string& hypervisors,
-    std::string& endscene, std::string& proxifier) const
+    std::string& renderer, std::string& proxifier) const
 {
     if (!!m_lastTimeCheckServer)
     {
@@ -1424,11 +1515,24 @@ void WardenWin::GetPlayerInfo(std::string& clock, std::string& fingerprint, std:
     if (m_hypervisors.length() > 0)
         hypervisors = "Hypervisor(s) found: " + m_hypervisors;
 
+    if (m_renderingApi.has_value())
+    {
+        std::stringstream s;
+        s << "Renderer: " << ClientRenderingApiToString(m_renderingApi.value());
+        renderer = s.str();
+    }
+    else
+    {
+        std::stringstream s;
+        s << "Renderer: Unknown";
+        renderer = s.str();
+    }
+
     if (m_endSceneFound)
     {
         std::stringstream s;
-        s << "EndScene: 0x" << std::hex << m_endSceneAddress;
-        endscene = s.str();
+        s << " (EndScene: 0x" << std::hex << m_endSceneAddress << ")";
+        renderer += s.str();
     }
 
     if (m_proxifierFound)

--- a/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
@@ -48,9 +48,6 @@
 
 namespace
 {
-// An offset not yet reverse-engineered. To be determined.
-uint32 constexpr tbd = static_cast<uint32>(-1);
-
 // fixed offsets for classic client(s):
 static constexpr struct ClientOffsets
 {
@@ -97,7 +94,7 @@ static constexpr struct ClientOffsets
         0x226E0,
         0xBEC94C,
         0xC60AD0,
-        0xB804E0, tbd, 0x3890, 0x0, 0xA8,
+        0xB804E0, 0x1FC, 0x3890, 0x0, 0xA8,
         0xC598DC, 0x228, 0x08,
         0xBBEFC8
     },
@@ -108,7 +105,7 @@ static constexpr struct ClientOffsets
         0x22580,
         0xC01BBC,
         0xC74844,
-        0xB95818, tbd, 0x38A0, 0x0, 0xA8,
+        0xB95818, 0x1FC, 0x38A0, 0x0, 0xA8,
         0xC6EBF4, 0x228, 0x08,
         0xBD4260
     },
@@ -119,7 +116,7 @@ static constexpr struct ClientOffsets
         0x226A0,
         0xC213E4,
         0xC9470C,
-        0xBB4E98, tbd, 0x38A0, 0x0, 0xA8,
+        0xBB4E98, 0x1FC, 0x38A0, 0x0, 0xA8,
         0xC8E64C, 0x228, 0x08,
         0xBF3A94
     },
@@ -130,7 +127,7 @@ static constexpr struct ClientOffsets
         0x2BDF0,
         0xC6F4CC,
         0xCE4BD0,
-        0xC02F48, tbd, 0x38A8, 0x0, 0xA8,
+        0xC02F48, 0x1FC, 0x38A8, 0x0, 0xA8,
         0xCDCB8C, 0x228, 0x08,
         0xC41B44
     },
@@ -152,7 +149,7 @@ static constexpr struct ClientOffsets
         0x2C010,
         0xC7B2A4,
         0xCF0BC8,
-        0xC0ED38, tbd, 0x38A8, 0x0, 0xA8,
+        0xC0ED38, 0x1FC, 0x38A8, 0x0, 0xA8,
         0xCE897C, 0x228, 0x08,
         0xC4D890
     },
@@ -163,7 +160,7 @@ static constexpr struct ClientOffsets
         0x2C010,
         0xC7F9C4,
         0xCF52E8,
-        0xC133E0, tbd, 0x38A8, 0x0, 0xA8,
+        0xC133E0, 0x1FC, 0x38A8, 0x0, 0xA8,
         0xCED09C, 0x228, 0x08,
         0xC51FB0
     }
@@ -1111,15 +1108,8 @@ void WardenWin::LoadScriptedScans()
 
         auto const offsets = GetClientOffets(wardenWin->m_clientBuild);
 
-        // immediately request next scan in this chain. Either 1.5 (which checks OpenGL/DirectX) or step 2
-        if (offsets->g_gxDevicePtr_OfsApiKind == tbd) // tbd = to be determined
-        {
-            wardenWin->EnqueueScans({ endSceneLocate2 });
-        }
-        else
-        {
-            wardenWin->EnqueueScans({ endSceneLocate15 });
-        }
+        // immediately request next scan in this chain.
+        wardenWin->EnqueueScans({ endSceneLocate15 });
 
         return false;
     }, sizeof(uint8) + sizeof(uint8) + sizeof(uint32) + sizeof(uint8), sizeof(uint8) + sizeof(uint32),

--- a/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenWin.cpp
@@ -1052,8 +1052,16 @@ void WardenWin::LoadScriptedScans()
         }
         wardenWin->m_renderingApi = rendering_api;
 
-        // immediately request second stage
-        wardenWin->EnqueueScans({ endSceneLocate2 });
+        if (wardenWin->m_renderingApi == ClientRenderingApi::Direct3D)
+        {
+            // immediately request second stage
+            wardenWin->EnqueueScans({ endSceneLocate2 });
+        }
+        else
+        {
+            // We are not able to determine the endSceneAddress for OpenGL (because nobody reverse engineered it yet)
+            wardenWin->m_endSceneAddress = 0;
+        }
 
         return false;
     }, sizeof(uint8) + sizeof(uint8) + sizeof(uint32) + sizeof(uint8), sizeof(uint8) + sizeof(uint32),

--- a/src/game/Anticheat/WardenAnticheat/WardenWin.hpp
+++ b/src/game/Anticheat/WardenAnticheat/WardenWin.hpp
@@ -57,6 +57,14 @@ struct WIN_SYSTEM_INFO {
 
 static_assert(sizeof(WIN_SYSTEM_INFO) == 0x24, "WIN_SYSTEM_INFO wrong size");
 
+enum class ClientRenderingApi
+{
+    OpenGL,
+    Direct3D, // DirectX 9.0c in vanilla wow
+};
+
+std::string const& ClientRenderingApiToString(ClientRenderingApi client_rendering_api);
+
 class WardenWin final : public Warden
 {
     private:
@@ -78,7 +86,9 @@ class WardenWin final : public Warden
         uint32 m_lastTimeCheckServer;
 
         bool m_endSceneFound;
-        uint32 m_endSceneAddress;
+        uint32 m_endSceneAddress; // will change with each EndScene stage (pointer dereference chain). Only valid when m_endSceneFound is true.
+        nonstd::optional<ClientRenderingApi> m_renderingApi;
+
 
         bool m_offsetsInitialized;
 
@@ -89,7 +99,7 @@ class WardenWin final : public Warden
         // send module initialization information (function offsets, etc.)
         virtual void InitializeClient();
 
-        /* 
+        /*
             (a, b) initialization packet options:
 
             (4, 0) -> "lua string check" initialization
@@ -150,7 +160,7 @@ class WardenWin final : public Warden
         virtual void SetCharEnumPacket(WorldPacket&& packet);
 
         virtual void GetPlayerInfo(std::string& clock, std::string& fingerprint, std::string& hypervisors,
-            std::string& endscene, std::string& proxifier) const;
+            std::string& renderer, std::string& proxifier) const;
 };
 
 #endif /*!__WARDENWIN_HPP_*/

--- a/src/game/Chat/AsyncCommandHandlers.cpp
+++ b/src/game/Chat/AsyncCommandHandlers.cpp
@@ -57,7 +57,7 @@ void PInfoHandler::HandlePInfoCommand(WorldSession* session, Player* target, Obj
         if (auto const warden = target->GetSession()->GetWarden())
         {
             warden->GetPlayerInfo(data->m_wardenClock, data->m_wardenFingerprint, data->m_wardenHypervisors,
-                data->m_wardenEndscene, data->m_wardenProxifier);
+                data->m_wardenRenderer, data->m_wardenProxifier);
             data->m_hasUsedClickToMove = warden->HasUsedClickToMove();
         }
 
@@ -225,8 +225,8 @@ void PInfoHandler::HandleResponse(WorldSession* session, PInfoData* data)
         cHandler.SendSysMessage(data->m_wardenFingerprint.c_str());
     if (!data->m_wardenHypervisors.empty())
         cHandler.SendSysMessage(data->m_wardenHypervisors.c_str());
-    if (!data->m_wardenEndscene.empty())
-        cHandler.SendSysMessage(data->m_wardenEndscene.c_str());
+    if (!data->m_wardenRenderer.empty())
+        cHandler.SendSysMessage(data->m_wardenRenderer.c_str());
     if (!data->m_wardenProxifier.empty())
         cHandler.SendSysMessage(data->m_wardenProxifier.c_str());
     if (data->m_hasUsedClickToMove)
@@ -397,7 +397,7 @@ bool PlayerSearchQueryHolder::GetAccountInfo(uint32 queryIndex, std::pair<uint32
     PlayerSearchAccountMap::const_iterator iter = m_accounts.find(queryIndex);
     if (iter == m_accounts.cend())
         return false;
-    
+
     pair.first = (*iter).second.first;
     pair.second = (*iter).second.second;
 

--- a/src/game/Chat/AsyncCommandHandlers.h
+++ b/src/game/Chat/AsyncCommandHandlers.h
@@ -70,7 +70,7 @@ struct PInfoData
     std::string m_wardenClock;
     std::string m_wardenFingerprint;
     std::string m_wardenHypervisors;
-    std::string m_wardenEndscene;
+    std::string m_wardenRenderer;
     std::string m_wardenProxifier;
     bool m_hasUsedClickToMove = false;
 };


### PR DESCRIPTION
## 🍰 Pullrequest
`OpenGL` users are flagged as cheaters since the `endSceneAddress` checks were only developed with `DirectX` in mind.  
We skip those checks for now if `OpenGL` is used.

In addition `.pinfo` will now show whenever the client is using `DirectX` or `OpenGL` .

_Sideinfo_: Users can enable `OpenGL` in their `Config.wtf`
```
SET gxApi "OpenGL"
```
