### PR TITLE
Fix Spectral Essence spell_area to include Scholo

### DIFF
--- a/sql/migrations/20260203223545_world.sql
+++ b/sql/migrations/20260203223545_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260203223545');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260203223545');
+-- Add your query below.
+
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_start_active`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`) VALUES (17623, 2057, 0, 0, 0, 0, 0, 2, 0); -- Spectral Essence is usable in Scholo WMO
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
Currently it removes upon entering Scholomance, preventing you from finishing Ras Frostwhisper questline.