### PR TITLE
Prevent Shadowfang Keep escort delay race condition.

### DIFF
--- a/sql/migrations/20260405082412_world.sql
+++ b/sql/migrations/20260405082412_world.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260405082412');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260405082412');
+-- Add your query below.
+
+-- Shadowfang Keep - Deathstalker Adamant (3849) and Sorcerer Ashcrombe (3850)
+-- Set CREATURE_FLAG_EXTRA_NO_MOVEMENT_PAUSE to skip the gossip movement pause.
+-- This prevents a rare race where a second near-simultaneous gossip interaction
+-- pauses waypoint movement for 180 seconds before the escort starts.
+UPDATE `creature_template` SET `flags_extra`=(`flags_extra` | 0x00000020) WHERE `entry`=3849;
+UPDATE `creature_template` SET `flags_extra`=(`flags_extra` | 0x00000020) WHERE `entry`=3850;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
This fixes the rare race condition outlined in #2597:

- Player A selects `Please unlock the courtyard door.`
- Before Sorcerer Ashcrombe actually moves and before Player B's client receives the update that removed Ashcrombe's gossip flag, Player B right-clicks him (this needs to essentially happen almost simultaneously as Player A's click, but in the correct order, to trigger this race condition bug)
- `WorldSession::HandleGossipHelloOpcode` pauses his waypoint movement for 180 seconds before he finally starts moving

This affects both [Sorcerer Ashcrombe](https://www.wowhead.com/classic/npc=3850/sorcerer-ashcrombe) (on Alliance side) and [Deathstalker Adamant](https://www.wowhead.com/classic/npc=3849/deathstalker-adamant) (on Horde side).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #2597

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
An artificial solo reproduction is:

- Use an Alliance character from a GM account
- Prepare a macro with `.npc set flag 1` (this sets the selected creature's NPC flags field to `1`, i.e. `UNIT_NPC_FLAG_GOSSIP`, which artificially reproduces the race condition because Ashcrombe’s first gossip interaction normally removes his gossip flag immediately, making him unrightclickable)
- `.go creature 16242`
- Target Rethilgore
- `.die`
- Open Sorcerer Ashcrombe's cell door, go inside and talk to him
- Click `Please unlock the courtyard door.`
- Immediately use the `.npc set flag 1` macro on him and right-click him again
- Observe that he doesn't pause for 180 seconds anymore (as it is without with fix) before he starts his waypoint movement

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
