### PR TITLE
Fix Tranquil air totem 

### DIFF
--- a/sql/migrations/20260314234811_world.sql
+++ b/sql/migrations/20260314234811_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260314234811');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260314234811');
+-- Add your query below.
+
+UPDATE `creature_template` SET `patch`=0 WHERE  `entry`=15803 AND `patch`=7;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
When playing on a 1.12 client on a server with patch set below 1.9 - tranquil totem will not spawn.

Tranquil air totem was added in patch 1.9, so its current patch set to 7 is technically correct, but it breaks the spell on 1.12.

I know.. This smells like a hackfix. 

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
