### PR TITLE
Fix wand damage incorrectly affected by Curse of Weakness

### DIFF
--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -1042,7 +1042,7 @@ float SpellCaster::MeleeDamageBonusDone(Unit const* pVictim, float pdamage, Weap
     bool isWeaponDamageBasedSpell = !(spellProto && (damagetype == DOT || spellProto->HasEffect(SPELL_EFFECT_SCHOOL_DAMAGE)));
     Item* pWeapon          = GetTypeId() == TYPEID_PLAYER ? ((Player*)this)->GetWeaponForAttack(attType, true, false) : nullptr;
     uint32 creatureTypeMask = pVictim->GetCreatureTypeMask();
-    uint32 schoolMask       = spellProto ? spellProto->GetSpellSchoolMask() : GetMeleeDamageSchoolMask();
+    uint32 schoolMask = spell ? spell->m_spellSchoolMask : (spellProto ? spellProto->GetSpellSchoolMask() : GetMeleeDamageSchoolMask());
 
     // FLAT damage bonus auras
     // =======================

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -5932,7 +5932,7 @@ float Unit::MeleeDamageBonusTaken(SpellCaster const* pCaster, float pdamage, Wea
 
     // differentiate for weapon damage based spells
     bool isWeaponDamageBasedSpell = !(spellProto && (damagetype == DOT || spellProto->HasEffect(SPELL_EFFECT_SCHOOL_DAMAGE)));
-    uint32 schoolMask       = spellProto ? spellProto->GetSpellSchoolMask() : uint32(pCaster->GetMeleeDamageSchoolMask());
+    uint32 schoolMask = spell ? spell->m_spellSchoolMask : (spellProto ? spellProto->GetSpellSchoolMask() : uint32(pCaster->GetMeleeDamageSchoolMask()));
 
     // FLAT damage bonus auras
     // =======================


### PR DESCRIPTION
## 🍰 Pullrequest
Curse of Weakness was reducing wand auto-shoot damage because the damage bonus functions were using spellProto->GetSpellSchoolMask() instead of the spell instance's m_spellSchoolMask. For wand attacks, the spell instance overrides the school mask to use the weapon's magical damage school instead of Physical.

### Proof
- None

### Issues
- fixes https://github.com/vmangos/core/issues/2852

### How2Test
- None

### Todo / Checklist
- [X] None