### PR TITLE
Fix Imp Fire Shield owner targeting while grouped.

### DIFF
--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -371,7 +371,7 @@ void PetAI::UpdateAllies()
 
     m_AllySet.clear();
     m_AllySet.insert(m_creature->GetObjectGuid());
-    m_AllySet.insert(owner->GetObjectGuid()); // Owner must always be a valid friendly target
+    m_AllySet.insert(owner->GetObjectGuid()); // The pet owner must always be a valid friendly target.
 
     if (group)
     {

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -366,12 +366,14 @@ void PetAI::UpdateAllies()
         return;
 
     //owner is in group; group members filled in already (no raid -> subgroupcount = whole count)
-    if (group && !group->isRaidGroup() && m_AllySet.size() == (group->GetMembersCount() + 2))
+    if (group && !group->isRaidGroup() && m_AllySet.size() == (group->GetMembersCount() + 1))
         return;
 
     m_AllySet.clear();
     m_AllySet.insert(m_creature->GetObjectGuid());
-    if (group)                                             //add group
+    m_AllySet.insert(owner->GetObjectGuid()); // Owner must always be a valid friendly autocast target
+
+    if (group)
     {
         for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
         {
@@ -385,8 +387,6 @@ void PetAI::UpdateAllies()
             m_AllySet.insert(target->GetObjectGuid());
         }
     }
-    else                                                    //remove group
-        m_AllySet.insert(owner->GetObjectGuid());
 }
 
 void PetAI::KilledUnit(Unit* victim)
@@ -523,7 +523,7 @@ std::pair<Unit*, ePetSelectTargetReason> PetAI::SelectNextTarget() const
     Unit* owner = m_creature->GetCharmerOrOwner();
     if (!owner)
         return std::make_pair(nullptr, PSTR_FAIL_NO_OWNER);
-    
+
     if (Creature const* pOwnerCreature = owner->ToCreature())
     {
         // Owner is creature and is evading. We must not re-aggro.
@@ -552,7 +552,7 @@ std::pair<Unit*, ePetSelectTargetReason> PetAI::SelectNextTarget() const
     {
         if (Unit* pVictim = owner->GetVictim())
         {
-            if (!pVictim->HasAuraPetShouldAvoidBreaking() && 
+            if (!pVictim->HasAuraPetShouldAvoidBreaking() &&
                (!m_creature->GetCharmInfo()->IsAtStay() || m_creature->CanReachWithMeleeAutoAttack(pVictim)))
                 return std::make_pair(pVictim, PSTR_SUCCESS_OWNER_VICTIM);
         }
@@ -727,7 +727,7 @@ bool PetAI::CanAttack(Unit* target)
     // CC - mobs under crowd control can be attacked if owner commanded
     if (target->HasAuraPetShouldAvoidBreaking())
         return m_creature->GetCharmInfo()->IsCommandAttack();
-        
+
     // Returning - pets ignore attacks only if owner clicked follow
     if (m_creature->GetCharmInfo()->IsReturning())
         return !m_creature->GetCharmInfo()->IsCommandFollow();
@@ -801,4 +801,3 @@ void PetAI::AttackedBy(Unit* attacker)
     // Continue to evaluate and attack if necessary
     AttackStart(attacker);
 }
-

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -369,9 +369,11 @@ void PetAI::UpdateAllies()
     if (group && !group->isRaidGroup() && m_AllySet.size() == (group->GetMembersCount() + 1))
         return;
 
+    // Cache potential friendly targets here. Charmed owner/group members are
+    // filtered later by spell target validation before the pet actually casts.
     m_AllySet.clear();
     m_AllySet.insert(m_creature->GetObjectGuid());
-    m_AllySet.insert(owner->GetObjectGuid()); // The pet owner must always be a valid friendly target.
+    m_AllySet.insert(owner->GetObjectGuid()); // The pet owner must always be included.
 
     if (group)
     {

--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -371,7 +371,7 @@ void PetAI::UpdateAllies()
 
     m_AllySet.clear();
     m_AllySet.insert(m_creature->GetObjectGuid());
-    m_AllySet.insert(owner->GetObjectGuid()); // Owner must always be a valid friendly autocast target
+    m_AllySet.insert(owner->GetObjectGuid()); // Owner must always be a valid friendly target
 
     if (group)
     {


### PR DESCRIPTION
## 🍰 Pullrequest
Currently, `PetAI::UpdateAllies()` skips the owner (= the summoning Warlock in this case) in the grouped-member loop here: https://github.com/vmangos/core/blob/09a9a84ae949b6016053258624f7498a6e3b3a02/src/game/AI/PetAI.cpp#L382-L383
That would be fine if the owner were added unconditionally elsewhere. However, in the current code the owner is only inserted in the non-grouped branch here: https://github.com/vmangos/core/blob/09a9a84ae949b6016053258624f7498a6e3b3a02/src/game/AI/PetAI.cpp#L388-L389
That makes the Imp stop considering its summoning Warlock as a valid friendly autocast target while grouped.

In addition, the cached `m_AllySet` can also stay stale after leaving a 2-player party, because a 2-entry set can still be `{pet, former party member}` (since the owner was never added in the grouped branch) versus `{pet, owner}` after leaving the party, and the size-based `m_AllySet.size() == 2 && !group` check will incorrectly still pass.

This change always inserts the owner before processing grouped allies. This fixes both the grouped case and the stale cache after leaving a 2-player party, because even with a 2-player party the size of `m_AllySet` will be 3 (`{pet, owner, party member}`) and thus not hit the early return anymore.

Note that I could not reproduce the GM visibility issue around Fire Shield that I first reported in #2916 anymore, so I probably initially misinterpreted it while simultaneously hitting this party bug.

### Proof
- None

### Issues
- Fixes #2916

### How2Test
- Create a Warlock character using a GM account
- `.levelup 13` (need to be level 14 to learn Fire Shield)
- `.learn all_myclass`
- `.additem 16326 1`
- Cast `Summon Imp`
- Learn Fire Shield by right-click the `Grimoire of Fire Shield (Rank 1)` in the inventory
- Enable Fire Shield autocasting by right clicking on it in the pet action bar
- `.partybot add priest`
- Keep the party bot out of combat and attack a mob
- Observe that the Imp will still cast Fire Shield on you, despite being in a party (this is not the case without this fix)
- Leave the party, wait at least 10 seconds, retest without relogging, and confirm you can still receive Fire Shield (this also does not work without relogging without this fix)

### Todo / Checklist
- Fire Shield currently also autocasts when not attacked in melee (as soon as you get aggro) because its conditional in `Spell::CanAutoCast()` uses `GetAttackerForHelper()`. I am not entirely sure, but I think this is not fully blizz-like. I didn't touch this in this PR though.