### PR TITLE
Centralize OpenSSL init

### DIFF
--- a/src/mangosd/Main.cpp
+++ b/src/mangosd/Main.cpp
@@ -31,9 +31,9 @@
 #include "Master.h"
 #include "SystemConfig.h"
 #include "revision.h"
-#include <openssl/opensslv.h>
-#include <openssl/crypto.h>
 #include "ArgparserForServer.h"
+
+#include "Crypto/InitializeCrypto.h"
 
 #ifdef WIN32
 #include "ServiceWin32.h"
@@ -112,8 +112,6 @@ extern int main(int argc, char **argv)
 #endif
     }
 
-    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Core revision: %s [world-daemon]", _FULLVERSION);
-    sLog.Out(LOG_BASIC, LOG_LVL_BASIC, "<Ctrl-C> to stop." );
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "\n\n"
         "MM     MM MM   MM         MM   MM  MMMMM   MMMMM   MMMMM\n"
         "MM     MM MM   MM         MM   MM MMM MMM MM   MM MMM MMM\n"
@@ -126,14 +124,15 @@ extern int main(int argc, char **argv)
         "    M     MM   MM MM  MMM MM   MM  MMMMMM  MMMMM   MMMMM\n"
         "                  MMMMMM\n"
         "                          https://github.com/vmangos\n\n");
-    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Using configuration file %s", sConfig.GetFilename().c_str());
-    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Core Revision: " _FULLVERSION);
-    sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "%s (Library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
-    if (SSLeay() < 0x009080bfL )
+    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Core revision: %s [world-daemon]", _FULLVERSION);
+    if (!Crypto::InitializeCryptoAndPrintVersion())
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "WARNING: Outdated version of OpenSSL lib. Logins to server may not work!");
-        sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "WARNING: Minimal required version [OpenSSL 0.9.8k]");
+        sLog.WaitBeforeContinueIfNeed();
+        return EXIT_FAILURE;
     }
+
+    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "<Ctrl-C> to stop.");
+    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Using configuration file %s", sConfig.GetFilename().c_str());
 
     // Set progress bars show mode
     BarGoLink::SetOutputState(sConfig.GetBoolDefault("ShowProgressBars", true));

--- a/src/realmd/Main.cpp
+++ b/src/realmd/Main.cpp
@@ -36,9 +36,8 @@
 #include "revision.h"
 #include "Util.h"
 #include "migrations_list.h"
-#include <openssl/opensslv.h>
-#include <openssl/crypto.h>
 #include "ArgparserForServer.h"
+#include "Crypto/InitializeCrypto.h"
 #include "Crypto/Encoding/Base32.h"
 #include "ProxyProtocol/ProxyV2Reader.h"
 
@@ -127,7 +126,13 @@ extern int main(int argc, char** argv)
     }
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Core revision: %s [realm-daemon]", _FULLVERSION);
-    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "<Ctrl-C> to stop.\n");
+    if (!Crypto::InitializeCryptoAndPrintVersion())
+    {
+        sLog.WaitBeforeContinueIfNeed();
+        return EXIT_FAILURE;
+    }
+
+    sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "<Ctrl-C> to stop.");
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Using configuration file %s.", sConfig.GetFilename().c_str());
 
     // Check the version of the configuration file
@@ -140,13 +145,6 @@ extern int main(int argc, char** argv)
         sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "          strange behavior.                                                  ");
         sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "*****************************************************************************");
         Log::WaitBeforeContinueIfNeed();
-    }
-
-    sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "%s (Library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
-    if (SSLeay() < 0x009080bfL)
-    {
-        sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "WARNING: Outdated version of OpenSSL lib. Logins to server may not work!");
-        sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "WARNING: Minimal required version [OpenSSL 0.9.8k]");
     }
 
 #ifdef ENABLE_MAILSENDER

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -42,6 +42,8 @@ set (shared_SRCS
     Config/ConfigEnv.h
     Crypto/BigNumber.h
     Crypto/BigNumber.cpp
+    Crypto/InitializeCrypto.h
+    Crypto/InitializeCrypto.cpp
     Crypto/Authentication/SRP6.h
     Crypto/Authentication/SRP6.cpp
     Crypto/Encoding/Base32.h

--- a/src/shared/Crypto/Encryption/RC4.cpp
+++ b/src/shared/Crypto/Encryption/RC4.cpp
@@ -24,9 +24,6 @@
 
 RC4::RC4(uint8 len) : m_ctx()
 {
-    #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-        OSSL_PROVIDER_load(NULL, "legacy");
-    #endif
     m_ctx = EVP_CIPHER_CTX_new();
     EVP_EncryptInit_ex(m_ctx, EVP_rc4(), nullptr, nullptr, nullptr);
     EVP_CIPHER_CTX_set_key_length(m_ctx, len);
@@ -34,9 +31,6 @@ RC4::RC4(uint8 len) : m_ctx()
 
 RC4::RC4(uint8* seed, uint8 len) : m_ctx()
 {
-    #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-        OSSL_PROVIDER_load(NULL, "legacy");
-    #endif
     m_ctx = EVP_CIPHER_CTX_new();
     EVP_EncryptInit_ex(m_ctx, EVP_rc4(), nullptr, nullptr, nullptr);
     EVP_CIPHER_CTX_set_key_length(m_ctx, len);

--- a/src/shared/Crypto/Hash/HMACSHA1.cpp
+++ b/src/shared/Crypto/Hash/HMACSHA1.cpp
@@ -18,8 +18,10 @@
 
 #include "HMACSHA1.h"
 #include "../BigNumber.h"
+#include "Errors.h"
 
 #include <openssl/hmac.h>
+#include <openssl/sha.h>
 
 
 Crypto::Hash::HMACSHA1::Generator::Generator(std::vector<uint8> const& key)
@@ -30,19 +32,29 @@ Crypto::Hash::HMACSHA1::Generator::Generator(std::vector<uint8> const& key)
 
 Crypto::Hash::HMACSHA1::Generator::Generator(uint8 const* key, size_t len)
 {
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
-    m_ctx = HMAC_CTX_new();
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    m_mac = EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+    MANGOS_ASSERT(m_mac != nullptr);
+    m_ctx = EVP_MAC_CTX_new(m_mac);
+    MANGOS_ASSERT(m_ctx != nullptr);
+
+    OSSL_PARAM params[2];
+    params[0] = OSSL_PARAM_construct_utf8_string("digest", const_cast<char*>("SHA1"), 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    MANGOS_ASSERT(EVP_MAC_init(m_ctx, key, len, params) == 1);
 #else
     m_ctx = new HMAC_CTX;
     HMAC_CTX_init(m_ctx);
-#endif
     HMAC_Init_ex(m_ctx, key, static_cast<int>(len), EVP_sha1(), nullptr);
+#endif
 }
 
 Crypto::Hash::HMACSHA1::Generator::~Generator()
 {
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
-    HMAC_CTX_free(m_ctx);
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    EVP_MAC_CTX_free(m_ctx);
+    EVP_MAC_free(m_mac);
 #else
     HMAC_CTX_cleanup(m_ctx);
     delete m_ctx;
@@ -66,13 +78,23 @@ void Crypto::Hash::HMACSHA1::Generator::UpdateData(BigNumber const& bn)
 
 void Crypto::Hash::HMACSHA1::Generator::UpdateData(uint8 const* data, size_t length)
 {
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    MANGOS_ASSERT(EVP_MAC_update(m_ctx, data, length) == 1);
+#else
     HMAC_Update(m_ctx, data, length);
+#endif
 }
 
 Crypto::Hash::HMACSHA1::Digest Crypto::Hash::HMACSHA1::Generator::GetDigest()
 {
     Digest digest;
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    size_t length = 0;
+    MANGOS_ASSERT(EVP_MAC_final(m_ctx, digest.data(), &length, digest.size()) == 1);
+#else
     uint32 length = 0;
     HMAC_Final(m_ctx, digest.data(), &length);
+#endif
+    MANGOS_ASSERT(length == SHA_DIGEST_LENGTH);
     return digest;
 }

--- a/src/shared/Crypto/Hash/HMACSHA1.h
+++ b/src/shared/Crypto/Hash/HMACSHA1.h
@@ -27,9 +27,16 @@
 
 #include "SHA1.h"
 
+#include <openssl/opensslv.h>
+
 class BigNumber;
 
 typedef struct hmac_ctx_st HMAC_CTX;
+
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+typedef struct evp_mac_st EVP_MAC;
+typedef struct evp_mac_ctx_st EVP_MAC_CTX;
+#endif
 
 namespace Crypto { namespace Hash { namespace HMACSHA1
 {
@@ -54,7 +61,12 @@ namespace Crypto { namespace Hash { namespace HMACSHA1
         Digest GetDigest();
 
     private:
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+        EVP_MAC* m_mac;
+        EVP_MAC_CTX* m_ctx;
+#else
         HMAC_CTX* m_ctx;
+#endif
     };
 
 }}} // namespace Crypto::Hash::HMACSHA1

--- a/src/shared/Crypto/InitializeCrypto.cpp
+++ b/src/shared/Crypto/InitializeCrypto.cpp
@@ -1,0 +1,165 @@
+#include "InitializeCrypto.h"
+#include "Util.h"
+#include "Authentication/SRP6.h"
+#include "Encoding/Base32.h"
+#include "Encryption/RC4.h"
+#include "Hash/MD5.h"
+#include "Hash/SHA1.h"
+#include "IO/Filesystem/FileHandle.h"
+#include "IO/Filesystem/FileSystem.h"
+#include "Log.h"
+
+#include <openssl/crypto.h>
+
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#include <openssl/provider.h>
+#endif
+
+template <typename C1, typename C2>
+static bool ArrayEqual(C1 const& a, C2 const& b)
+{
+    if (a.size() != b.size())
+        return false;
+    return std::equal(a.begin(), a.end(), b.begin());
+}
+
+static std::string CalculateShaPassHash(std::string const& name, std::string const& password)
+{
+    auto pwHash = Crypto::Hash::SHA1::ComputeFrom(name + ":" + password);
+
+    std::string encoded;
+    hexEncodeByteArray(pwHash.data(), pwHash.size(), encoded);
+
+    return encoded;
+}
+
+static bool Check_SRP6()
+{
+    SRP6 srp;
+
+    char const* salt = "D04E6342FE6CB5FAE54C6182F885778D0AEFE4BFCDDC6B5C7DF7DC25FF6E3C2D";
+    char const* expectedHashResult = "46FD48476D925C4422DD1761C299C79FD6C92B5243E4F3C6C62576C0DABD8260";
+
+    if (!srp.CalculateVerifier(CalculateShaPassHash("VMANGOS", "4EVER"), salt))
+        return false;
+
+    if (!srp.ProofVerifier(expectedHashResult))
+        return false;
+
+    return true;
+}
+
+static bool Check_Base32()
+{
+    std::vector<uint8> testData = { 'H', 'e', 'l', 'l', 'o' };
+    std::string encoded = Crypto::Encoding::Base32::Encode(testData);
+    std::string expectedEncoded = "JBSWY3DP";
+    return encoded == expectedEncoded;
+}
+
+static bool Check_RC4()
+{
+    uint8 constexpr rc4Key[] = { 0xf7, 0xff, 0x9e, 0x8b, 0x7b, 0xb2, 0xe0, 0x9b, 0x70, 0x93, 0x5a, 0x5d, 0x78, 0x5e, 0x0c, 0xc5 };
+    RC4 rc4(16);
+    rc4.Init(rc4Key);
+
+    uint8 constexpr expectedCipher[] = { 0x1c, 0x9f, 0x73, 0x6b, 0xbc, 0x91, 0xa8, 0xc6, 0x0d };
+    uint8 rc4Data[] = { 0x50, 0x6C, 0x61, 0x69, 0x6E, 0x74, 0x65, 0x78, 0x74 }; // "Plaintext"
+    rc4.UpdateData(rc4Data, sizeof(rc4Data));
+    return std::equal(std::begin(rc4Data), std::end(rc4Data), std::begin(expectedCipher));
+}
+
+static bool Check_MD5()
+{
+    auto md5 = Crypto::Hash::MD5::ComputeFrom("Hello");
+    Crypto::Hash::MD5::Digest expectedMd5;
+    uint8 constexpr md5Raw[] = { 0x8b, 0x1a, 0x99, 0x53, 0xc4, 0x61, 0x12, 0x96, 0xa8, 0x27, 0xab, 0xf8, 0xc4, 0x78, 0x04, 0xd7 };
+    std::copy(std::begin(md5Raw), std::end(md5Raw), expectedMd5.begin());
+    return ArrayEqual(md5, expectedMd5);
+}
+
+static bool Check_SHA1()
+{
+    auto sha1 = Crypto::Hash::SHA1::ComputeFrom("Hello");
+    Crypto::Hash::SHA1::Digest expectedSha1;
+    uint8 constexpr sha1Raw[] = { 0xf7, 0xff, 0x9e, 0x8b, 0x7b, 0xb2, 0xe0, 0x9b, 0x70, 0x93, 0x5a, 0x5d, 0x78, 0x5e, 0x0c, 0xc5, 0xd9, 0xd0, 0xab, 0xf0 };
+    std::copy(std::begin(sha1Raw), std::end(sha1Raw), expectedSha1.begin());
+    return ArrayEqual(sha1, expectedSha1);
+}
+
+static bool CryptoSelfCheck()
+{
+    sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Running Crypto Library Selftest...");
+    bool isOkay = true;
+
+    // Authentication
+    if (!Check_SRP6())
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "SelfTest SRP6: Error");
+        isOkay = false;
+    }
+
+    // Encoding
+    if (!Check_Base32())
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "SelfTest Base32: Error");
+        isOkay = false;
+    }
+
+    // Encryption
+    if (!Check_RC4()) // This requires "legacy" module
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "SelfTest RC4: Error");
+        isOkay = false;
+    }
+
+    // Hash
+    if (!Check_MD5())
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "SelfTest MD5: Error");
+        isOkay = false;
+    }
+    if (!Check_SHA1())
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "SelfTest SHA1: Error");
+        isOkay = false;
+    }
+
+    return isOkay;
+}
+
+bool Crypto::InitializeCryptoAndPrintVersion()
+{
+    sLog.Out(LOG_BASIC, LOG_LVL_DETAIL, "%s (Library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
+
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    if (!OSSL_PROVIDER_available(nullptr, "legacy"))
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "OpenSSL: legacy provider is not available. Trying to load it...");
+        if (!OSSL_PROVIDER_load(nullptr, "legacy"))
+        {
+            sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "OpenSSL: legacy provider load failed. Retrying after setting CWD...");
+            std::string cwd = IO::Filesystem::ToAbsolutePath(".");
+
+            if (!OSSL_PROVIDER_set_default_search_path(nullptr, cwd.c_str()))
+            {
+                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "OpenSSL: failed to set provider default search path to CWD");
+            }
+
+            if (!OSSL_PROVIDER_load(nullptr, "legacy"))
+            {
+                sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "OpenSSL: Failed to load openssl legacy provider.");
+                return false;
+            }
+        }
+    }
+#endif
+
+    if (!CryptoSelfCheck())
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "CryptoSelfCheck failed");
+        return false;
+    }
+
+    return true;
+}

--- a/src/shared/Crypto/InitializeCrypto.h
+++ b/src/shared/Crypto/InitializeCrypto.h
@@ -1,0 +1,8 @@
+#ifndef _CRYPTO_INITIALIZE_H
+#define _CRYPTO_INITIALIZE_H
+
+namespace Crypto {
+    bool InitializeCryptoAndPrintVersion();
+}
+
+#endif // _CRYPTO_INITIALIZE_H


### PR DESCRIPTION
- Improve support for newer version of OpenSSL
- Replaced deprecated OpenSSL functions with OpenSSL3 compatible ones.
- Don't initialize `legacy` provider in `RC4` constructor
- Quick self check at the beginning to ensure that all crypto methods are available
- Hide all `<openssl/*>` includes behind `Crypto::` namespace
