### PR TITLE
Remove function "IsInSlime"

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -1035,8 +1035,6 @@ void Player::OnMirrorTimerExpirationPulse(MirrorTimer::Type timer)
         case MirrorTimer::ENVIRONMENTAL:
             if (IsInMagma())
                 EnvironmentalDamage(DAMAGE_LAVA, urand(sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MIN), sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MAX)));
-            if (IsInSlime())
-                EnvironmentalDamage(DAMAGE_SLIME, urand(sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MIN), sWorld.getConfig(CONFIG_UINT32_ENVIRONMENTAL_DAMAGE_MAX)));
             break;
         case MirrorTimer::FEIGNDEATH:
             // Vanilla: kill player on feigning death for too long

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1853,7 +1853,6 @@ class Player final: public Unit
         bool IsUnderwater() const override { return (m_environmentFlags & ENVIRONMENT_FLAG_UNDERWATER); }
         bool IsInWater() const override { return (m_environmentFlags & ENVIRONMENT_FLAG_IN_WATER); }
         inline bool IsInMagma() const { return (m_environmentFlags & ENVIRONMENT_FLAG_IN_MAGMA); }
-        inline bool IsInSlime() const { return (m_environmentFlags & ENVIRONMENT_FLAG_IN_SLIME); }
         inline bool IsInHighSea() const { return (m_environmentFlags & ENVIRONMENT_FLAG_HIGH_SEA); }
         inline bool IsInHighLiquid() const { return (m_environmentFlags & ENVIRONMENT_FLAG_HIGH_LIQUID); }
 

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -1006,13 +1006,13 @@ PerformanceLog.SlowPacketBroadcast      = 0
 #                  0 (instant underwater breathing damage start)
 #
 #    MirrorTimer.Environmental.Max
-#        Generic environmental (lava/slime/etc) damage delay max timer value (in secs)
+#        Generic environmental damage delay max timer value (in secs); only lava is affected by this
 #        Default:  1
 #                  0 (instant in liquid damage start)
 #
 #    EnvironmentalDamage.Min
 #    EnvironmentalDamage.Max
-#        Generic environmental (lava/slime/etc) damage taken on tick
+#        Generic environmental damage taken on tick; only lava is affected by this
 #        Default:  605-610
 #
 #    MaxPrimaryTradeSkill


### PR DESCRIPTION
## 🍰 Pullrequest
Remove obsolet function "IsInSlime". The slime in Undercity will not apply environmental damage anymore.

Related commit:
f54db6b4a82f40929c13868f61f0fa1e40c974c7 (PR #3118)

Also see discussion in PR #3250.

### Proof
None

### Issues
Closes #3246

### How2Test
Swim in the slime in Undercity

### Todo / Checklist
None
