### PR TITLE
Add missing gloves strength enchant to GM Island Enchanting vendor

### DIFF
--- a/src/scripts/custom/custom_creatures.cpp
+++ b/src/scripts/custom/custom_creatures.cpp
@@ -586,7 +586,7 @@ enum Enchants
     BRACER_HEAL,
     BRACER_INT,
     BRACER_MP5,
-    ,
+    GLOVES_STR,
     GLOVES_AGI,
     GLOVES_FIRE,
     GLOVES_FROST,

--- a/src/scripts/custom/custom_creatures.cpp
+++ b/src/scripts/custom/custom_creatures.cpp
@@ -586,6 +586,7 @@ enum Enchants
     BRACER_HEAL,
     BRACER_INT,
     BRACER_MP5,
+    GLOVES_STR,
     GLOVES_AGI,
     GLOVES_FIRE,
     GLOVES_FROST,
@@ -657,6 +658,7 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
             player->ADD_GOSSIP_ITEM(5, "MP5",                GOSSIP_SENDER_MAIN, BRACER_MP5);
             break;
         case EQUIPMENT_SLOT_HANDS:
+            player->ADD_GOSSIP_ITEM(5, "Agility",            GOSSIP_SENDER_MAIN, GLOVES_STR);
             player->ADD_GOSSIP_ITEM(5, "Agility",            GOSSIP_SENDER_MAIN, GLOVES_AGI);
             player->ADD_GOSSIP_ITEM(5, "Fire Power",         GOSSIP_SENDER_MAIN, GLOVES_FIRE);
             player->ADD_GOSSIP_ITEM(5, "Frost Power",        GOSSIP_SENDER_MAIN, GLOVES_FROST);
@@ -822,6 +824,10 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
             case BRACER_MP5:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_WRISTS);
                 id = 2565;
+                break;
+            case GLOVES_STR:
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_HANDS);
+                id = 927;
                 break;
             case GLOVES_AGI:
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_HANDS);

--- a/src/scripts/custom/custom_creatures.cpp
+++ b/src/scripts/custom/custom_creatures.cpp
@@ -586,7 +586,7 @@ enum Enchants
     BRACER_HEAL,
     BRACER_INT,
     BRACER_MP5,
-    GLOVES_STR,
+    ,
     GLOVES_AGI,
     GLOVES_FIRE,
     GLOVES_FROST,
@@ -658,7 +658,7 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
             player->ADD_GOSSIP_ITEM(5, "MP5",                GOSSIP_SENDER_MAIN, BRACER_MP5);
             break;
         case EQUIPMENT_SLOT_HANDS:
-            player->ADD_GOSSIP_ITEM(5, "Strength",            GOSSIP_SENDER_MAIN, GLOVES_STR);
+            player->ADD_GOSSIP_ITEM(5, "Strength",           GOSSIP_SENDER_MAIN, GLOVES_STR);
             player->ADD_GOSSIP_ITEM(5, "Agility",            GOSSIP_SENDER_MAIN, GLOVES_AGI);
             player->ADD_GOSSIP_ITEM(5, "Fire Power",         GOSSIP_SENDER_MAIN, GLOVES_FIRE);
             player->ADD_GOSSIP_ITEM(5, "Frost Power",        GOSSIP_SENDER_MAIN, GLOVES_FROST);

--- a/src/scripts/custom/custom_creatures.cpp
+++ b/src/scripts/custom/custom_creatures.cpp
@@ -658,7 +658,7 @@ bool GossipSelect_EnchantNPC(Player* player, Creature* creature, uint32 sender, 
             player->ADD_GOSSIP_ITEM(5, "MP5",                GOSSIP_SENDER_MAIN, BRACER_MP5);
             break;
         case EQUIPMENT_SLOT_HANDS:
-            player->ADD_GOSSIP_ITEM(5, "Agility",            GOSSIP_SENDER_MAIN, GLOVES_STR);
+            player->ADD_GOSSIP_ITEM(5, "Strength",            GOSSIP_SENDER_MAIN, GLOVES_STR);
             player->ADD_GOSSIP_ITEM(5, "Agility",            GOSSIP_SENDER_MAIN, GLOVES_AGI);
             player->ADD_GOSSIP_ITEM(5, "Fire Power",         GOSSIP_SENDER_MAIN, GLOVES_FIRE);
             player->ADD_GOSSIP_ITEM(5, "Frost Power",        GOSSIP_SENDER_MAIN, GLOVES_FROST);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
The Strength enchant for gloves is missing on the GM Island Enchanting vendor. This PR adds it back.

https://www.wowhead.com/classic/spell=20013/enchant-gloves-greater-strength

### How2Test
Go to the GM Island. Talk to the Enchant 2 NPC. See that there is a Strength option.


