### PR TITLE
CI: Explicitly set workflow permissions.

### DIFF
--- a/.github/workflows/db_check.yml
+++ b/.github/workflows/db_check.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest # 18.04 has mysql5.7 and latest(20.04) has mysql8
+    permissions:
+      contents: read
 
     # ... some other config ...
 

--- a/.github/workflows/db_dump.yml
+++ b/.github/workflows/db_dump.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest # 18.04 has mysql5.7 and latest(20.04) has mysql8
+    permissions:
+      contents: read
 
     # ... some other config ...
 
@@ -142,6 +144,13 @@ jobs:
           name: snapshot-db-sqlite-dump
           path: "${{github.workspace}}/dbexport/db-sqlite-${{steps.vars.outputs.sha_short}}.zip"
 
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
     - name: Download artifact snapshot-db-dump
       uses: actions/download-artifact@v4
       with:
@@ -163,7 +172,7 @@ jobs:
     - name: Upload snapshot
       uses: "crowbarmaster/GH-Automatic-Releases@latest"
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        repo_token: "${{ github.token }}"
         automatic_release_tag: "db_latest"
         prerelease: true
         title: "Development DB Dump(${{ steps.date.outputs.time }})"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: windows-2022
+    permissions:
+      contents: read
 
     steps:
     #git checkout
@@ -76,6 +78,13 @@ jobs:
           name: snapshot-devbuild
           path: "${{github.workspace}}/bin/${{env.ARCHIVE_FILENAME}}"
 
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
     - name: Download artifact snapshot-Release
       uses: actions/download-artifact@v4
       with:
@@ -92,7 +101,7 @@ jobs:
     - name: Upload snapshot
       uses: "crowbarmaster/GH-Automatic-Releases@latest"
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        repo_token: "${{ github.token }}"
         automatic_release_tag: "latest"
         prerelease: true
         title: "Development Build(${{ steps.date.outputs.time }})"

--- a/.github/workflows/vmangos.yml
+++ b/.github/workflows/vmangos.yml
@@ -36,6 +36,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       #matrix declaration
       matrix:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This explicitly sets permissions for the GitHub Actions workflows instead of relying on the repository’s default Actions token permissions, which allows the artifact-publishing workflows to run successfully on forks with a read-only default (instead of failing with insufficient permissions).

It also changes `secrets.GITHUB_TOKEN` to `github.token`; both refer to the same value but using the latter makes it clearer that this is auto-generated by GitHub Actions and not an actual repository secret that needs to be configured manually.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
