### PR TITLE
Improve bot pet handling.

### DIFF
--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -33,25 +33,71 @@ enum CombatBotSpells
     SPELL_TAME_BEAST = 13481,
     SPELL_REVIVE_PET = 982,
     SPELL_CALL_PET = 883,
-
-    PET_WOLF    = 565,
-    PET_CAT     = 681,
-    PET_BEAR    = 822,
-    PET_CRAB    = 831,
-    PET_GORILLA = 1108,
-    PET_BIRD    = 1109,
-    PET_BOAR    = 1190,
-    PET_BAT     = 1554,
-    PET_CROC    = 1693,
-    PET_SPIDER  = 1781,
-    PET_OWL     = 1997,
-    PET_STRIDER = 2322,
-    PET_SCORPID = 3127,
-    PET_SERPENT = 3247,
-    PET_RAPTOR  = 3254,
-    PET_TURTLE  = 3461,
-    PET_HYENA   = 4127,
 };
+
+namespace
+{
+bool HasUsableHunterPetSpellData(uint32 petEntry)
+{
+    PetCreateSpellEntry const* createSpells = sObjectMgr.GetPetCreateSpellEntry(petEntry);
+    if (!createSpells)
+        return false;
+
+    for (uint32 spellId : createSpells->spellId)
+    {
+        if (!spellId)
+            break; // Match Pet::InitPetCreateSpells(), which stops at the first empty slot.
+
+        SpellEntry const* learnSpellInfo = sSpellMgr.GetSpellEntry(spellId);
+        if (!learnSpellInfo)
+            continue;
+
+        uint32 petSpellId = spellId;
+        if (learnSpellInfo->Effect[0] == SPELL_EFFECT_LEARN_SPELL ||
+            learnSpellInfo->Effect[0] == SPELL_EFFECT_LEARN_PET_SPELL)
+            petSpellId = learnSpellInfo->EffectTriggerSpell[0];
+
+        SpellEntry const* petSpellInfo = sSpellMgr.GetSpellEntry(petSpellId);
+        if (petSpellInfo && petSpellInfo->IsAutocastable())
+            return true;
+    }
+
+    return false;
+}
+
+uint32 SelectHunterBotPetEntry()
+{
+    static std::vector<uint32> const petEntries = []()
+    {
+        std::vector<uint32> entries;
+
+        for (const auto& itr : sObjectMgr.GetCreatureInfoMap())
+        {
+            CreatureInfo const* cInfo = itr.second.get();
+            if (!cInfo || !cInfo->IsTameable())
+                continue;
+
+            // Exclude some special case creatures.
+            if (cInfo->npc_flags || cInfo->script_id || cInfo->spawn_spell_id)
+                continue;
+
+            // Exclude creatures that don't have at last one usable Hunter pet spell.
+            if (HasUsableHunterPetSpellData(cInfo->entry))
+                entries.push_back(cInfo->entry);
+        }
+
+        if (entries.empty())
+            sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "CombatBotBaseAI::SelectHunterBotPetEntry: No valid hunter bot pet entries found for patch %u.", sWorld.GetWowPatch());
+
+        return entries;
+    }();
+
+    if (petEntries.empty())
+        return 0;
+
+    return SelectRandomContainerElement(petEntries);
+}
+}
 
 void CombatBotBaseAI::AutoAssignRole()
 {
@@ -2388,9 +2434,10 @@ void CombatBotBaseAI::SummonPetIfNeeded()
             return;
         }
 
-        uint32 petId = PickRandomValue( PET_WOLF, PET_CAT, PET_BEAR, PET_CRAB, PET_GORILLA, PET_BIRD,
-                                        PET_BOAR, PET_BAT, PET_CROC, PET_SPIDER, PET_OWL, PET_STRIDER,
-                                        PET_SCORPID, PET_SERPENT, PET_RAPTOR, PET_TURTLE, PET_HYENA );
+        uint32 petId = SelectHunterBotPetEntry();
+        if (!petId)
+            return;
+
         if (Creature* pCreature = me->SummonCreature(petId,
             me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0.0f,
             TEMPSUMMON_TIMED_COMBAT_OR_DEAD_DESPAWN, 3000, false, 3000))

--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -2667,6 +2667,8 @@ void CombatBotBaseAI::EquipPremadeGearTemplate()
     }
 }
 
+namespace
+{
 inline uint32 GetPrimaryItemStatForClassAndRole(uint8 playerClass, uint8 role)
 {
     switch (playerClass)
@@ -2697,6 +2699,7 @@ inline uint32 GetPrimaryItemStatForClassAndRole(uint8 playerClass, uint8 role)
         }
     }
     return ITEM_MOD_STAMINA;
+}
 }
 
 void CombatBotBaseAI::EquipRandomGearInEmptySlots()

--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -2328,8 +2328,45 @@ Player* CombatBotBaseAI::SelectDispelTarget(SpellEntry const* pSpellEntry) const
     return nullptr;
 }
 
+void CombatBotBaseAI::InitializeBotPetAutocast()
+{
+    if (!me)
+        return;
+
+    Pet* pet = me->GetPet();
+    if (!pet || pet->GetPetAutoSpellSize() > 0)
+        return;
+
+    CharmInfo* charmInfo = pet->GetCharmInfo();
+    if (!charmInfo)
+        return;
+
+    for (uint8 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
+    {
+        UnitActionBarEntry const* actionBarEntry = charmInfo->GetActionBarEntry(i);
+        if (!actionBarEntry || !actionBarEntry->IsActionBarForSpell())
+            continue;
+
+        uint32 spellId = actionBarEntry->GetAction();
+        if (!spellId || !pet->HasSpell(spellId))
+            continue;
+
+        SpellEntry const* spellInfo = sSpellMgr.GetSpellEntry(spellId);
+        if (!spellInfo || !spellInfo->IsAutocastable())
+            continue;
+
+        pet->ToggleAutocast(spellId, true);
+        charmInfo->SetSpellAutocast(spellId, true);
+    }
+}
+
 void CombatBotBaseAI::SummonPetIfNeeded()
 {
+    // Only initialize autocast for spells the current pet already knows.
+    // Bot pets do not currently simulate trainer/grimoire-based pet spell
+    // learning.
+    InitializeBotPetAutocast();
+
     if (me->GetClass() == CLASS_HUNTER)
     {
         if (me->GetCharmGuid())

--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -2406,6 +2406,41 @@ void CombatBotBaseAI::InitializeBotPetAutocast()
     }
 }
 
+std::vector<uint32> CombatBotBaseAI::CollectWarlockBotSummonSpells() const
+{
+    std::vector<uint32> summons;
+    if (!me)
+        return summons;
+
+    if (me->HasSpell(SPELL_SUMMON_IMP))
+        summons.push_back(SPELL_SUMMON_IMP);
+    if (me->HasSpell(SPELL_SUMMON_VOIDWALKER))
+        summons.push_back(SPELL_SUMMON_VOIDWALKER);
+    if (me->HasSpell(SPELL_SUMMON_FELHUNTER))
+        summons.push_back(SPELL_SUMMON_FELHUNTER);
+    if (me->HasSpell(SPELL_SUMMON_SUCCUBUS))
+        summons.push_back(SPELL_SUMMON_SUCCUBUS);
+
+    if (!summons.empty())
+        return summons;
+
+    // Fall back to the earliest summon quest requirements when no premade spec
+    // provides the summon spells (intended for bots that are below level 19
+    // where no premade spec exists, but still includes higher levels for
+    // completeness' sake).
+    uint32 level = me->GetLevel();
+    if (level >= 1)
+        summons.push_back(SPELL_SUMMON_IMP);
+    if (level >= 10)
+        summons.push_back(SPELL_SUMMON_VOIDWALKER);
+    if (level >= 20)
+        summons.push_back(SPELL_SUMMON_SUCCUBUS);
+    if (level >= 30)
+        summons.push_back(SPELL_SUMMON_FELHUNTER);
+
+    return summons;
+}
+
 void CombatBotBaseAI::SummonPetIfNeeded()
 {
     // Only initialize autocast for spells the current pet already knows.
@@ -2451,15 +2486,7 @@ void CombatBotBaseAI::SummonPetIfNeeded()
         if (me->GetPetGuid() || me->GetCharmGuid())
             return;
 
-        std::vector<uint32> vSummons;
-        if (me->HasSpell(SPELL_SUMMON_IMP))
-            vSummons.push_back(SPELL_SUMMON_IMP);
-        if (me->HasSpell(SPELL_SUMMON_VOIDWALKER))
-            vSummons.push_back(SPELL_SUMMON_VOIDWALKER);
-        if (me->HasSpell(SPELL_SUMMON_FELHUNTER))
-            vSummons.push_back(SPELL_SUMMON_FELHUNTER);
-        if (me->HasSpell(SPELL_SUMMON_SUCCUBUS))
-            vSummons.push_back(SPELL_SUMMON_SUCCUBUS);
+        std::vector<uint32> vSummons = CollectWarlockBotSummonSpells();
         if (!vSummons.empty())
             me->CastSpell(me, SelectRandomContainerElement(vSummons), true);
     }

--- a/src/game/PlayerBots/CombatBotBaseAI.h
+++ b/src/game/PlayerBots/CombatBotBaseAI.h
@@ -92,6 +92,7 @@ public:
     void ResetSpellData();
     void AddAllSpellReagents();
     void SummonPetIfNeeded();
+    void InitializeBotPetAutocast();
     void LearnArmorProficiencies();
     void LearnPremadeSpecForClass();
     void EquipPremadeGearTemplate();

--- a/src/game/PlayerBots/CombatBotBaseAI.h
+++ b/src/game/PlayerBots/CombatBotBaseAI.h
@@ -5,6 +5,8 @@
 #include "SpellEntry.h"
 #include "Player.h"
 
+#include <vector>
+
 struct HealSpellCompare
 {
     bool operator() (SpellEntry const* const lhs, SpellEntry const* const rhs) const
@@ -93,6 +95,7 @@ public:
     void AddAllSpellReagents();
     void SummonPetIfNeeded();
     void InitializeBotPetAutocast();
+    std::vector<uint32> CollectWarlockBotSummonSpells() const;
     void LearnArmorProficiencies();
     void LearnPremadeSpecForClass();
     void EquipPremadeGearTemplate();


### PR DESCRIPTION
## 🍰 Pullrequest
This improves bot pet handling via a few separate commits:
1. https://github.com/vmangos/core/commit/3586ea8ba91dc8457c9ae73fcd748c3280d9ee6d: This enables autocasting for bot pet spells (fixes #2474).
2. https://github.com/vmangos/core/commit/8d866e4de7ad5148337639c23d9907880d9002e8: This gets rid of the hardcoded list of 17 pets and instead lets Hunter bots select from a much larger pool, to add some variety.
3. https://github.com/vmangos/core/commit/d7e63d73b68e7d99eb75bd006388b7aa41883af4: This adds a fallback for Warlock pets that allows Warlock bots without a matching premade spec (so below level 19) to still summon pets, which makes them more useful in lower level content. The fallback only applies if there is no premade spec or if a premade spec doesn't provide any summon spells (which felt like the better way to do it for completeness' sake, instead of just hardcoding it below level 19).
4. https://github.com/vmangos/core/commit/a3fc22b697c2433bf1eb1fe48fe9281ebc868842: This just wraps the `GetPrimaryItemStatForClassAndRole()` function into an anonymous namespace, so the helper is not globally exported as a free function.

As an addition for 3.), I also have a commit prepared that teaches Warlock bots all Grimoire pet spells they can learn at their level automatically, but I left this out of this PR for now because I don't want to bloat it too much and I am also not sure if this is something we even want to add. If there are no objections, I will make a follow-up PR for that later.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #2474

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->

#### Hunter bots

1. Create a character using a GM account
2. `.levelup 9`
3. `.partybot add hunter`
4. Observe the Hunter partybot summons a pet from the now broader pool
6. Target a mob
7. `.partybot attackstart`
8. Observe that the Hunter pet uses spells

#### Warlock bots

1. Create a character using a GM account
2. `.levelup 9`
3. `.partybot add warlock`
4. Observe the Warlock partybot summons an Imp or a Voidwalker
5. Target a mob
6. `.partybot attackstart`
7. Observe that the Imp starts using Firebolt or that the Voidwalker starts using Torment

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
