### PR TITLE
Fix log format string mismatches and suppress script errors with SF_GENERAL_SKIP_MISSING_TARGETS

### DIFF
--- a/sql/migrations/20260406103411_world.sql
+++ b/sql/migrations/20260406103411_world.sql
@@ -1,0 +1,40 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260406103411');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260406103411');
+-- Add your query below.
+
+-- Gordo
+-- Gloom Weed spawns are pooled and thus sometimes can't be found and despawned
+-- SF_GENERAL_ABORT_ON_FAILURE + SF_GENERAL_SKIP_MISSING_TARGETS for CMD 81 = despawn go
+UPDATE `creature_movement_scripts` SET `data_flags` = 24 WHERE `command` = 81 AND `id` IN
+(
+1066602,
+1066603,
+1066604,
+1066605,
+1066606,
+1066607,
+1066608,
+1066609,
+1066610,
+1066611,
+1066612,
+1066613,
+1066614
+);
+
+-- Rot Hide Mongrel
+-- SF_GENERAL_SKIP_MISSING_TARGETS: TARGET_T_HOSTILE_RANDOM returns null when threat list is empty
+UPDATE `creature_ai_scripts` SET `data_flags` = 16 WHERE `id` = 167502;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Commands/AccountCommands.cpp
+++ b/src/game/Commands/AccountCommands.cpp
@@ -578,7 +578,7 @@ bool ChatHandler::HandleBanAllIPCommand(char* args)
         if (sAccountMgr.IsAccountBanned(it))
             continue;
         sWorld.BanAccount(BAN_ACCOUNT, accountsIdToName[it], 0, reason, m_session ? m_session->GetPlayerName() : "");
-        PSendSysMessage("Account '%s' permanently banned.", accountsIdToName[it].c_str(), reason);
+        PSendSysMessage("Account '%s' permanently banned. Reason: %s", accountsIdToName[it].c_str(), reason);
         ++bannedCount;
     }
     PSendSysMessage("%u accounts banned for %s (%u on this IP)", bannedCount, reason, accountsIdToName.size());

--- a/src/game/Conditions.cpp
+++ b/src/game/Conditions.cpp
@@ -1110,7 +1110,7 @@ bool ConditionEntry::IsValid()
         {
             if (m_value1 > 10)
             {
-                sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Patch condition (entry %u, type %u) has an invalid value in value1 (must be 0..10), skipping.", m_entry, m_condition, m_value1);
+                sLog.Out(LOG_DBERROR, LOG_LVL_MINIMAL, "Patch condition (entry %u, type %u, value1 %u) has an invalid value in value1 (must be 0..10), skipping.", m_entry, m_condition, m_value1);
                 return false;
             }
             if (m_value2 > 2)

--- a/src/game/Handlers/BattleGroundHandler.cpp
+++ b/src/game/Handlers/BattleGroundHandler.cpp
@@ -501,7 +501,7 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPackets::Battleground::Battl
             sBattleGroundMgr.ScheduleQueueUpdate(bgQueueTypeId, bgTypeId, _player->GetBattleGroundBracketIdFromLevel(bgTypeId));
             SendPacket(&data);
             sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Battleground: player %s (%u) left queue for bgtype %u, queue type %u.", _player->GetName(), _player->GetGUIDLow(), bg->GetTypeID(), bgQueueTypeId);
-            sLog.Out(LOG_BG, LOG_LVL_DETAIL, "[%u,%u] %s:%u [%u:%s] leaves queue",
+            sLog.Out(LOG_BG, LOG_LVL_DETAIL, "[%u,%u] %s:%u [%u:%s] leaves queue, bgTypeId: %u",
                      bg->GetMapId(), bg->GetInstanceID(),
                      _player->GetName(),
                      _player->GetGUIDLow(),

--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -1124,7 +1124,7 @@ void WorldSession::HandleMoverRelocation(Unit* pMover, MovementInfo& movementInf
 
             if (undermap)
                 if (pPlayerMover->UndermapRecall())
-                    sLog.Player(this, LOG_MOVEMENT, LOG_LVL_MINIMAL, "[UNDERMAP] Teleporting to safe position. MapId: %u Pos: %g %g %g", pPlayerMover->GetName(), pPlayerMover->GetGUIDLow(), pPlayerMover->GetMapId(), pPlayerMover->GetPositionX(), pPlayerMover->GetPositionY(), pPlayerMover->GetPositionZ());
+                    sLog.Player(this, LOG_MOVEMENT, LOG_LVL_MINIMAL, "[UNDERMAP] Player: %s (GUID: %u) Teleporting to safe position. MapId: %u Pos: %g %g %g", pPlayerMover->GetName(), pPlayerMover->GetGUIDLow(), pPlayerMover->GetMapId(), pPlayerMover->GetPositionX(), pPlayerMover->GetPositionY(), pPlayerMover->GetPositionZ());
         }
         else if (pPlayerMover->CanFreeMove())
             pPlayerMover->SaveNoUndermapPosition(pMover->m_movementInfo.GetPos().x, pMover->m_movementInfo.GetPos().y, pMover->m_movementInfo.GetPos().z + 3.0f, pMover->m_movementInfo.GetPos().o);

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2132,7 +2132,7 @@ bool DungeonMap::CanEnter(Player* player)
 
     if (m_resetAfterUnload)
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "[DungeonReset] %s attempted to enter map %u, instance %u during reset", player->GetName(), m_instanceId);
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "[DungeonReset] %s attempted to enter map %u, instance %u during reset", player->GetName(), GetId(), m_instanceId);
         player->SendTransferAborted(TRANSFER_ABORT_NOT_FOUND);
         return false;
     }

--- a/src/game/Maps/ScriptCommands.cpp
+++ b/src/game/Maps/ScriptCommands.cpp
@@ -374,7 +374,8 @@ bool Map::ScriptCommand_RespawnGameObject(ScriptInfo const& script, WorldObject*
 
     if (!pGo)
     {
-        sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_RESPAWN_GAMEOBJECT (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
+        if (!(script.raw.data[4] & SF_GENERAL_SKIP_MISSING_TARGETS))
+            sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_RESPAWN_GAMEOBJECT (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
         return ShouldAbortScript(script);
     }
 
@@ -493,7 +494,8 @@ bool Map::ScriptCommand_OpenDoor(ScriptInfo const& script, WorldObject* source, 
 
     if (!pDoor)
     {
-        sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_OPEN_DOOR (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
+        if (!(script.raw.data[4] & SF_GENERAL_SKIP_MISSING_TARGETS))
+            sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_OPEN_DOOR (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
         return ShouldAbortScript(script);
     }
 
@@ -537,7 +539,8 @@ bool Map::ScriptCommand_CloseDoor(ScriptInfo const& script, WorldObject* source,
 
     if (!pDoor)
     {
-        sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_CLOSE_DOOR (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
+        if (!(script.raw.data[4] & SF_GENERAL_SKIP_MISSING_TARGETS))
+            sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_CLOSE_DOOR (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
         return ShouldAbortScript(script);
     }
     if (pDoor->GetGoType() != GAMEOBJECT_TYPE_DOOR)
@@ -2306,7 +2309,8 @@ bool Map::ScriptCommand_DespawnGameObject(ScriptInfo const& script, WorldObject*
 
     if (!pGo)
     {
-        sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_DESPAWN_GAMEOBJECT (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
+        if (!(script.raw.data[4] & SF_GENERAL_SKIP_MISSING_TARGETS))
+            sLog.Out(LOG_SCRIPTS, LOG_LVL_ERROR, "SCRIPT_COMMAND_DESPAWN_GAMEOBJECT (script id %u) failed for gameobject (guid: %u).", script.id, guidlow);
         return ShouldAbortScript(script);
     }
 

--- a/src/game/Objects/DynamicObject.cpp
+++ b/src/game/Objects/DynamicObject.cpp
@@ -107,7 +107,7 @@ bool DynamicObject::Create(uint32 guidlow, WorldObject* caster, uint32 spellId, 
     SpellEntry const* spellProto = sSpellMgr.GetSpellEntry(spellId);
     if (!spellProto)
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "DynamicObject (spell %u) not created. Spell not exist!", spellId, GetPositionX(), GetPositionY());
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "DynamicObject (spell %u) not created. Spell not exist! Position: X: %f, Y: %f", spellId, GetPositionX(), GetPositionY());
         return false;
     }
 

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -18780,7 +18780,7 @@ void Player::LeaveBattleground(bool teleportToEntryPoint)
                 AddAura(26013, 0, this);               // Deserter
         }
         bg->RemovePlayerAtLeave(GetObjectGuid(), teleportToEntryPoint, true);
-        sLog.Out(LOG_BG, LOG_LVL_DETAIL, "[%u,%u]: %s:%u [%u:%s] leaves",
+        sLog.Out(LOG_BG, LOG_LVL_DETAIL, "[%u,%u]: %s:%u [%u:%s] leaves, TypeID: %u",
                  bg->GetMapId(), bg->GetInstanceID(),
                  GetName(),
                  GetGUIDLow(), GetSession()->GetAccountId(), GetSession()->GetRemoteAddress().c_str(),

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -1626,7 +1626,7 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 a
 SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(Unit* pVictim, uint32 amount, uint32 originalAmount, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlags, uint32 procEx, uint32 cooldown)
 {
     SpellEntry const* spellInfo = triggeredByAura->GetSpellProto();
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "ProcDamageAndSpell: doing %u damage from spell id %u (triggered by auratype %u of spell %u)",
+    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "ProcDamageAndSpell: doing %.2f damage from spell id %u (triggered by auratype %u of spell %u)",
                      triggeredByAura->GetModifier()->m_amount, spellInfo->Id, triggeredByAura->GetModifier()->m_auraname, triggeredByAura->GetId());
 
     if (!pVictim || !pVictim->IsAlive())


### PR DESCRIPTION
## 🍰 Pullrequest
- Fix several log statements had mismatched format strings and arguments
- Script commands respawn/open/close door and despawn gameobject now suppress the missing target error when SF_GENERAL_SKIP_MISSING_TARGETS is set, as sometimes this is expected behavior

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None