### PR TITLE
Despawn dead bots when removed from group.

### DIFF
--- a/src/game/PlayerBots/PlayerBotAI.cpp
+++ b/src/game/PlayerBots/PlayerBotAI.cpp
@@ -48,6 +48,29 @@ void PlayerBotAI::UpdateAI(uint32 const diff)
         me->GetSession()->HandleMoveWorldportAck();
 }
 
+void PlayerBotAI::PrepareForLogout()
+{
+    if (!me || !me->IsDead())
+        return;
+
+    me->GetHostileRefManager().deleteReferences();
+
+    if (me->GetCorpse())
+    {
+        me->SpawnCorpseBones();
+        return;
+    }
+
+    // Dead bots that have not released yet do not have a corpse object.
+    // Create one and immediately convert it to bones so the bot can log out
+    // without leaving a persistent body behind.
+    if (me->GetDeathState() == CORPSE)
+    {
+        me->BuildPlayerRepop();
+        me->SpawnCorpseBones();
+    }
+}
+
 void PlayerBotAI::Remove()
 {
     if (me)

--- a/src/game/PlayerBots/PlayerBotAI.h
+++ b/src/game/PlayerBots/PlayerBotAI.h
@@ -41,6 +41,7 @@ class PlayerBotAI: public PlayerAI
         virtual void OnPacketReceived(WorldPacket const* /*packet*/) {} // server has sent a packet to this session
         void UpdateAI(uint32 const /*diff*/) override; // Handle delayed teleports
         virtual void OnPlayerLogin() {}
+        virtual void PrepareForLogout();
         virtual void BeforeAddToMap(Player* player) {} // me=nullptr at call
         // Helpers
         bool SpawnNewPlayer(WorldSession* sess, uint8 classId, uint32 raceId, uint32 mapId, uint32 instanceId, float dx, float dy, float dz, float o, Player* pClone = nullptr);

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -235,7 +235,10 @@ void PlayerBotMgr::Update(uint32 diff)
             if (iter->second->requestRemoval)
             {
                 if (iter->second->ai && iter->second->ai->me)
+                {
+                    iter->second->ai->PrepareForLogout();
                     iter->second->ai->me->RemoveFromGroup();
+                }
 
                 DeleteBot(iter);
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This despawns dead bots when removed from the group, so they don't stick around until the next server restart (as described in #1826). Instead, they now "release" and spawn bones. It could also be done without spawning bones, but this seems like the cleaner solution to me.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #1826

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1. `.partybot add warrior`
2. Target Warrior party bot
3. `.die`
4. Target dead party bot
5. `.partybot remove` (alternatively, leave the party or kick the bot)
6. Observe that the bot properly despawns and leaves bones

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
