### PR TITLE
Fix unit underwater pathing

### DIFF
--- a/src/game/Maps/PathFinder.cpp
+++ b/src/game/Maps/PathFinder.cpp
@@ -164,7 +164,7 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
     float startPoint[VERTEX_SIZE] = {startPos.y, startPos.z, startPos.x};
     float endPoint[VERTEX_SIZE] = {endPos.y, endPos.z, endPos.x};
 
-    bool const canSwimToDestination = m_sourceUnit->CanSwim() &&
+    bool const canSwimToDestination = m_sourceUnit->CanSwim() && (!m_sourceUnit->IsCreature() || m_sourceUnit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_USE_SWIM_ANIMATION)) &&
                                       m_sourceUnit->CanSwimAtPosition(startPos) &&
                                       m_sourceUnit->CanSwimAtPosition(endPos);
 


### PR DESCRIPTION
## 🍰 Pullrequest
Fix a small issue concerning creatures which walk on the ground under water, e.g. the Enraged Reef Crawler (creature ID 12347). Path generation used shortcut paths which led to "bunny-hopping" or falling through the ground if there were valleys or obstacles. I added a check for flag UNIT_FLAG_USE_SWIM_ANIMATION to determine which paths to generate. If the flag is missing the creature is meant to walk on the ground and use normal path finding there.

Also related to this flag:
https://github.com/vmangos/core/blob/82edaee41485778920586fcb97e3e80e2ad493f0/src/game/Objects/Object.cpp#L1954-L1957

### Proof
none

### Issues
none

### How2Test
Watch Enraged Reef Crawlers, e.g. GUID 27740

### Todo / Checklist
none
