### PR TITLE
Makes the casters stop using wand forever

### DIFF
--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -745,6 +745,7 @@ void PartyBotAI::UpdateAI(uint32 const diff)
         {
             if (me->GetPowerPercent(POWER_MANA) >= 20.0f)
                 me->InterruptSpell(CURRENT_AUTOREPEAT_SPELL, true);
+        }
         return;
     }
 

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -739,7 +739,12 @@ void PartyBotAI::UpdateAI(uint32 const diff)
             else
                 UpdateInCombatAI_Hunter();
         }
-
+        else if (me->GetClass() == CLASS_MAGE ||
+                 me->GetClass() == CLASS_WARLOCK ||
+                 me->GetClass() == CLASS_PRIEST)
+        {
+            if (me->GetPowerPercent(POWER_MANA) >= 20.0f)
+                me->InterruptSpell(CURRENT_AUTOREPEAT_SPELL, true);
         return;
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Currently, once a caster runs out of mana, they will use the wand forever, even if their mana is fully regenerated. This changes it so that they will return to casting spells once their mana reaches 20%

### How2Test
Get a caster to attack a Training Dummy on GM Island until it switches to wand.