### PR TITLE
Fix 1.9.4 build.

### DIFF
--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -371,15 +371,15 @@ void WorldSession::HandleMovementOpcodes(WorldPackets::Movement::MovementPacket 
 #if SUPPORTED_CLIENT_BUILD == CLIENT_BUILD_1_9_4
     if (opcode == MSG_MOVE_FALL_LAND)
     {
-        if (!movementInfo.HasMovementFlag(MOVEFLAG_MASK_MOVING))
+        if (!packet.movementInfo.HasMovementFlag(MOVEFLAG_MASK_MOVING))
             opcode = MSG_MOVE_STOP;
-        else if (movementInfo.HasMovementFlag(MOVEFLAG_BACKWARD))
+        else if (packet.movementInfo.HasMovementFlag(MOVEFLAG_BACKWARD))
             opcode = MSG_MOVE_START_BACKWARD;
-        else if (movementInfo.HasMovementFlag(MOVEFLAG_FORWARD))
+        else if (packet.movementInfo.HasMovementFlag(MOVEFLAG_FORWARD))
             opcode = MSG_MOVE_START_FORWARD;
-        else if (movementInfo.HasMovementFlag(MOVEFLAG_STRAFE_LEFT))
+        else if (packet.movementInfo.HasMovementFlag(MOVEFLAG_STRAFE_LEFT))
             opcode = MSG_MOVE_START_STRAFE_LEFT;
-        else if (movementInfo.HasMovementFlag(MOVEFLAG_STRAFE_RIGHT))
+        else if (packet.movementInfo.HasMovementFlag(MOVEFLAG_STRAFE_RIGHT))
             opcode = MSG_MOVE_START_STRAFE_RIGHT;
         else
             opcode = MSG_MOVE_HEARTBEAT;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fix yet another regression from 6f25c89c03f5a3033b2c10cd4cab5e6dd33dd231, this time when building `1.9.4.5086`:
```
/build/core/src/game/Handlers/MovementHandler.cpp: In member function 'void WorldSession::HandleMovementOpcodes(const WorldPackets::Movement::MovementPacket&)':
/build/core/src/game/Handlers/MovementHandler.cpp:374:14: error: 'movementInfo' was not declared in this scope; did you mean 'MovementInfo'?
  374 |         if (!movementInfo.HasMovementFlag(MOVEFLAG_MASK_MOVING))
      |              ^~~~~~~~~~~~
      |              MovementInfo
```

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
