### PR TITLE
Fix battlebots failing to pick up WSG flags when shapeshifted.

### DIFF
--- a/src/game/PlayerBots/BattleBotAI.cpp
+++ b/src/game/PlayerBots/BattleBotAI.cpp
@@ -865,7 +865,8 @@ void BattleBotAI::UpdateAI(uint32 const diff)
     if (me->GetSheath() == SHEATH_STATE_UNARMED && !me->IsMounted())
         me->SetSheath(SHEATH_STATE_MELEE);
 
-    UpdateBattleGroundAI();
+    if (UpdateBattleGroundAI())
+        return;
 
     if (!me->IsInCombat())
     {
@@ -966,36 +967,56 @@ void BattleBotAI::UpdateAI(uint32 const diff)
         UpdateInCombatAI();
 }
 
-void BattleBotAI::UpdateBattleGroundAI()
+bool BattleBotAI::UpdateBattleGroundAI()
 {
     BattleGround* bg = me->GetBattleGround();
     if (!bg)
-        return;
+        return false;
 
     switch (bg->GetTypeID())
     {
         case BATTLEGROUND_WS:
         {
             // Pick up dropped flags.
-            if (GameObject* pGo = me->FindNearestGameObject(GO_WSG_DROPPED_SILVERWING_FLAG, INTERACTION_DISTANCE))
-                pGo->Use(me);
-            if (GameObject* pGo = me->FindNearestGameObject(GO_WSG_DROPPED_WARSONG_FLAG, INTERACTION_DISTANCE))
-                pGo->Use(me);
+            if (TryUseBattleGroundFlag(GO_WSG_DROPPED_SILVERWING_FLAG) ||
+                TryUseBattleGroundFlag(GO_WSG_DROPPED_WARSONG_FLAG))
+                return true;
 
             // Pick up stationary flags from bases.
             if (me->GetTeam() == HORDE)
             {
-                if (GameObject* pGo = me->FindNearestGameObject(GO_WSG_SILVERWING_FLAG, INTERACTION_DISTANCE))
-                    pGo->Use(me);
+                return TryUseBattleGroundFlag(GO_WSG_SILVERWING_FLAG);
             }
             else
             {
-                if (GameObject* pGo = me->FindNearestGameObject(GO_WSG_WARSONG_FLAG, INTERACTION_DISTANCE))
-                    pGo->Use(me);
+                return TryUseBattleGroundFlag(GO_WSG_WARSONG_FLAG);
             }
-            break;
         }
     }
+
+    return false;
+}
+
+bool BattleBotAI::TryUseBattleGroundFlag(uint32 entry)
+{
+    GameObject* pGo = me->FindNearestGameObject(entry, INTERACTION_DISTANCE);
+    if (!pGo)
+        return false;
+
+    if (me->IsMounted())
+    {
+        me->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
+        return true;
+    }
+
+    if (me->IsInDisallowedMountForm())
+    {
+        me->RemoveSpellsCausingAura(SPELL_AURA_MOD_SHAPESHIFT);
+        return true;
+    }
+
+    pGo->Use(me);
+    return true;
 }
 
 void BattleBotAI::UpdateFlagCarrierAI()

--- a/src/game/PlayerBots/BattleBotAI.h
+++ b/src/game/PlayerBots/BattleBotAI.h
@@ -45,7 +45,7 @@ public:
     {
         return SpawnNewPlayer(sess, m_class, m_race, m_mapId, m_instanceId, m_x, m_y, m_z, m_o);
     }
-  
+
     void OnPlayerLogin() final;
     void UpdateAI(uint32 const diff) final;
     void OnPacketReceived(WorldPacket const* packet) final;
@@ -67,7 +67,8 @@ public:
     void OnLeaveBattleGround();
 
     void UpdateFlagCarrierAI();
-    void UpdateBattleGroundAI();
+    bool UpdateBattleGroundAI();
+    bool TryUseBattleGroundFlag(uint32 entry);
     void UpdateInCombatAI() final;
     void UpdateOutOfCombatAI() final;
     void UpdateInCombatAI_Paladin() final;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This fixes battlebots, particularly druids, not picking up WSG flags when shapeshifted.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #1814

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create an Alliance character using a GM account
1. `.levelup 39`
2. `.debug bg`
3. `.gm on`
4. `.gm visible off` (so bots won't react to you in the battleground)
5. `.go warsong`
6. Click `Join Battle` in the window
7. Use `.battlebot add warsong horde 39 temp` and `.battlebot removeall` (best to create macros for these two commands) until you get a Druid battlebot (maybe there is a better way, but I couldn't think of one); if you don't manage to get one before the BG starts, use `.bg stop` and go back to step 5.)
8. Once the BG starts, use `.goname <Druid battlebot name>` to teleport to the battlebot
9. The battlebot should activate Cat Form and use Prowl and then proceed to run to the alliance flag
10. Once it arrives at the flag, it should drop out of Prowl and Cat Form and pick up the flag, then go back into Cat Form (without Prowl) and run back home to the Horde base

Demonstration video:

https://github.com/user-attachments/assets/8d342e75-5e04-4386-8300-f24208de0282

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
