### PR TITLE
Process all outstanding honor maintenance periods in a single run.

### DIFF
--- a/src/game/HonorMgr.cpp
+++ b/src/game/HonorMgr.cpp
@@ -226,8 +226,10 @@ void HonorMaintenancer::SetCityRanks()
 
 void HonorMaintenancer::FlushRankPoints()
 {
-    // Imediatly reset honor standing before flushing
-    CharacterDatabase.Execute("UPDATE `characters` SET `honor_standing` = 0 WHERE `honor_standing` > 0");
+    // Use DirectExecute/DirectPExecute so data is committed before the next
+    // maintenance period reads it back (when processing multiple outstanding
+    // periods)
+    CharacterDatabase.DirectExecute("UPDATE `characters` SET `honor_standing` = 0 WHERE `honor_standing` > 0");
 
     for (auto& pair : m_weeklyScores)
     {
@@ -242,7 +244,7 @@ void HonorMaintenancer::FlushRankPoints()
         if (currentRank.visualRank > 0 && (currentRank.visualRank > highestRank.visualRank))
             highestRank = currentRank;
 
-        CharacterDatabase.PExecute("UPDATE `characters` SET `honor_highest_rank` = %u, `honor_rank_points` = %.1f, `honor_standing` = %u, "
+        CharacterDatabase.DirectPExecute("UPDATE `characters` SET `honor_highest_rank` = %u, `honor_rank_points` = %.1f, `honor_standing` = %u, "
             "`honor_last_week_hk` = %u, `honor_stored_hk` = (`honor_stored_hk` + %u), `honor_stored_dk` = (`honor_stored_dk` + %u), `honor_last_week_cp` = %.1f WHERE `guid` = %u",
             highestRank.rank,
             finiteAlways(weeklyScore.newRp), weeklyScore.standing,
@@ -251,7 +253,7 @@ void HonorMaintenancer::FlushRankPoints()
     }
 
     // Not includes weekend day, for correct view in honor tab for group "Yesterday"
-    CharacterDatabase.PExecute("DELETE FROM `character_honor_cp` WHERE `date` < %u", GetWeekEndDay());
+    CharacterDatabase.DirectPExecute("DELETE FROM `character_honor_cp` WHERE `date` < %u", GetWeekEndDay());
 }
 
 void HonorMaintenancer::DoMaintenance()
@@ -259,34 +261,57 @@ void HonorMaintenancer::DoMaintenance()
     if (!m_markerToStart)
         return;
 
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Honor maintenance starting.");
-
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Load weekly players scores.");
-    LoadWeeklyScores();
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Load standing lists.");
-    LoadStandingLists();
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Distribute rank points for Alliance.");
-    DistributeRankPoints(ALLIANCE);
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Distribute rank points for Horde.");
-    DistributeRankPoints(HORDE);
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Decay rank points for inactive players.");
-    InactiveDecayRankPoints();
-
-    if (sWorld.getConfig(CONFIG_BOOL_ENABLE_CITY_PROTECTOR))
+    // Process all outstanding maintenance periods in a single run, so the
+    // server doesn't need multiple restarts to catch up
+    uint32 const totalPeriods = (sWorld.GetGameDay() - m_nextMaintenanceDay) / 7 + 1;
+    uint32 periodsProcessed = 0;
+    while (m_markerToStart)
     {
-        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Assign city titles.");
-        SetCityRanks();
+        periodsProcessed++;
+
+        // Clear data from any previous iteration
+        m_weeklyScores.clear();
+        m_allianceStandingList.clear();
+        m_hordeStandingList.clear();
+        m_inactiveStandingList.clear();
+
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Honor maintenance starting (period %u/%u).",
+            periodsProcessed, totalPeriods);
+
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Load weekly players scores.");
+        LoadWeeklyScores();
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Load standing lists.");
+        LoadStandingLists();
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Distribute rank points for Alliance.");
+        DistributeRankPoints(ALLIANCE);
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Distribute rank points for Horde.");
+        DistributeRankPoints(HORDE);
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Decay rank points for inactive players.");
+        InactiveDecayRankPoints();
+
+        if (sWorld.getConfig(CONFIG_BOOL_ENABLE_CITY_PROTECTOR))
+        {
+            sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Assign city titles.");
+            SetCityRanks();
+        }
+
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Flush rank points.");
+        FlushRankPoints();
+
+        CreateCalculationReport();
+
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Honor maintenance finished (period %u/%u).", periodsProcessed, totalPeriods);
+
+        ToggleMaintenanceMarker();
+        SetMaintenanceDays(GetNextMaintenanceDay());
+
+        // Check if there are more outstanding periods to process
+        if (sWorld.GetGameDay() >= m_nextMaintenanceDay)
+            ToggleMaintenanceMarker(); // Set marker back to true for next iteration
     }
 
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Flush rank points.");
-    FlushRankPoints();
-
-    CreateCalculationReport();
-
-    sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Honor maintenance finished.");
-
-    ToggleMaintenanceMarker();
-    SetMaintenanceDays(GetNextMaintenanceDay());
+    if (periodsProcessed > 1)
+        sLog.Out(LOG_HONOR, LOG_LVL_BASIC, "[MAINTENANCE] Processed %u outstanding honor maintenance periods.", periodsProcessed);
 }
 
 void HonorMaintenancer::CreateCalculationReport()
@@ -595,7 +620,7 @@ void HonorMaintenancer::CheckMaintenanceDay()
 void HonorMaintenancer::ToggleMaintenanceMarker()
 {
     m_markerToStart = !m_markerToStart;
-    CharacterDatabase.PExecute("INSERT INTO `saved_variables` (`key`, `honor_maintenance_marker`) VALUES (0, %u) "
+    CharacterDatabase.DirectPExecute("INSERT INTO `saved_variables` (`key`, `honor_maintenance_marker`) VALUES (0, %u) "
         "ON DUPLICATE KEY UPDATE `honor_maintenance_marker` = %u", m_markerToStart, m_markerToStart);
 }
 
@@ -606,7 +631,7 @@ void HonorMaintenancer::SetMaintenanceDays(uint32 last, uint32 next)
     if (!next)
         m_nextMaintenanceDay = m_lastMaintenanceDay + 7;
 
-    CharacterDatabase.PExecute("INSERT INTO `saved_variables` (`key`, `honor_last_maintenance_day`, `honor_next_maintenance_day`) VALUES (0, %u, %u) "
+    CharacterDatabase.DirectPExecute("INSERT INTO `saved_variables` (`key`, `honor_last_maintenance_day`, `honor_next_maintenance_day`) VALUES (0, %u, %u) "
         "ON DUPLICATE KEY UPDATE `honor_last_maintenance_day` = %u, `honor_next_maintenance_day` = %u",
         m_lastMaintenanceDay, m_nextMaintenanceDay, m_lastMaintenanceDay, m_nextMaintenanceDay);
 }

--- a/src/game/HonorMgr.cpp
+++ b/src/game/HonorMgr.cpp
@@ -267,7 +267,7 @@ void HonorMaintenancer::DoMaintenance()
     uint32 periodsProcessed = 0;
     while (m_markerToStart)
     {
-        periodsProcessed++;
+        ++periodsProcessed;
 
         // Clear data from any previous iteration
         m_weeklyScores.clear();

--- a/src/game/HonorMgr.cpp
+++ b/src/game/HonorMgr.cpp
@@ -183,6 +183,14 @@ void HonorMaintenancer::InactiveDecayRankPoints()
 
 void HonorMaintenancer::SetCityRanks()
 {
+    // A direct transaction is needed to keep the clear-and-reassign sequence
+    // ordered if CharacterDatabase.WorkerThreads is > 1
+    if (!CharacterDatabase.BeginTransaction())
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "HonorMaintenancer::SetCityRanks: failed to start transaction.");
+        return;
+    }
+
     CharacterDatabase.Execute("UPDATE `characters` SET `extra_flags` = `extra_flags` & ~0x0400");
 
     std::map<uint8, std::pair<uint32, uint32>> highestStandingInRace =
@@ -222,6 +230,8 @@ void HonorMaintenancer::SetCityRanks()
         if (lowGuid > 0)
             CharacterDatabase.PExecute("UPDATE `characters` SET `extra_flags` = `extra_flags` | 0x0400 WHERE `guid` = %u", standing.second.first);
     }
+
+    CharacterDatabase.CommitTransactionDirect();
 }
 
 void HonorMaintenancer::FlushRankPoints()

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1087,7 +1087,7 @@ void World::LoadConfigSettings(bool reload)
     setConfig(CONFIG_BOOL_ACCURATE_PVP_TIMELINE, "PvP.AccurateTimeline", true);
     setConfig(CONFIG_BOOL_ACCURATE_PVP_REWARDS, "PvP.AccurateRewards", true);
     setConfig(CONFIG_BOOL_ENABLE_DK, "PvP.DishonorableKills", true);
-    setConfig(CONFIG_BOOL_ENABLE_CITY_PROTECTOR, "PvP.CityProtector", true);
+    setConfig(CONFIG_BOOL_ENABLE_CITY_PROTECTOR, "PvP.CityProtector", false);
 
     // Progression settings
     setConfig(CONFIG_BOOL_ACCURATE_PETS, "Progression.AccuratePetStatistics", true);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This makes it so that all outstanding honor maintenance periods (weeks) are processed in a single run, without requiring multiple restarts. This is mainly useful for private instances where there might be long periods where VMaNGOS isn't running (e.g., because the users take a multi-month break from playing).

Several queries had to be changed to use `DirectExecute`/`DirectPExecute` to prevent async DB race conditions (ensure data is written before the next iteration).

The PR also includes a small fix: before, `HonorMaintenancer::SetCityRanks()` used separate async writes, so with `CharacterDatabase.WorkerThreads` set higher than `1` the clear and set statements could be reordered or interleaved. It now uses a direct transaction to keep the sequence ordered.

This also changes `CONFIG_BOOL_ENABLE_CITY_PROTECTOR` to `false` to match the [default in the config file](https://github.com/vmangos/core/blob/5d8386543430a63674d19106b244b35bfb84b5d6/src/mangosd/mangosd.conf.dist.in#L446); I can also change the default to `true` in the config file instead if it should be on by default (but considering it's not blizz-like I doubt it 😄).

__Example logs for processing multiple periods at once:__
```
[MAINTENANCE] Honor maintenance starting (period 1/3).
[MAINTENANCE] Load weekly players scores.
[MAINTENANCE] Load standing lists.
[MAINTENANCE] Alliance: 0, Horde: 0, Inactive: 0
[MAINTENANCE] Distribute rank points for Alliance.
[MAINTENANCE] Distribute rank points for Horde.
[MAINTENANCE] Decay rank points for inactive players.
[MAINTENANCE] Assign city titles.
[MAINTENANCE] Flush rank points.
[MAINTENANCE] Honor maintenance finished (period 1/3).
[MAINTENANCE] Honor maintenance starting (period 2/3).
[MAINTENANCE] Load weekly players scores.
[MAINTENANCE] Load standing lists.
[MAINTENANCE] Alliance: 0, Horde: 0, Inactive: 0
[MAINTENANCE] Distribute rank points for Alliance.
[MAINTENANCE] Distribute rank points for Horde.
[MAINTENANCE] Decay rank points for inactive players.
[MAINTENANCE] Assign city titles.
[MAINTENANCE] Flush rank points.
[MAINTENANCE] Honor maintenance finished (period 2/3).
[MAINTENANCE] Honor maintenance starting (period 3/3).
[MAINTENANCE] Load weekly players scores.
[MAINTENANCE] Load standing lists.
[MAINTENANCE] Alliance: 0, Horde: 0, Inactive: 0
[MAINTENANCE] Distribute rank points for Alliance.
[MAINTENANCE] Distribute rank points for Horde.
[MAINTENANCE] Decay rank points for inactive players.
[MAINTENANCE] Assign city titles.
[MAINTENANCE] Flush rank points.
[MAINTENANCE] Honor maintenance finished (period 3/3).
[MAINTENANCE] Processed 3 outstanding honor maintenance periods.
```
(no honor to actually process in my test instance, so that's why it shows `0` everywhere)

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #2547 (the issue was already closed, just mentioning it for reference purposes; this PR addresses the restart loops described in the issue)

### How2Test
1. To manually force a maintenance run, update the `saved_variables` row in the `characters` DB accordingly, e.g.:
```sql
UPDATE `saved_variables`
SET `honor_maintenance_marker` = 1,
    `honor_last_maintenance_day` = `honor_last_maintenance_day` - 7,
    `honor_next_maintenance_day` = `honor_next_maintenance_day` - 7
WHERE `key` = 0;
```
2. Multiply the `- 7` to test processing several periods at once (e.g., `-14` for two periods).
3. Restart `mangosd` and it should start the honor maintenance.

__Note:__ this will obviously cause incorrect data if it is re-run for already calculated past periods, so don't run it on a production DB or create a backup first.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
