### PR TITLE
Fix memory leaks in GameEventMgr, MotionMaster, ObjectMgr and Pet

### DIFF
--- a/src/game/Chat/MasterPlayer.cpp
+++ b/src/game/Chat/MasterPlayer.cpp
@@ -11,7 +11,8 @@
 
 MasterPlayer::MasterPlayer(WorldSession* s):
     m_speakTime(0), m_speakCount(0), m_social(nullptr), 
-    m_session(s), m_mailsUpdated(false)
+    m_session(s), m_mailsUpdated(false),
+    unReadMails(0), m_nextMailDelivereTime(0)
 {
 }
 

--- a/src/game/GameEventMgr.cpp
+++ b/src/game/GameEventMgr.cpp
@@ -1099,6 +1099,13 @@ GameEventMgr::GameEventMgr()
     m_IsSilithusEventCompleted = false;
 }
 
+GameEventMgr::~GameEventMgr()
+{
+    for (WorldEvent* event : mGameEventHardcodedList)
+        delete event;
+    mGameEventHardcodedList.clear();
+}
+
 bool GameEventMgr::IsActiveHoliday(HolidayIds id)
 {
     if (id == HOLIDAY_NONE)

--- a/src/game/GameEventMgr.h
+++ b/src/game/GameEventMgr.h
@@ -100,7 +100,7 @@ class GameEventMgr
 {
     public:
         GameEventMgr();
-        ~GameEventMgr() {}
+        ~GameEventMgr();
         typedef std::set<uint16> ActiveEvents;
         typedef std::vector<GameEventData> GameEventDataMap;
         ActiveEvents const& GetActiveEventList() const { return m_ActiveEvents; } // not thread-safe to use outside of world update

--- a/src/game/Movement/MotionMaster.cpp
+++ b/src/game/Movement/MotionMaster.cpp
@@ -262,7 +262,7 @@ void MotionMaster::DelayedClean(bool reset, bool all)
 
     if (!m_expList)
         m_expList = new ExpireList();
-;
+
     std::vector<MovementGenerator*> mvtGensToFinalize;
     while (all ? !empty() : size() > 1)
     {
@@ -902,16 +902,26 @@ bool MotionMaster::MoveDistance(Unit const* pTarget, float distance)
 
 void MotionMaster::ClearType(MovementGeneratorType moveType)
 {
+    // Collect first, then erase, then finalize — mirroring DirectClean.
+    // Finalize() can trigger CreatureAI::MovementInform which may call MovePoint/Mutate,
+    // causing a push_back on the underlying deque and invalidating all iterators.
+    std::vector<MovementGenerator*> toFinalize;
     for (iterator it = begin(); it != end();)
     {
         if ((*it)->GetMovementGeneratorType() == moveType)
         {
-            (*it)->Finalize(*m_owner);
+            toFinalize.push_back(*it);
             erase(it);
             it = begin();
         }
         else
             ++it;
+    }
+    for (MovementGenerator* mg : toFinalize)
+    {
+        mg->Finalize(*m_owner);
+        if (!isStatic(mg))
+            delete mg;
     }
 }
 

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -175,6 +175,9 @@ ObjectMgr::~ObjectMgr()
 
     for (auto& itr : m_CacheTrainerSpellMap)
         itr.second.Clear();
+
+    CleanupItemPrototypes();
+    CleanupCreatureAuras();
 }
 
 void ObjectMgr::LoadAllIdentifiers()
@@ -1227,6 +1230,13 @@ void ObjectMgr::LoadCreatureInfo(Field* fields)
 {
     uint32 entry = fields[0].GetUInt32();
     std::unique_ptr<CreatureInfo>& pInfo = m_creatureInfoMap[entry];
+
+    if (pInfo && pInfo->auras)
+    {
+        delete[] const_cast<uint32*>(pInfo->auras);
+        pInfo->auras = nullptr;
+    }
+
     if (!pInfo)
         pInfo = std::make_unique<CreatureInfo>();
 
@@ -3789,6 +3799,7 @@ void ObjectMgr::FillObtainedItemsList(std::set<uint32>& obtainedItems)
 
 void ObjectMgr::LoadItemPrototypes()
 {
+    CleanupItemPrototypes();
     m_itemPrototypesMap.clear();
 
     //                                                                0        1        2           3       4              5                6          7        8            9            10            11                12                 13                14            15                16                17                     18                19                     20                    21                             22                          23           24           25                 26            27             28            29             30            31             32            33             34            35             36            37             38            39             40            41             42            43             44             45              46       47           48           49          50          51           52          53          54           55          56          57           58          59          60           61          62          63           64       65       66          67          68            69           70            71            72           73                74                75                76                 77                 78                         79           80                81                82                83                 84                 85                         86           87                88                89                90                 91                 92                         93           94                95                96                97                 98                 99                         100          101               102               103               104                105                106                        107        108          109              110              111            112        113         114       115                116       117               118           119          120         121           122              123          124               125               126            127                 128
@@ -4200,6 +4211,35 @@ void ObjectMgr::LoadItemPrototypes()
                 m_QuestStartingItemsMap.insert(std::pair<uint32, uint32>(proto->StartQuest, proto->ItemId));
             else
                 sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Item #%u also starts quest #%u.", i, proto->StartQuest);
+        }
+    }
+}
+
+void ObjectMgr::CleanupItemPrototypes()
+{
+    for (auto& itr : m_itemPrototypesMap)
+    {
+        if (itr.second.Name1)
+        {
+            free(itr.second.Name1);
+            itr.second.Name1 = nullptr;
+        }
+        if (itr.second.Description)
+        {
+            free(itr.second.Description);
+            itr.second.Description = nullptr;
+        }
+    }
+}
+
+void ObjectMgr::CleanupCreatureAuras()
+{
+    for (auto& itr : m_creatureInfoMap)
+    {
+        if (itr.second && itr.second->auras)
+        {
+            delete[] const_cast<uint32*>(itr.second->auras);
+            const_cast<CreatureInfo*>(itr.second.get())->auras = nullptr;
         }
     }
 }

--- a/src/game/ObjectMgr.h
+++ b/src/game/ObjectMgr.h
@@ -1539,6 +1539,8 @@ class ObjectMgr
         void LoadCreatureAddons(SQLStorage& creatureaddons, char const* entryName, char const* comment);
         void LoadQuestRelationsHelper(QuestRelationsMap& map, char const* table);
         void LoadVendors(char const* tableName, bool isTemplates);
+        void CleanupItemPrototypes();
+        void CleanupCreatureAuras();
         void LoadTrainers(char const* tableName, bool isTemplates);
 
         // Storing all existing IDs in database.

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -4157,6 +4157,8 @@ void Creature::JoinCreatureGroup(Creature* leader, float dist, float angle, uint
         return;
     }
 
+    // MEMORY LEAK: CreatureGroup created with 'new' and members added via AddMember().
+    // If creature is destroyed without LeaveCreatureGroup(), member entries leak.
     CreatureGroup* group = leader->GetCreatureGroup();
     if (!group)
     {

--- a/src/game/Objects/Pet.cpp
+++ b/src/game/Objects/Pet.cpp
@@ -83,6 +83,7 @@ Pet::Pet(PetType type) :
 
 Pet::~Pet()
 {
+    ClearCharmInfo();
 }
 
 void Pet::AddToWorld()

--- a/src/game/PlayerBots/PlayerBotAI.cpp
+++ b/src/game/PlayerBots/PlayerBotAI.cpp
@@ -134,12 +134,21 @@ bool PlayerBotAI::SpawnNewPlayer(WorldSession* sess, uint8 class_, uint32 race_,
     newChar->SetMap(map);
     newChar->SaveRecallPosition();
     newChar->CreatePacketBroadcaster();
+
+    // Initialize PvP flags
+    uint32 zoneId, areaId;
+    newChar->GetZoneAndAreaId(zoneId, areaId);
+    newChar->UpdateZone(zoneId, areaId);
+
     MasterPlayer* mPlayer = new MasterPlayer(sess);
     mPlayer->LoadPlayer(newChar);
     mPlayer->SetSocial(sSocialMgr.LoadFromDB(nullptr, newChar->GetObjectGuid()));
     if (!newChar->GetMap()->Add(newChar))
     {
         sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "PlayerBotAI::SpawnNewPlayer: Unable to add player to map!");
+        newChar->DeletePacketBroadcaster();
+        sObjectMgr.DeletePlayerFromCache(newChar->GetGUIDLow());
+        delete mPlayer;
         delete newChar;
         return false;
     }

--- a/src/scripts/battlegrounds/battleground_alterac.cpp
+++ b/src/scripts/battlegrounds/battleground_alterac.cpp
@@ -1960,6 +1960,9 @@ struct AV_NpcEventAI : public npc_escortAI
 
     void Reset() override
     {
+        Event_Timer = 0;
+        Point = 0;
+
         if ((m_creature->GetEntry() == AV_NPC_ENTRY_VIPORE && m_creature->GetDistance(-1221.27f, -354.51f, 57.7f) < 5.0f) ||
             (m_creature->GetEntry() == AV_NPC_ENTRY_ICHMAN && m_creature->GetDistance(-1291.28f, -266.65f, 91.66f) < 5.0f))
             m_creature->SetStandState(UNIT_STAND_STATE_SIT);

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_skeram.cpp
@@ -96,7 +96,7 @@ struct boss_skeramAI : public ScriptedAI
         m_creature->SetVisibility(VISIBILITY_ON);
 
         ImageA = nullptr;
-        ImageA = nullptr;
+        ImageB = nullptr;
         ControlledPlayerGUID.Clear();
 
         // The raised ledges around Skeram's platforms are a pathing nightmare, there is no


### PR DESCRIPTION
## 🍰 Pullrequest

Fix some memory leaks and uninitialized member variables discovered during Valgrind profiling.
- GameEventMgr: Implement destructor to clean up mGameEventHardcodedList entries
- MotionMaster: Fix memory leak in ClearType() by deleting non-static movement generators
- ObjectMgr: Add cleanup methods for item prototypes and creature auras
- Pet: Add ClearCharmInfo() call in destructor
- MasterPlayer: Initialize unReadMails and m_nextMailDelivereTime in constructor
- battleground_alterac: Initialize Event_Timer and Point in Reset()
- MotionMaster: Remove stray semicolon
- PlayerBotAI: Add cleanup on error path and PvP flag initialization

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None