### PR TITLE
Improve accuracy of packed XYZ

### DIFF
--- a/src/shared/ByteBuffer.h
+++ b/src/shared/ByteBuffer.h
@@ -477,9 +477,9 @@ class ByteBuffer
         void appendPackXYZ(float x, float y, float z)
         {
             uint32 packed = 0;
-            packed |= ((int)(x / 0.25f) & 0x7FF);
-            packed |= ((int)(y / 0.25f) & 0x7FF) << 11;
-            packed |= ((int)(z / 0.25f) & 0x3FF) << 22;
+            packed |= ((int)lroundf(x * 4.0f) & 0x7FF);
+            packed |= ((int)lroundf(y * 4.0f) & 0x7FF) << 11;
+            packed |= ((int)lroundf(z * 4.0f) & 0x3FF) << 22;
             *this << packed;
         }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This change improves accuracy of packed XYZ by using rounding instead of truncation.

This reduces max "error" from +-0.25 to +-0.125

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Watch NPCs walk around. idk

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
