### PR TITLE
Fix 1.5.1 build.

### DIFF
--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1190,6 +1190,7 @@ void WorldSession::HandleRequestPetInfoOpcode(NullClientPacket const& /*packet *
         _player->CharmSpellInitialize();
 }
 
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_5_1
 void WorldSession::HandleWardenDataOpcode(WorldPackets::Misc::WardenData const& packet)
 {
     if (!m_warden)
@@ -1204,3 +1205,4 @@ void WorldSession::HandleWardenDataOpcode(WorldPackets::Misc::WardenData const& 
         m_warden->m_packetDataQueue.emplace(packet.data);
     }
 }
+#endif

--- a/src/game/Server/Packets/Misc.cpp
+++ b/src/game/Server/Packets/Misc.cpp
@@ -235,7 +235,7 @@ void WorldPackets::Misc::Bug::ReadFromWorldPacket(WorldPacket& recv_data)
     recv_data >> type;
 }
 
-
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_5_1
 void WorldPackets::Misc::WardenData::ReadFromWorldPacket(WorldPacket& recv_data)
 {
     uint32 const remaining = recv_data.size() - recv_data.rpos();
@@ -243,3 +243,4 @@ void WorldPackets::Misc::WardenData::ReadFromWorldPacket(WorldPacket& recv_data)
     if (!data.empty())
         recv_data.read(data.data(), data.size());
 }
+#endif


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Building for client version `1.5.1.4449` currently fails:
```
/build/core/src/game/Handlers/MiscHandler.cpp:1193:6: error: variable or field 'HandleWardenDataOpcode' declared void
 1193 | void WorldSession::HandleWardenDataOpcode(WorldPackets::Misc::WardenData const& packet)
      |      ^~~~~~~~~~~~
/build/core/src/game/Handlers/MiscHandler.cpp:1193:63: error: 'WardenData' is not a member of 'WorldPackets::Misc'
 1193 | void WorldSession::HandleWardenDataOpcode(WorldPackets::Misc::WardenData const& packet)
      |                                                               ^~~~~~~~~~
```
This is due to the refactor in 6f25c89c03f5a3033b2c10cd4cab5e6dd33dd231 which left two Warden-related functions unguarded.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
