### PR TITLE
Fix cmake warning

### DIFF
--- a/dep/cpptrace/CMakeLists.txt
+++ b/dep/cpptrace/CMakeLists.txt
@@ -425,11 +425,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
           SOURCE_SUBDIR build/cmake
           DOWNLOAD_EXTRACT_TIMESTAMP TRUE
           URL "${CPPTRACE_ZSTD_URL}"
+          EXCLUDE_FROM_ALL
       )
       FetchContent_GetProperties(zstd)
       if(NOT zstd_POPULATED)
-        FetchContent_Populate(zstd)
-        add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR} EXCLUDE_FROM_ALL)
+        FetchContent_MakeAvailable(zstd)
       endif()
     endif()
     # Libdwarf itself
@@ -441,11 +441,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
       GIT_REPOSITORY ${CPPTRACE_LIBDWARF_REPO}
       GIT_TAG ${CPPTRACE_LIBDWARF_TAG}
       GIT_SHALLOW ${CPPTRACE_LIBDWARF_SHALLOW}
+      EXCLUDE_FROM_ALL
     )
     FetchContent_GetProperties(libdwarf)
     if(NOT libdwarf_POPULATED)
-      FetchContent_Populate(libdwarf)
-      add_subdirectory(${libdwarf_SOURCE_DIR} ${libdwarf_BINARY_DIR} EXCLUDE_FROM_ALL)
+      FetchContent_MakeAvailable(libdwarf)
     endif()
     target_include_directories(
       dwarf

--- a/dep/cpptrace/README.md
+++ b/dep/cpptrace/README.md
@@ -61,34 +61,39 @@ README.md -> README_original.md
 ```
 
 ### Prevent zstd, libdwarf from installing files (EXCLUDE_FROM_ALL)
-Use `FetchContent_Populate` + `add_subdirectory(EXCLUDE_FROM_ALL)` instead of
-`FetchContent_MakeAvailable` so the subprojects are excluded from the install step.
+Add `EXCLUDE_FROM_ALL` to `FetchContent_Declare`
 ```diff
+diff --git a/dep/cpptrace/CMakeLists.txt b/dep/cpptrace/CMakeLists.txt
+index 2c73da03f..c1dfaf6a9 100644
 --- a/dep/cpptrace/CMakeLists.txt
 +++ b/dep/cpptrace/CMakeLists.txt
-@@ -424,7 +424,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
+@@ -425,8 +425,12 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
+           SOURCE_SUBDIR build/cmake
+           DOWNLOAD_EXTRACT_TIMESTAMP TRUE
            URL "${CPPTRACE_ZSTD_URL}"
++          EXCLUDE_FROM_ALL
        )
 -      FetchContent_MakeAvailable(zstd)
 +      FetchContent_GetProperties(zstd)
 +      if(NOT zstd_POPULATED)
-+        FetchContent_Populate(zstd)
-+        add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR} EXCLUDE_FROM_ALL)
++        FetchContent_MakeAvailable(zstd)
 +      endif()
      endif()
      # Libdwarf itself
      set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-@@ -435,7 +439,11 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
+@@ -437,8 +441,12 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
+       GIT_REPOSITORY ${CPPTRACE_LIBDWARF_REPO}
        GIT_TAG ${CPPTRACE_LIBDWARF_TAG}
        GIT_SHALLOW ${CPPTRACE_LIBDWARF_SHALLOW}
++      EXCLUDE_FROM_ALL
      )
 -    FetchContent_MakeAvailable(libdwarf)
 +    FetchContent_GetProperties(libdwarf)
 +    if(NOT libdwarf_POPULATED)
-+      FetchContent_Populate(libdwarf)
-+      add_subdirectory(${libdwarf_SOURCE_DIR} ${libdwarf_BINARY_DIR} EXCLUDE_FROM_ALL)
++      FetchContent_MakeAvailable(libdwarf)
 +    endif()
      target_include_directories(
        dwarf
        PRIVATE
+@@ -601,9 +609,10 @@ endif()
 ```


### PR DESCRIPTION
## 🍰 Pullrequest
Fix this warning:
```
CMake Warning (dev) at /usr/share/cmake-3.31/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(zstd) is deprecated, call
  FetchContent_MakeAvailable(zstd) instead.  Policy CMP0169 can be set to OLD
  to allow FetchContent_Populate(zstd) to be called directly for now, but the
  ability to call it with declared details will be removed completely in a
  future version.
Call Stack (most recent call first):
  dep/cpptrace/CMakeLists.txt:431 (FetchContent_Populate)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Related commit:
efa0d8b043d4798db4e409a2486c71e8885cfd2e (PR #3199)

### Proof
None

### Issues
None

### How2Test
I used Cmake 3.31.6 on Debian 13:
```bash
mkdir ~/vmangos/build
cd ~/vmangos/build
cmake ~/vmangos/core -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DUSE_PCH=OFF -DUSE_STD_MALLOC=1 -DUSE_EXTRACTORS=0 -DCMAKE_INSTALL_PREFIX=~/vmangos-srv -DCMAKE_BUILD_TYPE=Release
```

### Todo / Checklist
None
