### PR TITLE
Drain queued context callbacks during shutdown.

### DIFF
--- a/src/shared/IO/Networking/AsyncSocket_posix.cpp
+++ b/src/shared/IO/Networking/AsyncSocket_posix.cpp
@@ -494,14 +494,14 @@ void IO::Networking::AsyncSocket::OnIoEvent(uint32_t event)
     #error "Unsupported"
 #endif
 
-    if (m_atomicState.load(std::memory_order_relaxed) & SocketStateFlags::IGNORE_TRANSFERS)
-        return; // This is just an initial check, must be atomically checked in the handlers later.
-
     if (event == CALLBACK_EVENT_FLAG)
     {
         PerformContextSwitch();
         return;
     }
+
+    if (m_atomicState.load(std::memory_order_relaxed) & SocketStateFlags::IGNORE_TRANSFERS)
+        return; // This is just an initial check, must be atomically checked in the handlers later.
 
 #if defined(__linux__)
     if (event & EPOLLERR)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

__Preface:__ I am not a networking/IO expert and this proposed fix was discovered by GitHub Copilot; I merely made sure it compiles and did some basic testing.

I originally didn't plan to open a PR for a LLM-generated edit (and only wanted to see if the cause of the issue could be figured out by a LLM), but considering it's only moving three lines of code, it seems like this might be an acceptable solution. If nothing else, it can perhaps act as inspiration for a better/proper fix.

I can confirm the [linked issue](https://github.com/vmangos/core/issues/3223) should be fixed with it, but this likely needs further testing and validation before merging it.

---

Currently, abrupt client disconnect patterns (e.g., when using `nc -z` for Docker container healthchecks) can leave socket descriptors on Linux unreleased over time. The leak comes from shutdown ordering in the Linux async socket event path, where queued context callbacks could be skipped and keep connection objects alive.

This change ensures queued context callbacks are still drained during shutdown, causing socket descriptors to actually close.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #3223

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Check how many file descriptors are currently used:
```sh
ls -al /proc/*/fd/* 2>/dev/null | wc -l
50
```

Run `nc -z` in a loop against the `mangosd` port for a while; without the change in this PR, this would leak a lot of file descriptors:
```sh
for i in {1..1000}; do
  nc -z localhost 8085
  sleep 0.1
done
```

Confirm the number of used file descriptors didn't go up (or only a little; some increase not related to the `nc -z` calls can be normal, of course, based on what else is going on on the system):
```sh
ls -al /proc/*/fd/* 2>/dev/null | wc -l
50
```

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
