### PR TITLE
Fix missing petstats after first summon

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -2354,6 +2354,7 @@ void Spell::EffectSummon(SpellEffectIndex effIdx)
     spawnCreature->InitializeDefaultName();
     spawnCreature->AIM_Initialize();
     spawnCreature->InitPetCreateSpells();
+    spawnCreature->UpdateAllStats();
     spawnCreature->SetHealth(spawnCreature->GetMaxHealth());
     spawnCreature->SetPower(POWER_MANA, spawnCreature->GetMaxPower(POWER_MANA));
 
@@ -3229,6 +3230,7 @@ ObjectGuid Unit::EffectSummonPet(uint32 spellId, uint32 petEntry, uint32 petLeve
 
     newSummon->AIM_Initialize();
     newSummon->InitPetCreateSpells();
+    newSummon->UpdateAllStats();
     newSummon->SetHealth(newSummon->GetMaxHealth());
     newSummon->SetPower(POWER_MANA, newSummon->GetMaxPower(POWER_MANA));
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Recalculates stats after applying create spells.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/vmangos/core/issues/2497

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
