### PR TITLE
Delete gear instead of un-equipping gear when using the Premade Gear NPC on GM Island

### DIFF
--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -12107,6 +12107,7 @@ void ObjectMgr::ApplyPremadeGearTemplateToPlayer(uint32 entry, Player* pPlayer) 
             ItemPrototype const* pItem = GetItemPrototype(item.itemId);
 
             pPlayer->SatisfyItemRequirements(pItem);
+            pPlayer->DestroyItemCount(item.itemId, 1, true);
             pPlayer->StoreNewItemInBestSlots(item.itemId, 1, item.enchantId);
         }
     }

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -12091,9 +12091,9 @@ void ObjectMgr::ApplyPremadeGearTemplateToPlayer(uint32 entry, Player* pPlayer) 
         pPlayer->SetUInt32Value(PLAYER_XP, 0);
     }
 
-    // Unequip current gear
+    // Delete current gear
     for (int i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i)
-        pPlayer->AutoUnequipItemFromSlot(i);
+        pPlayer->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
 
     // Learn Dual Wield Specialization
     if (pPlayer->GetClass() == CLASS_WARRIOR || pPlayer->GetClass() == CLASS_ROGUE || pPlayer->GetClass() == CLASS_HUNTER)


### PR DESCRIPTION
## 🍰 Pullrequest
This pull request changes it so that when you choose a set of gear from the Premade Gear NPC on GM Island, your current gear is deleted instead of unequipped. 

The problem with un-equipping gear is that it quickly fills your bags up. 
And let's say, you switched from gear set 1 to gear set 2, and then you want to switch back to gear set 1, all using the Premade Gear NPC. It doesn't re-equip the gear you have in your bags. It just creates gear set 1 again. So you are left with many duplicated gear.

This also fixes the bug when you select an option from the Premade Gear NPC, and some gear is missing. The bug is caused by the server failing to create a Unique item that you already have. This PR fixes it by deleting the Unique item on you first, before creating a new one.

### How2Test

1. Speak to Premade Gear NPC on GM Island
2. Pick an option
3. Pick a second option
4. Pick the first option again
5. See that there is nothing added to your bags
