### PR TITLE
Fix Warrior bots not being able to Charge

### DIFF
--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -1065,7 +1065,8 @@ void CombatBotBaseAI::PopulateSpellData()
                     if (IsHigherRankSpell(m_spells.warrior.pDefensiveStance))
                         m_spells.warrior.pDefensiveStance = pSpellEntry;
                 }
-                else if (pSpellEntry->SpellName[0].find("Charge") != std::string::npos)
+                else if (pSpellEntry->SpellName[0].find("Charge") != std::string::npos &&
+                         pSpellEntry->SpellFamilyName == SPELLFAMILY_WARRIOR)
                 {
                     if (IsHigherRankSpell(m_spells.warrior.pCharge))
                         m_spells.warrior.pCharge = pSpellEntry;

--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -1065,8 +1065,7 @@ void CombatBotBaseAI::PopulateSpellData()
                     if (IsHigherRankSpell(m_spells.warrior.pDefensiveStance))
                         m_spells.warrior.pDefensiveStance = pSpellEntry;
                 }
-                else if (pSpellEntry->SpellName[0].find("Charge") != std::string::npos &&
-                         pSpellEntry->SpellFamilyName == SPELLFAMILY_WARRIOR)
+                else if (pSpellEntry->SpellName[0] == "Charge")
                 {
                     if (IsHigherRankSpell(m_spells.warrior.pCharge))
                         m_spells.warrior.pCharge = pSpellEntry;


### PR DESCRIPTION
## 🍰 Pullrequest
When you summon a Warrior bot, some of them will use Charge, some of them will never Charge. The reason for that is, the way the code searches for a spell is not deterministic. It only tries to match a spell with "Charge" in it. Some of the Warrior bots will find the spell, Charged Scale of Onyxia, instead.
https://www.wowhead.com/classic/spell=22434/charged-scale-of-onyxia

You can confirm that going into PartyBotAI.cpp, and changing the Charge code block to this
`if (m_spells.warrior.pCharge &&
            CanTryToCastSpell(pVictim, m_spells.warrior.pCharge))
        {   
            SpellCastResult result = DoCastSpell(pVictim, m_spells.warrior.pCharge);
            me->Say(("Charge spell ID: " + std::to_string(m_spells.warrior.pCharge->Id)).c_str(), LANG_UNIVERSAL);
            if (result == SPELL_CAST_OK)
                return;`

This is a pretty big bug actually, because the way spells are searched means that there may be other spells that bots cannot reliably use.
### How2Test
Summon a few Warrior bots, and see if they all use Charge, with and without this fix.
