### PR TITLE
CI: Use service container for MySQL.

### DIFF
--- a/.github/scripts/export-and-verify-sql-dumps.sh
+++ b/.github/scripts/export-and-verify-sql-dumps.sh
@@ -26,9 +26,8 @@ fi
 output_dir="$1"
 dump_dir="$output_dir/mysql-dump"
 mysql_container_id="${MYSQL_CONTAINER_ID:?MYSQL_CONTAINER_ID must be set}"
-mysql_packet_megabytes=128
-mysql_packet_limit="${mysql_packet_megabytes}M"
-mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot --max_allowed_packet="$mysql_packet_limit")
+mysql_packet_limit_bytes=$((128 * 1024 * 1024)) # 128M
+mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot --max_allowed_packet="$mysql_packet_limit_bytes")
 
 dump_database() {
   local database="$1"

--- a/.github/scripts/export-and-verify-sql-dumps.sh
+++ b/.github/scripts/export-and-verify-sql-dumps.sh
@@ -25,18 +25,21 @@ fi
 
 output_dir="$1"
 dump_dir="$output_dir/mysql-dump"
-mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot)
+mysql_container_id="${MYSQL_CONTAINER_ID:?MYSQL_CONTAINER_ID must be set}"
+mysql_packet_megabytes=128
+mysql_packet_limit="${mysql_packet_megabytes}M"
+mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot --max_allowed_packet="$mysql_packet_limit")
 
 dump_database() {
   local database="$1"
   local file_path="$2"
-  docker exec mysqldb mysqldump "${mysql_client_args[@]}" "$database" > "$file_path"
+  docker exec "$mysql_container_id" mysqldump "${mysql_client_args[@]}" "$database" >"$file_path"
 }
 
 import_sql_file() {
   local database="$1"
   local file_path="$2"
-  docker exec -i mysqldb mysql "${mysql_client_args[@]}" "$database" < "$file_path"
+  docker exec -i "$mysql_container_id" mysql "${mysql_client_args[@]}" "$database" <"$file_path"
 }
 
 mkdir -p "$dump_dir"
@@ -49,7 +52,7 @@ dump_database characters "$dump_dir/characters.sql"
 
 echo "Creating verification databases..."
 for database in realmd_verify characters_verify mangos_verify logs_verify; do
-  docker exec mysqldb mysql "${mysql_client_args[@]}" -e "CREATE DATABASE IF NOT EXISTS $database DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"
+  docker exec "$mysql_container_id" mysql "${mysql_client_args[@]}" -e "CREATE DATABASE IF NOT EXISTS $database DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"
 done
 
 echo "Reimporting exported dumps..."

--- a/.github/scripts/prepare-sql-test-environment.sh
+++ b/.github/scripts/prepare-sql-test-environment.sh
@@ -26,12 +26,9 @@ fi
 world_db_archive="$1"
 workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
 mysql_container_id="${MYSQL_CONTAINER_ID:?MYSQL_CONTAINER_ID must be set}"
-mysql_packet_megabytes=128
-mysql_packet_limit="${mysql_packet_megabytes}M"
-# MySQL runtime SET expects a numeric value and does not support suffixes like M.
-mysql_packet_bytes=$((mysql_packet_megabytes * 1024 * 1024))
+mysql_packet_limit_bytes=$((128 * 1024 * 1024)) # 128M
 mysqladmin_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot)
-mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot --max_allowed_packet="$mysql_packet_limit")
+mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot --max_allowed_packet="$mysql_packet_limit_bytes")
 
 import_sql_file() {
   local database="$1"
@@ -64,7 +61,7 @@ done
 echo "Database is ready!"
 
 echo "Configuring MySQL packet size..."
-docker exec "$mysql_container_id" mysql "${mysql_client_args[@]}" -e "SET GLOBAL max_allowed_packet=$mysql_packet_bytes;"
+docker exec "$mysql_container_id" mysql "${mysql_client_args[@]}" -e "SET GLOBAL max_allowed_packet=$mysql_packet_limit_bytes;"
 
 echo "Downloading base world database..."
 world_db_archive_path="$workspace/$world_db_archive.7z"

--- a/.github/scripts/prepare-sql-test-environment.sh
+++ b/.github/scripts/prepare-sql-test-environment.sh
@@ -25,12 +25,18 @@ fi
 
 world_db_archive="$1"
 workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
-mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot)
+mysql_container_id="${MYSQL_CONTAINER_ID:?MYSQL_CONTAINER_ID must be set}"
+mysql_packet_megabytes=128
+mysql_packet_limit="${mysql_packet_megabytes}M"
+# MySQL runtime SET expects a numeric value and does not support suffixes like M.
+mysql_packet_bytes=$((mysql_packet_megabytes * 1024 * 1024))
+mysqladmin_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot)
+mysql_client_args=(--host=127.0.0.1 --protocol=TCP -u root -proot --max_allowed_packet="$mysql_packet_limit")
 
 import_sql_file() {
   local database="$1"
   local file_path="$2"
-  docker exec -i mysqldb mysql "${mysql_client_args[@]}" "$database" < "$file_path"
+  docker exec -i "$mysql_container_id" mysql "${mysql_client_args[@]}" "$database" <"$file_path"
 }
 
 apply_migration_file() {
@@ -43,16 +49,10 @@ apply_migration_file() {
   fi
 }
 
-echo "Stopping preinstalled MySQL service..."
-sudo service mysql stop
-
-echo "Starting MySQL container..."
-sudo docker run --name mysqldb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:5.6 --max_allowed_packet=128M
-
 echo "Waiting for database availability..."
 max_attempts=30
 attempt=0
-until docker exec mysqldb mysqladmin "${mysql_client_args[@]}" ping --silent &> /dev/null; do
+until docker exec "$mysql_container_id" mysqladmin "${mysqladmin_client_args[@]}" ping --silent &>/dev/null; do
   attempt=$((attempt + 1))
   if [ "$attempt" -gt "$max_attempts" ]; then
     echo "Database failed to become ready in time!" >&2
@@ -63,6 +63,9 @@ until docker exec mysqldb mysqladmin "${mysql_client_args[@]}" ping --silent &> 
 done
 echo "Database is ready!"
 
+echo "Configuring MySQL packet size..."
+docker exec "$mysql_container_id" mysql "${mysql_client_args[@]}" -e "SET GLOBAL max_allowed_packet=$mysql_packet_bytes;"
+
 echo "Downloading base world database..."
 world_db_archive_path="$workspace/$world_db_archive.7z"
 curl --fail --location --silent --show-error \
@@ -72,7 +75,7 @@ curl --fail --location --silent --show-error \
 
 echo "Creating source databases..."
 for database in realmd characters mangos logs; do
-  docker exec mysqldb mysql "${mysql_client_args[@]}" -e "CREATE DATABASE IF NOT EXISTS $database DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"
+  docker exec "$mysql_container_id" mysql "${mysql_client_args[@]}" -e "CREATE DATABASE IF NOT EXISTS $database DEFAULT CHARSET utf8 COLLATE utf8_general_ci;"
 done
 
 echo "Importing schema and base data..."

--- a/.github/scripts/publish-moving-release.sh
+++ b/.github/scripts/publish-moving-release.sh
@@ -35,7 +35,7 @@ trap 'rm -f "$notes_file"' EXIT
 git fetch --force --tags origin
 previous_sha="$(git rev-parse -q --verify "refs/tags/$release_tag^{commit}" 2>/dev/null || true)"
 
-echo "## Commits" > "$notes_file"
+echo "## Commits" >"$notes_file"
 
 if [ -n "$previous_sha" ] && [ "$previous_sha" != "$GITHUB_SHA" ]; then
   git_log_args=(--reverse --format='%H%x09%s' "$previous_sha..$GITHUB_SHA")
@@ -45,13 +45,14 @@ fi
 
 git log "${git_log_args[@]}" | while IFS=$'\t' read -r commit_sha subject; do
   short_sha="${commit_sha:0:7}"
+  bullet_sha="- $short_sha"
   if [[ "$subject" =~ \(\#([0-9]+)\) ]]; then
     pr_number="${BASH_REMATCH[1]}"
-    printf -- '- %s: %s [#%s](%s/pull/%s)\n' "$short_sha" "$subject" "$pr_number" "$repo_url" "$pr_number"
+    printf '%s: %s [#%s](%s/pull/%s)\n' "$bullet_sha" "$subject" "$pr_number" "$repo_url" "$pr_number"
   else
-    printf -- '- %s: %s\n' "$short_sha" "$subject"
+    printf '%s: %s\n' "$bullet_sha" "$subject"
   fi
-done >> "$notes_file"
+done >>"$notes_file"
 
 if gh release view "$release_tag" >/dev/null 2>&1; then
   gh release delete "$release_tag" --yes

--- a/.github/workflows/development-db-dump.yaml
+++ b/.github/workflows/development-db-dump.yaml
@@ -25,15 +25,32 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    services:
+      mysql56:
+        # Public Docker Hub pulls on GitHub-hosted runners are exempt from
+        # Docker Hub rate limits:
+        # https://docs.github.com/actions/reference/limits#docker-hubs-rate-limit-for-github-actions
+        image: mysql:5.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -u root -proot --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
       - name: Prepare SQL test environment
+        env:
+          MYSQL_CONTAINER_ID: ${{ job.services.mysql56.id }}
         run: ./.github/scripts/prepare-sql-test-environment.sh "${{ env.WORLD_DB_ARCHIVE }}"
 
       - name: Export and verify MySQL dumps
+        env:
+          MYSQL_CONTAINER_ID: ${{ job.services.mysql56.id }}
         run: ./.github/scripts/export-and-verify-sql-dumps.sh "${{ github.workspace }}/database-artifacts"
 
       - name: Install SQLite conversion tools

--- a/.github/workflows/pr-sql-check.yaml
+++ b/.github/workflows/pr-sql-check.yaml
@@ -18,13 +18,30 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    services:
+      mysql56:
+        # Public Docker Hub pulls on GitHub-hosted runners are exempt from
+        # Docker Hub rate limits:
+        # https://docs.github.com/actions/reference/limits#docker-hubs-rate-limit-for-github-actions
+        image: mysql:5.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -u root -proot --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
       - name: Prepare SQL test environment
+        env:
+          MYSQL_CONTAINER_ID: ${{ job.services.mysql56.id }}
         run: ./.github/scripts/prepare-sql-test-environment.sh "${{ env.WORLD_DB_ARCHIVE }}"
 
       - name: Export and verify migrated databases
+        env:
+          MYSQL_CONTAINER_ID: ${{ job.services.mysql56.id }}
         run: ./.github/scripts/export-and-verify-sql-dumps.sh "${{ github.workspace }}/database-artifacts"


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This works around the Docker Hub rate limits encountered in this workflow run: https://github.com/vmangos/core/actions/runs/24279840969/job/70899883143

The fix moves the MySQL 5.6 container startup to a GitHub Actions service container, which should be exempt from Docker Hub rate limits according to the [GitHub docs](https://docs.github.com/en/actions/reference/limits#docker-hubs-rate-limit-for-github-actions). It's also generally a more appropriate way to handle this than the previous `docker run`.

I tested the changes end-to-end in my fork and behavior should otherwise remain the same.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
