### PR TITLE
Treat Undercity slime as water

### DIFF
--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -474,12 +474,18 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE* output, WMORoot* rootWMO, bool pPrecis
                     liquidEntry = 3;        // magma
                     break;
                 case 3:
-                    if (rootWMO->RootWMOID == 4489) // Stratholme_raid.wmo WMOID == 4489
+                    switch (rootWMO->RootWMOID)
                     {
-                        liquidEntry = 21;   // Naxxramas slime
+                        case 4489:            // Stratholme_Raid.wmo, WMOID 4489
+                            liquidEntry = 21; // Naxxramas slime
+                            break;
+                        case 1150:            // Undercity.wmo, WMOID 1150
+                            liquidEntry = 1;  // Water
+                            break;
+                        default:
+                            liquidEntry = 4;  // Normal slime
+                            break;
                     }
-                    else
-                        liquidEntry = 4;    // Normal slime
                     break;
                 default:
                     break;


### PR DESCRIPTION
## 🍰 Pullrequest
Treat the slime in the Undercity as water, so it won't hurt the players anymore. Don't know if this is the correct way to fix it, but it works.

Related commit:
f54db6b4a82f40929c13868f61f0fa1e40c974c7 (PR #3118)

### Proof
None

### Issues
Closes #3246

### How2Test
- Extract maps/vmaps
- Swim in the slime in Undercity

### Todo / Checklist
None
