### PR TITLE
Fix the Hunter bot from returning to melee range after getting into it once

### DIFF
--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -877,7 +877,7 @@ void PartyBotAI::UpdateAI(uint32 const diff)
             {
                 case IDLE_MOTION_TYPE:
                 case FOLLOW_MOTION_TYPE:
-                    me->GetMotionMaster()->MoveChase(pVictim);
+                    me->GetMotionMaster()->MoveChase(pVictim, 25.0f);
                     break;
             }
         }

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -877,8 +877,16 @@ void PartyBotAI::UpdateAI(uint32 const diff)
             {
                 case IDLE_MOTION_TYPE:
                 case FOLLOW_MOTION_TYPE:
-                    me->GetMotionMaster()->MoveChase(pVictim, 25.0f);
-                    break;
+                    if (GetRole() == ROLE_RANGE_DPS)
+                    {
+                        me->GetMotionMaster()->MoveChase(pVictim, 15.0f);
+                        break;    
+                    }
+                    else
+                    {
+                        me->GetMotionMaster()->MoveChase(pVictim);
+                        break;
+                    }
             }
         }
     }


### PR DESCRIPTION
## 🍰 Pullrequest
In the current version, once a Hunter bot gets into melee range, it retreats, then tries to get back to melee range. This PR fixes that. The Hunter bot will now stay at proper range after retreating. The range they stay at can be lower or higher, but that's up for debate.

The problem is that somewhere in the code, the Hunter bot is made to execute the MoveChase function without specifying the distance, which brings it to melee range. And then it executes the RunAwayFromTarget function again, making it a loop.

### How2Test
Bring a Hunter bot to melee range to a Training Dummy on GM Island, then order it to attack.
