### PR TITLE
refactor(Packet): Add ServerPacket structure

### DIFF
--- a/src/game/Battlegrounds/BattleGroundMgr.h
+++ b/src/game/Battlegrounds/BattleGroundMgr.h
@@ -70,11 +70,11 @@ enum BattleGroundQueueGroupTypes
 };
 #define BG_QUEUE_GROUP_TYPES_COUNT 4
 
-enum BattleGroundGroupJoinStatus
+enum BattleGroundGroupJoinStatus : uint32
 {
-    BG_GROUPJOIN_DESERTERS = -2,
-    BG_GROUPJOIN_FAILED = -1    // actually, any negative except 2
-                                // any other value is a MapID meaning successful join
+    BG_GROUPJOIN_DESERTERS = static_cast<uint32>(-2),
+    BG_GROUPJOIN_FAILED = static_cast<uint32>(-1) // actually, any negative except 2
+    // any other value is a MapID meaning successful join
 };
 
 class BattleGround;

--- a/src/game/Battlegrounds/BattleGroundMgr.h
+++ b/src/game/Battlegrounds/BattleGroundMgr.h
@@ -72,9 +72,9 @@ enum BattleGroundQueueGroupTypes
 
 enum BattleGroundGroupJoinStatus : uint32
 {
-    BG_GROUPJOIN_DESERTERS = static_cast<uint32>(-2),
-    BG_GROUPJOIN_FAILED = static_cast<uint32>(-1) // actually, any negative except 2
-    // any other value is a MapID meaning successful join
+    BG_GROUPJOIN_DESERTERS = 0xFFFFFFFE,
+    BG_GROUPJOIN_FAILED = 0xFFFFFFFF,
+    // any other value is a MapID (meaning successful join)
 };
 
 class BattleGround;

--- a/src/game/Commands/CharacterCommands.cpp
+++ b/src/game/Commands/CharacterCommands.cpp
@@ -2954,8 +2954,7 @@ bool ChatHandler::HandleLearnAllMyTaxisCommand(char* /*args*/)
                         if (uint32 taxiNode = sObjectMgr.GetNearestTaxiNode(data->position.x, data->position.y, data->position.z, data->position.mapId, player->GetTeam()))
                             if (player->GetTaxi().SetTaximaskNode(taxiNode))
                             {
-                                WorldPacket msg(SMSG_NEW_TAXI_PATH, 0);
-                                GetSession()->SendPacket(&msg);
+                                GetSession()->SendPacket(std::make_unique<WorldPackets::Taxi::NewTaxiPath>());
                             }
             }
     }

--- a/src/game/Commands/DebugCommands.cpp
+++ b/src/game/Commands/DebugCommands.cpp
@@ -200,7 +200,7 @@ bool ChatHandler::HandleDebugSendSpellFailCommand(char* args)
 
     WorldPacket data(SMSG_CAST_RESULT, 4 + 1 + 1);
     data << uint32(133);
-    data << uint8(2);
+    data << static_cast<uint8>(SPELL_RESULT_STATUS_FAIL);
     data << uint8(failnum);
     if (failarg1 || failarg2)
         data << uint32(failarg1);

--- a/src/game/Commands/DebugCommands.cpp
+++ b/src/game/Commands/DebugCommands.cpp
@@ -1211,7 +1211,7 @@ bool ChatHandler::HandleDebugSetValueByNameCommand(char* args)
                 break;
             }
         }
-       
+
     }
     else
         SendSysMessage("Wrong field name.");
@@ -2190,7 +2190,7 @@ bool ChatHandler::HandleDebugMonsterChatCommand(char* args)
     uint32 chatType;
     if (!ExtractUInt32(&args, chatType))
         return false;
-    
+
     std::ostringstream oss;
     oss << "Chat" << int(chatType);
     std::string rightText = oss.str();
@@ -2252,7 +2252,7 @@ bool ChatHandler::HandleDebugMonsterChatCommand(char* args)
     data << uint8(0);
     pTarget->SendMessageToSet(&data, true);
 #else // 1.11.2 client
-    
+
     if (chatType == 11 || chatType == 12 || chatType == 89 || chatType == 13 || chatType == 26)
     {
         data << uint32(strlen(pSender->GetName()) + 1);

--- a/src/game/Database/DBCStructure.h
+++ b/src/game/Database/DBCStructure.h
@@ -839,5 +839,6 @@ typedef Path<TaxiPathNodePtr,TaxiPathNodeEntry const> TaxiPathNodeList;
 typedef std::vector<TaxiPathNodeList> TaxiPathNodesByPath;
 
 #define TaxiMaskSize 8
+// TODO: Use custom struct which has std::bitset inside it
 typedef uint32 TaxiMask[TaxiMaskSize];
 #endif

--- a/src/game/GossipDef.cpp
+++ b/src/game/GossipDef.cpp
@@ -230,8 +230,7 @@ void PlayerMenu::SendGossipMenu(uint32 textId, ObjectGuid objectGuid)
 
 void PlayerMenu::CloseGossip()
 {
-    WorldPacket data(SMSG_GOSSIP_COMPLETE, 0);
-    GetMenuSession()->SendPacket(&data);
+    GetMenuSession()->SendPacket(std::make_unique<WorldPackets::Npc::GossipComplete>());
 
     //sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "WORLD: Sent SMSG_GOSSIP_COMPLETE");
 }

--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -79,7 +79,7 @@ void Roll::targetObjectBuildLink()
 //============== Group ==============================
 //===================================================
 
-Group::Group() : m_Id(0), m_leaderLastOnline(0), m_groupType(GROUPTYPE_NORMAL), 
+Group::Group() : m_Id(0), m_leaderLastOnline(0), m_groupType(GROUPTYPE_NORMAL),
                  m_bgGroup(nullptr), m_lootMethod(FREE_FOR_ALL), m_lootThreshold(ITEM_QUALITY_UNCOMMON),
                  m_subGroupsCounts(nullptr), m_groupTeam(TEAM_NONE), m_LFGAreaId(0)
 {
@@ -454,18 +454,25 @@ uint32 Group::RemoveMember(ObjectGuid guid, uint8 removeMethod)
                 }, 1);
             }
 
-            WorldPacket data;
-
             if (removeMethod == GROUP_KICK)
             {
-                data.Initialize(SMSG_GROUP_UNINVITE, 0);
-                player->GetSession()->SendPacket(&data);
+                player->GetSession()->SendPacket(std::make_unique<WorldPackets::Group::GroupUninviteNotification>());
 
                 if (IsInLFG())
                 {
-                    data.Initialize(SMSG_MEETINGSTONE_SETQUEUE, 5);
-                    data << 0 << uint8(MEETINGSTONE_STATUS_PARTY_MEMBER_REMOVED_PARTY_REMOVED);
+                    WorldPackets::Misc::MeetingstoneSetQueue packet;
+                    packet.areaId = 0;
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_4_2
+                    packet.idempotencyToken = 0;
+#else
+                    packet.status = MEETINGSTONE_STATUS_PARTY_MEMBER_REMOVED_PARTY_REMOVED;
+#endif
+                    // TODO Use broadcaster which does the binary conversion automatically
+                    WorldPacket data;
+                    data.SetOpcode(packet.GetOpcode());
+                    packet.AppendBodyTo(data);
                     BroadcastPacket(&data, true);
+
                     leftGroup = true;
                     sWorld.GetLFGQueue().GetMessager().AddMessage([groupId = GetId()](LFGQueue* queue)
                     {
@@ -485,8 +492,17 @@ uint32 Group::RemoveMember(ObjectGuid guid, uint8 removeMethod)
 
                 if (!leaderChanged)
                 {
-                    data.Initialize(SMSG_MEETINGSTONE_SETQUEUE, 5);
-                    data << m_LFGAreaId << uint8(MEETINGSTONE_STATUS_PARTY_MEMBER_LEFT_LFG);
+                    WorldPackets::Misc::MeetingstoneSetQueue packet;
+                    packet.areaId = m_LFGAreaId;
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_4_2
+                    packet.idempotencyToken = 0;
+#else
+                    packet.status = MEETINGSTONE_STATUS_PARTY_MEMBER_LEFT_LFG;
+#endif
+                    // TODO Use broadcaster which does the binary conversion automatically
+                    WorldPacket data;
+                    data.SetOpcode(packet.GetOpcode());
+                    packet.AppendBodyTo(data);
                     BroadcastPacket(&data, true);
                 }
             }
@@ -496,6 +512,7 @@ uint32 Group::RemoveMember(ObjectGuid guid, uint8 removeMethod)
                 group->SendUpdate();
             else
             {
+                WorldPacket data;
                 data.Initialize(SMSG_GROUP_LIST, 24);
                 data << uint64(0) << uint64(0) << uint64(0);
                 player->GetSession()->SendPacket(&data);
@@ -580,8 +597,7 @@ void Group::Disband(bool hideDestroy, ObjectGuid initiator)
         WorldPacket data;
         if (!hideDestroy)
         {
-            data.Initialize(SMSG_GROUP_DESTROYED, 0);
-            player->GetSession()->SendPacket(&data);
+            player->GetSession()->SendPacket(std::make_unique<WorldPackets::Group::GroupDestroyed>());
         }
 
         //we already removed player from group and in player->GetGroup() is his original group, send update
@@ -756,13 +772,18 @@ bool Group::FillPremadeLFG(ObjectGuid const& plrGuid, Classes playerClass, LfgRo
 
 void Group::SendLootStartRoll(uint32 CountDown, Roll const& r)
 {
-    WorldPacket data(SMSG_LOOT_START_ROLL, (8 + 4 + 4 + 4 + 4 + 4));
-    data << r.lootedTargetGUID;                             // creature guid what we're looting
-    data << uint32(r.itemSlot);                             // item slot in loot
-    data << uint32(r.itemid);                               // the itemEntryId for the item that shall be rolled for
-    data << uint32(0);                                      // randomSuffix - not used ?
-    data << uint32(r.itemRandomPropId);                     // item random property ID
-    data << uint32(CountDown);                              // the countdown time to choose "need" or "greed"
+    auto packet = std::make_unique<WorldPackets::Loot::LootStartRoll>();
+    packet->lootedTargetGuid = r.lootedTargetGUID;
+    packet->itemSlot = r.itemSlot;
+    packet->itemEntryId = r.itemid;
+    packet->randomSuffix = 0;
+    packet->itemRandomPropId = r.itemRandomPropId;
+    packet->countdownTime = CountDown;
+
+    // TODO Use broadcaster which does the binary conversion automatically
+    WorldPacket data;
+    data.SetOpcode(packet->GetOpcode());
+    packet->AppendBodyTo(data);
 
     for (const auto& itr : r.playerVote)
     {
@@ -779,15 +800,20 @@ void Group::SendLootStartRoll(uint32 CountDown, Roll const& r)
 
 void Group::SendLootRoll(ObjectGuid const& targetGuid, uint8 rollNumber, uint8 rollType, Roll const& r)
 {
-    WorldPacket data(SMSG_LOOT_ROLL, (8 + 4 + 8 + 4 + 4 + 4 + 1 + 1));
-    data << r.lootedTargetGUID;                             // creature guid that we're looting
-    data << uint32(r.itemSlot);
-    data << targetGuid;                                     // player guid
-    data << uint32(r.itemid);                               // the itemEntryId for the item that shall be rolled for
-    data << uint32(0);                                      // randomSuffix - not used?
-    data << uint32(r.itemRandomPropId);                     // Item random property ID
-    data << uint8(rollNumber);                              // 0: "Need for: [item name]" > 127: "you passed on: [item name]"      Roll number
-    data << uint8(rollType);                                // 0: "Need for: [item name]" 0: "You have selected need for [item name] 1: need roll 2: greed roll
+    auto packet = std::make_unique<WorldPackets::Loot::LootRollResponse>();
+    packet->lootedTargetGuid = r.lootedTargetGUID;
+    packet->itemSlot = r.itemSlot;
+    packet->rollerGuid = targetGuid;
+    packet->itemEntryId = r.itemid;
+    packet->randomSuffix = 0;
+    packet->itemRandomPropId = r.itemRandomPropId;
+    packet->rollNumber = rollNumber;
+    packet->rollType = rollType;
+
+    // TODO Use broadcaster which does the binary conversion automatically
+    WorldPacket data;
+    data.SetOpcode(packet->GetOpcode());
+    packet->AppendBodyTo(data);
 
     for (const auto& itr : r.playerVote)
     {
@@ -802,15 +828,20 @@ void Group::SendLootRoll(ObjectGuid const& targetGuid, uint8 rollNumber, uint8 r
 
 void Group::SendLootRollWon(ObjectGuid const& targetGuid, uint8 rollNumber, RollVote rollType, Roll const& r)
 {
-    WorldPacket data(SMSG_LOOT_ROLL_WON, (8 + 4 + 4 + 4 + 4 + 8 + 1 + 1));
-    data << r.lootedTargetGUID;                             // creature guid what we're looting
-    data << uint32(r.itemSlot);                             // item slot in loot
-    data << uint32(r.itemid);                               // the itemEntryId for the item that shall be rolled for
-    data << uint32(0);                                      // randomSuffix - not used ?
-    data << uint32(r.itemRandomPropId);                     // Item random property
-    data << targetGuid;                                     // guid of the player who won.
-    data << uint8(rollNumber);                              // rollnumber related to SMSG_LOOT_ROLL
-    data << uint8(rollType);                                // Rolltype related to SMSG_LOOT_ROLL
+    auto packet = std::make_unique<WorldPackets::Loot::LootRollWon>();
+    packet->lootedTargetGuid = r.lootedTargetGUID;
+    packet->itemSlot = r.itemSlot;
+    packet->itemEntryId = r.itemid;
+    packet->randomSuffix = 0;
+    packet->itemRandomPropId = r.itemRandomPropId;
+    packet->winnerGuid = targetGuid;
+    packet->rollNumber = rollNumber;
+    packet->rollType = uint8(rollType);
+
+    // TODO Use broadcaster which does the binary conversion automatically
+    WorldPacket data;
+    data.SetOpcode(packet->GetOpcode());
+    packet->AppendBodyTo(data);
 
     for (const auto& itr : r.playerVote)
     {
@@ -825,12 +856,17 @@ void Group::SendLootRollWon(ObjectGuid const& targetGuid, uint8 rollNumber, Roll
 
 void Group::SendLootAllPassed(Roll const& r)
 {
-    WorldPacket data(SMSG_LOOT_ALL_PASSED, (8 + 4 + 4 + 4 + 4));
-    data << r.lootedTargetGUID;                             // creature guid what we're looting
-    data << uint32(r.itemSlot);                             // item slot in loot
-    data << uint32(r.itemid);                               // The itemEntryId for the item that shall be rolled for
-    data << uint32(r.itemRandomPropId);                     // Item random property ID
-    data << uint32(0);                                      // Item random suffix ID - not used ?
+    auto packet = std::make_unique<WorldPackets::Loot::LootAllPassed>();
+    packet->lootedTargetGuid = r.lootedTargetGUID;
+    packet->itemSlot = r.itemSlot;
+    packet->itemEntryId = r.itemid;
+    packet->itemRandomPropId = r.itemRandomPropId;
+    packet->randomSuffixId = 0;
+
+    // TODO Use broadcaster which does the binary conversion automatically
+    WorldPacket data;
+    data.SetOpcode(packet->GetOpcode());
+    packet->AppendBodyTo(data);
 
     for (const auto& itr : r.playerVote)
     {
@@ -1057,15 +1093,15 @@ void Group::SendLootStartRollsForPlayer(Player* pPlayer)
             if (!countDown)
                 continue;
 
-            WorldPacket data(SMSG_LOOT_START_ROLL, (8 + 4 + 4 + 4 + 4 + 4));
-            data << roll->lootedTargetGUID;                   // creature guid what we're looting
-            data << uint32(roll->itemSlot);                   // item slot in loot
-            data << uint32(roll->itemid);                     // the itemEntryId for the item that shall be rolled for
-            data << uint32(0);                                // randomSuffix - not used ?
-            data << uint32(roll->itemRandomPropId);           // item random property ID
-            data << uint32(countDown);                        // the countdown time to choose "need" or "greed"
+            auto packet = std::make_unique<WorldPackets::Loot::LootStartRoll>();
+            packet->lootedTargetGuid = roll->lootedTargetGUID;
+            packet->itemSlot = roll->itemSlot;
+            packet->itemEntryId = roll->itemid;
+            packet->randomSuffix = 0;
+            packet->itemRandomPropId = roll->itemRandomPropId;
+            packet->countdownTime = countDown;
 
-            pPlayer->GetSession()->SendPacket(&data);
+            pPlayer->GetSession()->SendPacket(std::move(packet));
         }
     }
 }
@@ -1250,10 +1286,14 @@ void Group::SetTargetIcon(uint8 id, ObjectGuid targetGuid)
     m_targetIcons[id] = targetGuid;
 
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2
-    WorldPacket data(MSG_RAID_TARGET_UPDATE, (1 + 1 + 8));
-    data << uint8(0); // 1 - full icon list, 0 - delta update
-    data << uint8(id);
-    data << targetGuid;
+    WorldPackets::Group::RaidTargetUpdateDelta deltaPacket;
+    deltaPacket.iconId = id;
+    deltaPacket.targetGuid = targetGuid;
+
+    // TODO Use broadcaster which does the binary conversion automatically
+    WorldPacket data;
+    data.SetOpcode(deltaPacket.GetOpcode());
+    deltaPacket.AppendBodyTo(data);
     BroadcastPacket(&data, true);
 #endif
 }
@@ -1347,7 +1387,7 @@ void Group::SendUpdate()
                 markedTargets = std::make_unique<WorldPacket>(MSG_RAID_TARGET_UPDATE, (1 + TARGET_ICON_COUNT * 9));
                 *markedTargets << uint8(1); // 1 - full icon list, 0 - delta update
             }
-                
+
             *markedTargets << uint8(i);
             *markedTargets << m_targetIcons[i];
         }

--- a/src/game/Group/Group.h
+++ b/src/game/Group/Group.h
@@ -40,6 +40,7 @@ class Map;
 class BattleGround;
 class DungeonPersistentState;
 class Field;
+class Creature;
 class Unit;
 struct LFGGroupQueueInfo;
 
@@ -287,7 +288,7 @@ class Group
 
         void ChangeMembersGroup(ObjectGuid guid, uint8 group);
         void ChangeMembersGroup(Player* player, uint8 group);
-        
+
         void SwapMembersGroup(ObjectGuid guid, ObjectGuid swapGuid);
         void SwapMembersGroup(Player* player, Player* swapPlayer);
 

--- a/src/game/Guild/Guild.cpp
+++ b/src/game/Guild/Guild.cpp
@@ -811,7 +811,7 @@ void Guild::Roster(WorldSession* session /*= nullptr*/)
         if (spaceLeft <= 0)
             break;
         count++;
-        
+
         if (Player* pl = ObjectAccessor::FindPlayer(ObjectGuid(HIGHGUID_PLAYER, itr.first)))
         {
             data << pl->GetObjectGuid();

--- a/src/game/Guild/GuildMgr.h
+++ b/src/game/Guild/GuildMgr.h
@@ -108,7 +108,7 @@ public:
     void SetTeam(Team team) { m_team = team; }
 
     uint8 GetSignatureCount() const { return static_cast<uint8>(m_signatures.size()); }
-    const PetitionSignatureList& GetSignatureList() { return m_signatures; }
+    const PetitionSignatureList& GetSignatureList() const { return m_signatures; }
 
     void BuildSignatureData(WorldPacket& data) const;
 
@@ -146,7 +146,7 @@ public:
 
     void SaveToDB();
 
-    ObjectGuid const& GetSignatureGuid() { return m_playerGuid; }
+    ObjectGuid const& GetSignatureGuid() const { return m_playerGuid; }
     uint32 GetSignatureAccountId() const { return m_playerAccount; }
 
 private:

--- a/src/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/game/Handlers/AuctionHouseHandler.cpp
@@ -60,10 +60,10 @@ void WorldSession::SendAuctionHello(Unit* unit)
     // always return pointer
     AuctionHouseEntry const* ahEntry = AuctionHouseMgr::GetAuctionHouseEntry(unit);
 
-    WorldPacket data(MSG_AUCTION_HELLO, 12);
-    data << unit->GetObjectGuid();
-    data << uint32(ahEntry->houseId);
-    SendPacket(&data);
+    auto helloResponse = std::make_unique<WorldPackets::AuctionHouse::AuctionHelloResponse>();
+    helloResponse->auctioneerGuid = unit->GetObjectGuid();
+    helloResponse->houseId = ahEntry->houseId;
+    SendPacket(std::move(helloResponse));
 }
 
 // call this method when player bids, creates, or deletes auction
@@ -98,60 +98,50 @@ void WorldSession::SendAuctionCommandResult(AuctionEntry* auc, AuctionAction Act
 // this function sends notification, if bidder is online
 void WorldSession::SendAuctionBidderNotification(AuctionEntry* auction, bool won)
 {
-    WorldPacket data(SMSG_AUCTION_BIDDER_NOTIFICATION, (8 * 4));
-    data << uint32(auction->GetHouseId());
-    data << uint32(auction->Id);
-    data << ObjectGuid(HIGHGUID_PLAYER, auction->bidder);
-
+    auto notification = std::make_unique<WorldPackets::AuctionHouse::AuctionBidderNotification>();
+    notification->houseId = auction->GetHouseId();
+    notification->auctionId = auction->Id;
+    notification->bidderGuid = ObjectGuid(HIGHGUID_PLAYER, auction->bidder);
     // if 0, client shows ERR_AUCTION_WON_S, else ERR_AUCTION_OUTBID_S
-    data << uint32(won ? 0 : auction->bid);
-    data << uint32(auction->GetAuctionOutBid());            // AuctionOutBid?
-    data << uint32(auction->itemTemplate);
+    notification->bidOrZero = won ? 0 : auction->bid;
+    notification->outBid = auction->GetAuctionOutBid();
+    notification->itemTemplate = auction->itemTemplate;
 
     Item *item = sAuctionMgr.GetAItem(auction->itemGuidLow);
-    uint32 randomId = item ? item->GetItemRandomPropertyId() : 0;
+    notification->randomPropertyId = item ? item->GetItemRandomPropertyId() : 0;
 
-    data << uint32(randomId);                               // random property (value > 0) or suffix (value < 0)
-
-    SendPacket(&data);
+    SendPacket(std::move(notification));
 }
 
 // this void causes on client to display: "Your auction sold"
 void WorldSession::SendAuctionOwnerNotification(AuctionEntry* auction, bool sold)
 {
-    WorldPacket data(SMSG_AUCTION_OWNER_NOTIFICATION, (7 * 4));
-    data << uint32(auction->Id);
-    data << uint32(auction->bid);                           // if 0, client shows ERR_AUCTION_EXPIRED_S, else ERR_AUCTION_SOLD_S (works only when guid==0)
-    data << uint32(auction->GetAuctionOutBid());            // AuctionOutBid?
+    auto notification = std::make_unique<WorldPackets::AuctionHouse::AuctionOwnerNotification>();
+    notification->auctionId = auction->Id;
+    notification->bid = auction->bid;
+    notification->outBid = auction->GetAuctionOutBid();
 
-    ObjectGuid guid = ObjectGuid();
     if (!sold)                                               // not sold yet
-        guid = ObjectGuid(HIGHGUID_PLAYER, auction->bidder);// bidder==0 and !sold for expired auctions, so it will show error message properly
+        notification->bidderGuid = ObjectGuid(HIGHGUID_PLAYER, auction->bidder);
 
-    // if guid!=0, client updates auctions with new bid, outbid and bidderGuid, else it shows error messages as described above
-    data << guid;                                           // bidder guid
-    data << uint32(auction->itemTemplate);                  // item entry
+    notification->itemTemplate = auction->itemTemplate;
 
     Item *item = sAuctionMgr.GetAItem(auction->itemGuidLow);
-    uint32 randomId = item ? item->GetItemRandomPropertyId() : 0;
+    notification->randomPropertyId = item ? item->GetItemRandomPropertyId() : 0;
 
-    data << uint32(randomId);                               // random property (value > 0) or suffix (value < 0)
-    SendPacket(&data);
+    SendPacket(std::move(notification));
 }
 
 // shows ERR_AUCTION_REMOVED_S
 void WorldSession::SendAuctionRemovedNotification(AuctionEntry* auction)
 {
-    WorldPacket data(SMSG_AUCTION_REMOVED_NOTIFICATION, (3 * 4));
-    data << uint32(auction->Id);
-    data << uint32(auction->itemTemplate);
-
     Item *item = sAuctionMgr.GetAItem(auction->itemGuidLow);
-    uint32 randomId = item ? item->GetItemRandomPropertyId() : 0;
 
-    data << uint32(randomId);                               // random property (value > 0) or suffix (value < 0)
-
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::AuctionHouse::AuctionRemovedNotification>();
+    packet->auctionId = auction->Id;
+    packet->itemTemplate = auction->itemTemplate;
+    packet->randomPropertyId = item ? item->GetItemRandomPropertyId() : 0;
+    SendPacket(std::move(packet));
 }
 
 // this function sends mail to old bidder

--- a/src/game/Handlers/BattleGroundHandler.cpp
+++ b/src/game/Handlers/BattleGroundHandler.cpp
@@ -175,9 +175,9 @@ void WorldSession::RequestBgJoinQueue(ObjectGuid battlemaster, uint32 instanceId
         if (!_player->CanJoinToBattleground())
         {
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_4_2
-            WorldPacket data(SMSG_GROUP_JOINED_BATTLEGROUND, 4);
-            data << uint32(0xFFFFFFFE);
-            _player->GetSession()->SendPacket(&data);
+            auto bgPacket = std::make_unique<WorldPackets::Battleground::GroupJoinedBattleground>();
+            bgPacket->result = BG_GROUPJOIN_DESERTERS;
+            _player->GetSession()->SendPacket(std::move(bgPacket));
 #endif
             return;
         }
@@ -220,9 +220,9 @@ void WorldSession::RequestBgJoinQueue(ObjectGuid battlemaster, uint32 instanceId
 
         if (err == BG_JOIN_ERR_GROUP_DESERTER)
         {
-            WorldPacket data;
-            sBattleGroundMgr.BuildGroupJoinedBattlegroundPacket(&data, BG_GROUPJOIN_DESERTERS);
-            _player->GetSession()->SendPacket(&data);
+            auto bgJoined = std::make_unique<WorldPackets::Battleground::GroupJoinedBattleground>();
+            bgJoined->result = BG_GROUPJOIN_DESERTERS;
+            _player->GetSession()->SendPacket(std::move(bgJoined));
             SendBattleGroundJoinError(err);
             return;
         }
@@ -246,9 +246,9 @@ void WorldSession::RequestBgJoinQueue(ObjectGuid battlemaster, uint32 instanceId
 
             if (std::find(excludedMembers.begin(), excludedMembers.end(), member->GetGUIDLow()) != excludedMembers.end())
             {
-                WorldPacket data;
-                sBattleGroundMgr.BuildGroupJoinedBattlegroundPacket(&data, BG_GROUPJOIN_FAILED);
-                member->GetSession()->SendPacket(&data);
+                auto bgJoined = std::make_unique<WorldPackets::Battleground::GroupJoinedBattleground>();
+                bgJoined->result = BG_GROUPJOIN_FAILED;
+                member->GetSession()->SendPacket(std::move(bgJoined));
                 SendBattleGroundJoinError(err);
                 continue;
             }
@@ -260,8 +260,9 @@ void WorldSession::RequestBgJoinQueue(ObjectGuid battlemaster, uint32 instanceId
             // send status packet (in queue)
             sBattleGroundMgr.BuildBattleGroundStatusPacket(&data, bg, queueSlot, STATUS_WAIT_QUEUE, avgTime, 0);
             member->GetSession()->SendPacket(&data);
-            sBattleGroundMgr.BuildGroupJoinedBattlegroundPacket(&data, bg->GetMapId());
-            member->GetSession()->SendPacket(&data);
+            auto bgJoined = std::make_unique<WorldPackets::Battleground::GroupJoinedBattleground>();
+            bgJoined->result = bg->GetMapId();
+            member->GetSession()->SendPacket(std::move(bgJoined));
             sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Battleground: player joined queue for bg queue type %u bg type %u: GUID %u, NAME %s", bgQueueTypeId, bgTypeId, member->GetGUIDLow(), member->GetName());
         }
         sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Battleground: group end");
@@ -426,9 +427,9 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPackets::Battleground::Battl
         {
             //send bg command result to show nice message
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_4_2
-            WorldPacket data2(SMSG_GROUP_JOINED_BATTLEGROUND, 4);
-            data2 << uint32(0xFFFFFFFE);
-            _player->GetSession()->SendPacket(&data2);
+            auto bgJoined = std::make_unique<WorldPackets::Battleground::GroupJoinedBattleground>();
+            bgJoined->result = BG_GROUPJOIN_DESERTERS;
+            _player->GetSession()->SendPacket(std::move(bgJoined));
 #endif
             action = 0;
             sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Battleground: player %s (%u) has a deserter debuff, do not port him to battleground!", _player->GetName(), _player->GetGUIDLow());

--- a/src/game/Handlers/ChannelHandler.cpp
+++ b/src/game/Handlers/ChannelHandler.cpp
@@ -29,10 +29,10 @@ void WorldSession::HandleJoinChannelOpcode(WorldPackets::Channel::JoinChannel co
     // Channel name must begin with a letter.
     if (packet.channelName.empty() || (uint8(packet.channelName[0]) <= 127 && !isalpha(packet.channelName[0])))
     {
-        WorldPacket data(SMSG_CHANNEL_NOTIFY, 1 + packet.channelName.size() + 1);
-        data << uint8(CHAT_INVALID_NAME_NOTICE);
-        data << packet.channelName;
-        SendPacket(&data);
+        auto notifyPacket = std::make_unique<WorldPackets::Channel::ChannelNotify>();
+        notifyPacket->type = CHAT_INVALID_NAME_NOTICE;
+        notifyPacket->channelName = packet.channelName;
+        SendPacket(std::move(notifyPacket));
         return;
     }
 

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -184,7 +184,11 @@ void WorldSession::HandleCharEnumOpcode(NullClientPacket const& /*packet*/)
 
 void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate const& packet)
 {
-    WorldPacket data(SMSG_CHAR_CREATE, 1);                  // returned with diff.values in all cases
+    auto sendResponse = [this](uint8 result) {
+        auto response = std::make_unique<WorldPackets::Character::CharCreateResponse>();
+        response->result = result;
+        SendPacket(std::move(response));
+    };
 
     if (GetSecurity() == SEC_PLAYER)
     {
@@ -205,8 +209,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
 
             if (disabled)
             {
-                data << (uint8)CHAR_CREATE_DISABLED;
-                SendPacket(&data);
+                sendResponse(CHAR_CREATE_DISABLED);
                 return;
             }
         }
@@ -217,8 +220,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
 
     if (!classEntry || !raceEntry)
     {
-        data << (uint8)CHAR_CREATE_FAILED;
-        SendPacket(&data);
+        sendResponse(CHAR_CREATE_FAILED);
         std::stringstream oss;
         oss << "Attempt to create character of invalid Class (" << int(packet.class_) << ") or Race (" << int(packet.race) << ")";
         ProcessAnticheatAction("PassiveAnticheat", oss.str().c_str(), CHEAT_ACTION_LOG);
@@ -227,8 +229,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
 
     if (raceEntry->HasFlag(CHRRACES_FLAGS_NOT_PLAYABLE))
     {
-        data << (uint8)CHAR_CREATE_DISABLED;
-        SendPacket(&data);
+        sendResponse(CHAR_CREATE_DISABLED);
         std::stringstream oss;
         oss << "Attempt to create character of non-playable Race (" << int(packet.race) << ")";
         ProcessAnticheatAction("PassiveAnticheat", oss.str().c_str(), CHEAT_ACTION_LOG);
@@ -237,8 +238,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
 
     if (!Player::ValidateAppearance(packet.race, packet.gender, packet.hairStyle, packet.hairColor, packet.face, packet.facialHair, packet.skin))
     {
-        data << (uint8)CHAR_CREATE_FAILED;
-        SendPacket(&data);
+        sendResponse(CHAR_CREATE_FAILED);
         ProcessAnticheatAction("PassiveAnticheat", "Attempt to create character with invalid appearance attributes", CHEAT_ACTION_LOG);
         return;
     }
@@ -248,8 +248,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
     // prevent character creating with invalid name
     if (!normalizePlayerName(safeName))
     {
-        data << (uint8)CHAR_NAME_NO_NAME;
-        SendPacket(&data);
+        sendResponse(CHAR_NAME_NO_NAME);
         ProcessAnticheatAction("PassiveAnticheat", "Attempt to create character with invalid name", CHEAT_ACTION_LOG);
         return;
     }
@@ -258,29 +257,25 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
     uint8 res = ObjectMgr::CheckPlayerName(safeName, true);
     if (res != CHAR_NAME_SUCCESS)
     {
-        data << uint8(res);
-        SendPacket(&data);
+        sendResponse(res);
         return;
     }
 
     if (GetSecurity() == SEC_PLAYER && sObjectMgr.IsReservedName(safeName))
     {
-        data << (uint8)CHAR_NAME_RESERVED;
-        SendPacket(&data);
+        sendResponse(CHAR_NAME_RESERVED);
         return;
     }
 
     if (sObjectMgr.GetPlayerGuidByName(safeName))
     {
-        data << (uint8)CHAR_CREATE_NAME_IN_USE;
-        SendPacket(&data);
+        sendResponse(CHAR_CREATE_NAME_IN_USE);
         return;
     }
 
     if (m_charactersCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM))
     {
-        data << (uint8)CHAR_CREATE_SERVER_LIMIT;
-        SendPacket(&data);
+        sendResponse(CHAR_CREATE_SERVER_LIMIT);
         return;
     }
 
@@ -304,8 +299,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
             {
                 if (acc_race == 0 || Player::TeamForRace(acc_race) != team_)
                 {
-                    data << (uint8)CHAR_CREATE_PVP_TEAMS_VIOLATION;
-                    SendPacket(&data);
+                    sendResponse(CHAR_CREATE_PVP_TEAMS_VIOLATION);
                     return;
                 }
             }
@@ -319,18 +313,22 @@ void WorldSession::HandleCharCreateOpcode(WorldPackets::Character::CharCreate co
 
         LoginDatabase.PExecute("REPLACE INTO `realmcharacters` (`numchars`, `acctid`, `realmid`) VALUES (%u, %u, %u)", m_charactersCount, GetAccountId(), realmID);
 
-        data << (uint8)CHAR_CREATE_SUCCESS;
-        SendPacket(&data);
+        sendResponse(CHAR_CREATE_SUCCESS);
     }
     else
     {
-        data << (uint8)CHAR_CREATE_ERROR;
-        SendPacket(&data);
+        sendResponse(CHAR_CREATE_ERROR);
     }
 }
 
 void WorldSession::HandleCharDeleteOpcode(WorldPackets::Character::CharDelete const& packet)
 {
+    auto sendResponse = [this](uint8 result) {
+        auto response = std::make_unique<WorldPackets::Character::CharDeleteResponse>();
+        response->result = result;
+        SendPacket(std::move(response));
+    };
+
     // can't delete loaded character
     if (ObjectAccessor::FindPlayerNotInWorld(packet.guid))
         return;
@@ -341,9 +339,7 @@ void WorldSession::HandleCharDeleteOpcode(WorldPackets::Character::CharDelete co
     // is guild leader
     if (sGuildMgr.GetGuildByLeader(packet.guid))
     {
-        WorldPacket data(SMSG_CHAR_DELETE, 1);
-        data << (uint8)CHAR_DELETE_FAILED;
-        SendPacket(&data);
+        sendResponse(CHAR_DELETE_FAILED);
         return;
     }
 
@@ -368,9 +364,7 @@ void WorldSession::HandleCharDeleteOpcode(WorldPackets::Character::CharDelete co
 
     Player::DeleteFromDB(packet.guid, GetAccountId());
 
-    WorldPacket data(SMSG_CHAR_DELETE, 1);
-    data << (uint8)CHAR_DELETE_SUCCESS;
-    SendPacket(&data);
+    sendResponse(CHAR_DELETE_SUCCESS);
 }
 
 void WorldSession::HandlePlayerLoginOpcode(WorldPackets::Character::PlayerLogin const& packet)
@@ -378,9 +372,9 @@ void WorldSession::HandlePlayerLoginOpcode(WorldPackets::Character::PlayerLogin 
     if ((!sWorld.getConfig(CONFIG_BOOL_WORLD_AVAILABLE) && GetSecurity() == SEC_PLAYER) ||
         PlayerLoading() || GetPlayer() != nullptr || !packet.guid.IsPlayer())
     {
-        WorldPacket data(SMSG_CHARACTER_LOGIN_FAILED, 1);
-        data << (uint8)1;
-        SendPacket(&data);
+        auto loginFailedPacket = std::make_unique<WorldPackets::Character::CharacterLoginFailed>();
+        loginFailedPacket->result = 1;
+        SendPacket(std::move(loginFailedPacket));
         return;
     }
 
@@ -518,24 +512,13 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder *holder)
 
     sObjectAccessor.AddObject(m_masterPlayer);
 
-    WorldPacket data(SMSG_LOGIN_VERIFY_WORLD, 20);
-    data << pCurrChar->GetMapId();
-    if (pCurrChar->GetTransport())
-    {
-        Position const& transportPosition = pCurrChar->m_movementInfo.GetTransportPos();
-        data << transportPosition.x;
-        data << transportPosition.y;
-        data << transportPosition.z;
-        data << transportPosition.o;
-    }
-    else
-    {
-        data << pCurrChar->GetPositionX();
-        data << pCurrChar->GetPositionY();
-        data << pCurrChar->GetPositionZ();
-        data << pCurrChar->GetOrientation();
-    }
-    SendPacket(&data);
+    Position const& position = pCurrChar->GetTransport()
+                             ? pCurrChar->m_movementInfo.GetTransportPos()
+                             : pCurrChar->GetPosition();
+
+    auto loginVerifyWorld = std::make_unique<WorldPackets::Character::LoginVerifyWorld>();
+    loginVerifyWorld->location = position.WithMapId(pCurrChar->GetMapId());
+    SendPacket(std::move(loginVerifyWorld));
 
     // load player specific part before send times
     LoadAccountData(holder->TakeResult(PLAYER_LOGIN_QUERY_LOADACCOUNTDATA), NewAccountData::PER_CHARACTER_CACHE_MASK);

--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -767,21 +767,19 @@ void WorldSession::HandleChatIgnoredOpcode(WorldPackets::Misc::ChatIgnored const
 
 void WorldSession::SendPlayerNotFoundNotice(std::string const& name)
 {
-    WorldPacket data(SMSG_CHAT_PLAYER_NOT_FOUND, name.size() + 1);
-    data << name;
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Chat::ChatPlayerNotFound>();
+    packet->name = name;
+    SendPacket(std::move(packet));
 }
 
 void WorldSession::SendWrongFactionNotice()
 {
-    WorldPacket data(SMSG_CHAT_WRONG_FACTION, 0);
-    SendPacket(&data);
+    SendPacket(std::make_unique<WorldPackets::Chat::ChatWrongFaction>());
 }
 
 void WorldSession::SendChatRestrictedNotice()
 {
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
-    WorldPacket data(SMSG_CHAT_RESTRICTED, 0);
-    SendPacket(&data);
+    SendPacket(std::make_unique<WorldPackets::Chat::ChatRestricted>());
 #endif
 }

--- a/src/game/Handlers/CombatHandler.cpp
+++ b/src/game/Handlers/CombatHandler.cpp
@@ -89,15 +89,12 @@ void WorldSession::HandleSetSheathedOpcode(WorldPackets::Combat::SetSheathed con
 
 void WorldSession::SendAttackStop(Unit const* enemy)
 {
-#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
-    WorldPacket data(SMSG_ATTACKSTOP, (4 + 20));            // we guess size
-    data << GetPlayer()->GetPackGUID();
-    data << (enemy ? enemy->GetPackGUID() : PackedGuid());  // must be packed guid
-#else
-    WorldPacket data(SMSG_ATTACKSTOP);
-    data << GetPlayer()->GetGUID();
-    data << (enemy ? enemy->GetGUID() : uint64());
-#endif
-    data << uint32(0);                                      // unk, can be 1 also
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Combat::AttackStop>();
+    packet->attackerGuid = GetPlayer()->GetObjectGuid();
+    if (enemy)
+    {
+        packet->victimGuid = enemy->GetObjectGuid();
+        packet->isDead = enemy->IsDead();
+    }
+    SendPacket(std::move(packet));
 }

--- a/src/game/Handlers/GMTicketHandler.cpp
+++ b/src/game/Handlers/GMTicketHandler.cpp
@@ -65,18 +65,18 @@ void WorldSession::HandleGMTicketUpdateTextOpcode(WorldPackets::GmTicket::GmTick
         }
     }
 
-    WorldPacket data(SMSG_GMTICKET_UPDATETEXT, 4);
-    data << uint32(response);
-    SendPacket(&data);
+    auto responsePacket = std::make_unique<WorldPackets::GmTicket::GmTicketUpdateTextResponse>();
+    responsePacket->response = response;
+    SendPacket(std::move(responsePacket));
 }
 
 void WorldSession::HandleGMTicketDeleteTicketOpcode(NullClientPacket const& /*packet*/)
 {
     if (GmTicket* ticket = sTicketMgr->GetTicketByPlayer(GetPlayer()->GetGUID()))
     {
-        WorldPacket data(SMSG_GMTICKET_DELETETICKET, 4);
-        data << uint32(GMTICKET_RESPONSE_TICKET_DELETED);
-        SendPacket(&data);
+        auto packet = std::make_unique<WorldPackets::GmTicket::GmTicketDeleteTicketResponse>();
+        packet->response = GMTICKET_RESPONSE_TICKET_DELETED;
+        SendPacket(std::move(packet));
 
         sWorld.SendGMTicketText(LANG_COMMAND_TICKETPLAYERABANDON, GetPlayer()->GetName(), ticket->GetId());
 
@@ -125,18 +125,18 @@ void WorldSession::HandleGMTicketCreateOpcode(WorldPackets::GmTicket::GmTicketCr
         response = GMTICKET_RESPONSE_CREATE_SUCCESS;
     }
 
-    WorldPacket data(SMSG_GMTICKET_CREATE, 4);
-    data << uint32(response);
-    SendPacket(&data);
+    auto responsePacket = std::make_unique<WorldPackets::GmTicket::GmTicketCreateResponse>();
+    responsePacket->response = response;
+    SendPacket(std::move(responsePacket));
 }
 
 void WorldSession::HandleGMTicketSystemStatusOpcode(NullClientPacket const& /*packet*/)
 {
     // Note: This only disables the ticket UI at client side and is not fully reliable
     // are we sure this is a uint32? Should ask Zor
-    WorldPacket data(SMSG_GMTICKET_SYSTEMSTATUS, 4);
-    data << uint32(sTicketMgr->GetStatus() ? GMTICKET_QUEUE_STATUS_ENABLED : GMTICKET_QUEUE_STATUS_DISABLED);
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::GmTicket::GmTicketSystemStatus>();
+    packet->status = sTicketMgr->GetStatus() ? GMTICKET_QUEUE_STATUS_ENABLED : GMTICKET_QUEUE_STATUS_DISABLED;
+    SendPacket(std::move(packet));
 }
 
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2

--- a/src/game/Handlers/GroupHandler.cpp
+++ b/src/game/Handlers/GroupHandler.cpp
@@ -43,14 +43,13 @@
     -FIX sending PartyMemberStats
 */
 
-void WorldSession::SendPartyResult(PartyOperation operation, std::string const& member, PartyResult res)
+void WorldSession::SendPartyResult(PartyOperation operation, std::string const& memberName, PartyResult res)
 {
-    WorldPacket data(SMSG_PARTY_COMMAND_RESULT, (4 + member.size() + 1 + 4));
-    data << uint32(operation);
-    data << member; // max len 48
-    data << uint32(res);
-
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Group::PartyCommandResult>();
+    packet->operation = operation;
+    packet->memberName = memberName;
+    packet->result = res;
+    SendPacket(std::move(packet));
 }
 
 void WorldSession::HandleGroupInviteOpcode(WorldPackets::Group::GroupInvite const& packet)
@@ -143,9 +142,9 @@ void WorldSession::HandleGroupInviteOpcode(WorldPackets::Group::GroupInvite cons
     }
 
     // ok, we do it
-    WorldPacket data(SMSG_GROUP_INVITE, 10); // guess size
-    data << GetPlayer()->GetName();
-    player->GetSession()->SendPacket(&data);
+    auto invitePacket = std::make_unique<WorldPackets::Group::GroupInviteNotification>();
+    invitePacket->inviterName = GetPlayer()->GetName();
+    player->GetSession()->SendPacket(std::move(invitePacket));
 
     SendPartyResult(PARTY_OP_INVITE, packet.memberName, ERR_PARTY_RESULT_OK);
 }
@@ -211,9 +210,9 @@ void WorldSession::HandleGroupDeclineOpcode(NullClientPacket const& /*packet*/)
         return;
 
     // report
-    WorldPacket data(SMSG_GROUP_DECLINE, 10); // guess size
-    data << GetPlayer()->GetName();
-    leader->GetSession()->SendPacket(&data);
+    auto declinePacket = std::make_unique<WorldPackets::Group::GroupDeclineNotification>();
+    declinePacket->playerName = GetPlayer()->GetName();
+    leader->GetSession()->SendPacket(std::move(declinePacket));
 }
 
 void WorldSession::HandleGroupUninviteGuidOpcode(WorldPackets::Group::GroupUninviteGuid const& packet)
@@ -579,10 +578,10 @@ void WorldSession::HandleRaidReadyCheckOpcode(WorldPackets::Group::RaidReadyChec
         // Forward to the raid leader
         if (Player* gleader = sObjectMgr.GetPlayer(group->GetLeaderGuid()))
         {
-            WorldPacket data(MSG_RAID_READY_CHECK, 9);
-            data << GetPlayer()->GetObjectGuid();
-            data << uint8(packet.state.value());
-            gleader->GetSession()->SendPacket(&data);
+            auto response = std::make_unique<WorldPackets::Group::RaidReadyCheckResponse>();
+            response->senderGuid = GetPlayer()->GetObjectGuid();
+            response->state = packet.state.value();
+            gleader->GetSession()->SendPacket(std::move(response));
         }
     }
 }

--- a/src/game/Handlers/GuildHandler.cpp
+++ b/src/game/Handlers/GuildHandler.cpp
@@ -134,10 +134,10 @@ void WorldSession::HandleGuildInviteOpcode(WorldPackets::Guild::GuildInvite cons
     // Put record into guildlog
     guild->LogGuildEvent(GUILD_EVENT_LOG_INVITE_PLAYER, GetPlayer()->GetObjectGuid(), player->GetObjectGuid());
 
-    WorldPacket data(SMSG_GUILD_INVITE, (8 + 10));          // guess size
-    data << GetPlayer()->GetName();
-    data << guild->GetName();
-    player->GetSession()->SendPacket(&data);
+    auto invitePacket = std::make_unique<WorldPackets::Guild::GuildInviteNotification>();
+    invitePacket->inviterName = GetPlayer()->GetName();
+    invitePacket->guildName = guild->GetName();
+    player->GetSession()->SendPacket(std::move(invitePacket));
 }
 
 void WorldSession::HandleGuildRemoveOpcode(WorldPackets::Guild::GuildRemove const& packet)
@@ -229,9 +229,9 @@ void WorldSession::HandleGuildDeclineOpcode(NullClientPacket const& /*packet*/)
         {
             if (Player const* pInviter = ObjectAccessor::FindPlayer(inviterGuid))
             {
-                WorldPacket data(SMSG_GUILD_DECLINE);
-                data << _player->GetName();
-                pInviter->GetSession()->SendPacket(&data);
+                auto declinePacket = std::make_unique<WorldPackets::Guild::GuildDeclineNotification>();
+                declinePacket->playerName = _player->GetName();
+                pInviter->GetSession()->SendPacket(std::move(declinePacket));
             }
         }
     }
@@ -248,14 +248,14 @@ void WorldSession::HandleGuildInfoOpcode(NullClientPacket const& /*packet*/)
         return;
     }
 
-    WorldPacket data(SMSG_GUILD_INFO, (5 * 4 + guild->GetName().size() + 1));
-    data << guild->GetName();
-    data << uint32(guild->GetCreatedDay());
-    data << uint32(guild->GetCreatedMonth());
-    data << uint32(guild->GetCreatedYear());
-    data << uint32(guild->GetMemberSize());                 // amount of chars
-    data << uint32(guild->GetAccountsNumber());             // amount of accounts
-    SendPacket(&data);
+    auto guildInfoPacket = std::make_unique<WorldPackets::Guild::GuildInfo>();
+    guildInfoPacket->guildName = guild->GetName();
+    guildInfoPacket->createdDay = guild->GetCreatedDay();
+    guildInfoPacket->createdMonth = guild->GetCreatedMonth();
+    guildInfoPacket->createdYear = guild->GetCreatedYear();
+    guildInfoPacket->memberCount = guild->GetMemberSize();
+    guildInfoPacket->accountCount = guild->GetAccountsNumber();
+    SendPacket(std::move(guildInfoPacket));
 }
 
 void WorldSession::HandleGuildRosterOpcode(NullClientPacket const& /*packet*/)
@@ -648,11 +648,11 @@ void WorldSession::HandleGuildDelRankOpcode(NullClientPacket const& /*packet*/)
 
 void WorldSession::SendGuildCommandResult(uint32 typecmd, std::string const& str, uint32 cmdresult)
 {
-    WorldPacket data(SMSG_GUILD_COMMAND_RESULT, (8 + str.size() + 1));
-    data << typecmd;
-    data << str;
-    data << cmdresult;
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Guild::GuildCommandResult>();
+    packet->command = typecmd;
+    packet->str = str;
+    packet->result = cmdresult;
+    SendPacket(std::move(packet));
 }
 
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
@@ -729,7 +729,7 @@ void WorldSession::HandleSaveGuildEmblemOpcode(WorldPackets::Guild::SaveGuildEmb
 
 void WorldSession::SendSaveGuildEmblem(uint32 msg)
 {
-    WorldPacket data(MSG_SAVE_GUILD_EMBLEM, 4);
-    data << uint32(msg);                                    // not part of guild
-    SendPacket(&data);
+    auto emblemResult = std::make_unique<WorldPackets::Guild::SaveGuildEmblemResult>();
+    emblemResult->error = msg;
+    SendPacket(std::move(emblemResult));
 }

--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -441,13 +441,6 @@ void WorldSession::HandleReadItemOpcode(WorldPackets::Item::ReadItem const& pack
         _player->SendEquipError(EQUIP_ERR_ITEM_NOT_FOUND, nullptr, nullptr);
 }
 
-void WorldSession::HandlePageQuerySkippedOpcode(WorldPacket& recv_data)
-{
-    uint32 itemid;
-    ObjectGuid guid;
-    recv_data >> itemid >> guid;
-}
-
 void WorldSession::HandleSellItemOpcode(WorldPackets::Item::SellItem const& packet)
 {
     if (!packet.itemGuid || !GetPlayer()->IsInWorld())

--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -419,23 +419,20 @@ void WorldSession::HandleReadItemOpcode(WorldPackets::Item::ReadItem const& pack
 
     if (pItem && pItem->GetProto()->PageText)
     {
-        WorldPacket data;
-
         InventoryResult msg = _player->CanUseItem(pItem);
         if (msg == EQUIP_ERR_OK)
         {
-            data.Initialize(SMSG_READ_ITEM_OK, 8);
-            data << ObjectGuid(pItem->GetObjectGuid());
+            auto readOk = std::make_unique<WorldPackets::Item::ReadItemOk>();
+            readOk->itemGuid = pItem->GetObjectGuid();
+            SendPacket(std::move(readOk));
         }
         else
         {
-            data.Initialize(SMSG_READ_ITEM_FAILED, 8 + 1);
-            data << ObjectGuid(pItem->GetObjectGuid());
-            data << uint8(0);                       // 0..2, read failure reason? if == 1, use next command
+            auto readFailed = std::make_unique<WorldPackets::Item::ReadItemFailed>();
+            readFailed->itemGuid = pItem->GetObjectGuid();
+            SendPacket(std::move(readFailed));
             _player->SendEquipError(msg, pItem, nullptr);
         }
-        data << ObjectGuid(pItem->GetObjectGuid());
-        SendPacket(&data);
     }
     else
         _player->SendEquipError(EQUIP_ERR_ITEM_NOT_FOUND, nullptr, nullptr);
@@ -898,12 +895,11 @@ bool WorldSession::CheckBanker(ObjectGuid guid)
 
 void WorldSession::HandleBuyBankSlotOpcode(WorldPackets::Item::BuyBankSlot const& packet)
 {
-    WorldPacket data(SMSG_BUY_BANK_SLOT_RESULT, 4);
-
     if (!CheckBanker(packet.guid))
     {
-        data << uint32(ERR_BANKSLOT_NOTBANKER);
-        SendPacket(&data);
+        auto bankPacket = std::make_unique<WorldPackets::Item::BuyBankSlotResult>();
+        bankPacket->result = ERR_BANKSLOT_NOTBANKER;
+        SendPacket(std::move(bankPacket));
         return;
     }
 
@@ -916,8 +912,9 @@ void WorldSession::HandleBuyBankSlotOpcode(WorldPackets::Item::BuyBankSlot const
 
     if (!slotEntry)
     {
-        data << uint32(ERR_BANKSLOT_FAILED_TOO_MANY);
-        SendPacket(&data);
+        auto bankPacket = std::make_unique<WorldPackets::Item::BuyBankSlotResult>();
+        bankPacket->result = ERR_BANKSLOT_FAILED_TOO_MANY;
+        SendPacket(std::move(bankPacket));
         return;
     }
 
@@ -925,8 +922,9 @@ void WorldSession::HandleBuyBankSlotOpcode(WorldPackets::Item::BuyBankSlot const
 
     if (_player->GetMoney() < price)
     {
-        data << uint32(ERR_BANKSLOT_INSUFFICIENT_FUNDS);
-        SendPacket(&data);
+        auto bankPacket = std::make_unique<WorldPackets::Item::BuyBankSlotResult>();
+        bankPacket->result = ERR_BANKSLOT_INSUFFICIENT_FUNDS;
+        SendPacket(std::move(bankPacket));
         return;
     }
 
@@ -1032,14 +1030,14 @@ void WorldSession::HandleSetAmmoOpcode(WorldPackets::Item::SetAmmo const& packet
 
 void WorldSession::SendItemEnchantTimeUpdate(ObjectGuid playerGuid, ObjectGuid itemGuid, uint32 slot, uint32 duration)
 {
-    WorldPacket data(SMSG_ITEM_ENCHANT_TIME_UPDATE, (8 + 4 + 4 + 8));
-    data << ObjectGuid(itemGuid);
-    data << uint32(slot);
-    data << uint32(duration);
+    auto enchantUpdate = std::make_unique<WorldPackets::Item::ItemEnchantTimeUpdate>();
+    enchantUpdate->itemGuid = itemGuid;
+    enchantUpdate->slot = slot;
+    enchantUpdate->duration = duration;
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2
-    data << ObjectGuid(playerGuid);
+    enchantUpdate->playerGuid = playerGuid;
 #endif
-    SendPacket(&data);
+    SendPacket(std::move(enchantUpdate));
 }
 
 void WorldSession::HandleItemNameQueryOpcode(WorldPackets::Query::ItemNameQuery const& packet)
@@ -1060,13 +1058,11 @@ void WorldSession::HandleItemNameQueryOpcode(WorldPackets::Query::ItemNameQuery 
             }
         }
 
-        size_t const nameLen = strlen(name) + 1;
-
-        WorldPacket data(SMSG_ITEM_NAME_QUERY_RESPONSE, (4 + nameLen));
-        data << uint32(pProto->ItemId);
-        data.append(name, nameLen);
+        auto namePacket = std::make_unique<WorldPackets::Item::ItemNameQueryResponse>();
+        namePacket->itemId = pProto->ItemId;
+        namePacket->name = name;
         //data << uint32(pProto->InventoryType);    [-ZERO]
-        SendPacket(&data);
+        SendPacket(std::move(namePacket));
         return;
     }
 }

--- a/src/game/Handlers/MailHandler.cpp
+++ b/src/game/Handlers/MailHandler.cpp
@@ -840,10 +840,10 @@ void WorldSession::HandleItemTextQuery(WorldPackets::Misc::ItemTextQuery const& 
 
     // TODO: some check needed, if player has item with guid mailId, or has mail with id mailId
 
-    WorldPacket data(SMSG_ITEM_TEXT_QUERY_RESPONSE, (4 + 10)); // guess size
-    data << packet.itemTextId;
-    data << sObjectMgr.GetItemText(packet.itemTextId);
-    SendPacket(&data);
+    auto textPacket = std::make_unique<WorldPackets::Mail::ItemTextQueryResponse>();
+    textPacket->itemTextId = packet.itemTextId;
+    textPacket->text = sObjectMgr.GetItemText(packet.itemTextId);
+    SendPacket(std::move(textPacket));
 }
 
 /**
@@ -906,12 +906,9 @@ void WorldSession::HandleQueryNextMailTime(NullClientPacket const& /*packet*/)
 {
     MasterPlayer* player = GetMasterPlayer();
     ASSERT(player);
-    WorldPacket data(MSG_QUERY_NEXT_MAIL_TIME, 8);
-    if (player->HasUnreadMail())
-        data << float(0);
-    else
-        data << float(-86400.0f);
-    SendPacket(&data);
+    auto nextMailTime = std::make_unique<WorldPackets::Mail::QueryNextMailTimeResponse>();
+    nextMailTime->nextMailTime = player->HasUnreadMail() ? 0.0f : -float(DAY);
+    SendPacket(std::move(nextMailTime));
 }
 
 /*! @} */

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -297,10 +297,10 @@ void WorldSession::HandleLogoutRequestOpcode(NullClientPacket const& /*packet*/)
 
     if (reason)
     {
-        WorldPacket data(SMSG_LOGOUT_RESPONSE, 1 + 4);
-        data << uint32(reason);
-        data << uint8(0);
-        SendPacket(&data);
+        auto packet = std::make_unique<WorldPackets::Misc::LogoutResponse>();
+        packet->reason = reason;
+        packet->instant = 0;
+        SendPacket(std::move(packet));
         LogoutRequest(0);
         return;
     }
@@ -310,10 +310,10 @@ void WorldSession::HandleLogoutRequestOpcode(NullClientPacket const& /*packet*/)
         GetPlayer()->IsTaxiFlying() ||
         GetSecurity() >= (AccountTypes)sWorld.getConfig(CONFIG_UINT32_INSTANT_LOGOUT))
     {
-        WorldPacket data(SMSG_LOGOUT_RESPONSE, 1 + 4);
-        data << uint32(0);
-        data << uint8(1);
-        SendPacket(&data);
+        auto packet = std::make_unique<WorldPackets::Misc::LogoutResponse>();
+        packet->reason = 0;
+        packet->instant = 1;
+        SendPacket(std::move(packet));
         LogoutPlayer(true);
         return;
     }
@@ -332,10 +332,10 @@ void WorldSession::HandleLogoutRequestOpcode(NullClientPacket const& /*packet*/)
 
     GetPlayer()->ApplyModByteFlag(PLAYER_FIELD_BYTES, PLAYER_FIELD_BYTES_OFFSET_FLAGS, PLAYER_FIELD_BYTE_LOGGING_OUT, true);
 
-    WorldPacket data(SMSG_LOGOUT_RESPONSE, 1 + 4);
-    data << uint32(0);
-    data << uint8(0);
-    SendPacket(&data);
+    auto logoutPacket = std::make_unique<WorldPackets::Misc::LogoutResponse>();
+    logoutPacket->reason = 0;
+    logoutPacket->instant = 0;
+    SendPacket(std::move(logoutPacket));
     LogoutRequest(time(nullptr));
 }
 
@@ -347,8 +347,7 @@ void WorldSession::HandleLogoutCancelOpcode(NullClientPacket const& /*packet*/)
 {
     LogoutRequest(0);
 
-    WorldPacket data(SMSG_LOGOUT_CANCEL_ACK, 0);
-    SendPacket(&data);
+    SendPacket(std::make_unique<WorldPackets::Misc::LogoutCancelAck>());
 
     // not remove flags if can't free move - its not set in Logout request code.
     if (GetPlayer()->CanFreeMove())
@@ -391,9 +390,9 @@ void WorldSession::HandleZoneUpdateOpcode(WorldPackets::Misc::ZoneUpdate const& 
     // Note: There might be a better place to perform this trigger
     if (m_clientOS == CLIENT_OS_MAC && GetPlayer()->m_movementInfo.HasMovementFlag(MOVEFLAG_ONTRANSPORT))
     {
-        WorldPacket data(SMSG_STANDSTATE_UPDATE, 1);
-        data << GetPlayer()->GetStandState();
-        GetPlayer()->GetSession()->SendPacket(&data);
+        auto packet = std::make_unique<WorldPackets::Misc::StandStateUpdate>();
+        packet->standState = GetPlayer()->GetStandState();
+        GetPlayer()->GetSession()->SendPacket(std::move(packet));
     }
 }
 
@@ -861,10 +860,10 @@ void WorldSession::HandleRequestAccountData(WorldPackets::Misc::RequestAccountDa
     uint32 size = adata->data.size();
     if (!size)
     {
-        WorldPacket data(SMSG_UPDATE_ACCOUNT_DATA, 4 + 4);
-        data << uint32(packet.type);                         // use the original type sent by client
-        data << uint32(0);                                   // decompressed length
-        SendPacket(&data);
+        auto accountDataPacket = std::make_unique<WorldPackets::Misc::UpdateAccountDataResponse>();
+        accountDataPacket->type = packet.type;                         // use the original type sent by client
+        accountDataPacket->decompressedLength = 0;                     // decompressed length
+        SendPacket(std::move(accountDataPacket));
     }
     else
     {
@@ -875,11 +874,11 @@ void WorldSession::HandleRequestAccountData(WorldPackets::Misc::RequestAccountDa
             return;
         }
 
-        WorldPacket data(SMSG_UPDATE_ACCOUNT_DATA, 4 + 4 + compressedData->size() + 1);
-        data << uint32(packet.type);                            // use the original type sent by client
-        data << uint32(size);                                   // decompressed length
-        data.append(*compressedData);                           // compressed data
-        SendPacket(&data);
+        auto accountDataPacket = std::make_unique<WorldPackets::Misc::UpdateAccountDataResponse>();
+        accountDataPacket->type = packet.type;                            // use the original type sent by client
+        accountDataPacket->decompressedLength = size;                     // decompressed length
+        accountDataPacket->compressedData = std::move(*compressedData);   // compressed data
+        SendPacket(std::move(accountDataPacket));
     }
 }
 
@@ -935,10 +934,10 @@ void WorldSession::HandleSetActionBarTogglesOpcode(WorldPackets::Misc::SetAction
 
 void WorldSession::HandlePlayedTime(NullClientPacket const& /*packet*/)
 {
-    WorldPacket data(SMSG_PLAYED_TIME, 4 + 4);
-    data << uint32(_player->GetTotalPlayedTime());
-    data << uint32(_player->GetLevelPlayedTime());
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Misc::PlayedTime>();
+    packet->totalPlayedTime = _player->GetTotalPlayedTime();
+    packet->levelPlayedTime = _player->GetLevelPlayedTime();
+    SendPacket(std::move(packet));
 }
 
 void WorldSession::HandleInspectOpcode(WorldPackets::Misc::Inspect const& packet)
@@ -955,9 +954,9 @@ void WorldSession::HandleInspectOpcode(WorldPackets::Misc::Inspect const& packet
     if (_player->IsValidAttackTarget(pTarget))
         return;
 
-    WorldPacket data(SMSG_INSPECT, 8);
-    data << ObjectGuid(packet.guid);
-    SendPacket(&data);
+    auto inspectPacket = std::make_unique<WorldPackets::Misc::InspectResponse>();
+    inspectPacket->guid = packet.guid;
+    SendPacket(std::move(inspectPacket));
 }
 
 void WorldSession::HandleInspectHonorStatsOpcode(WorldPackets::Misc::InspectHonorStats const& packet)
@@ -972,87 +971,68 @@ void WorldSession::HandleInspectHonorStatsOpcode(WorldPackets::Misc::InspectHono
     if (_player->IsValidAttackTarget(pTarget))
         return;
 
-    WorldPacket data(MSG_INSPECT_HONOR_STATS, (
-        8
-        + 1
-        + 4
-        + 4
-        + 4
-// World of Warcraft Client Patch 1.6.0 (2005-07-12)
-// - There is a new "This Week" section of the Honor tab, which will display PvP accomplishments of the current week.
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
-        + 4
-#endif
-        + 4
-        + 4
-        + 4
-        + 4
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
-        + 4
-#endif
-        + 4
-// World of Warcraft Client Patch 1.6.0 (2005-07-12)
-// - There is now a progress bar on the Honor tab of your character window that displays how close you are to your next rank.
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
-        + 1
-#endif
-    ));
+    auto honorStats = std::make_unique<WorldPackets::Misc::InspectHonorStatsResponse>();
 
     // player guid
-    data << packet.guid;
+    honorStats->playerGuid = packet.guid;
+
+// World of Warcraft Client Patch 1.6.0 (2005-07-12)
+// - There is a new "This Week" section of the Honor tab, which will display PvP accomplishments of the current week.
+// World of Warcraft Client Patch 1.6.0 (2005-07-12)
+// - There is now a progress bar on the Honor tab of your character window that displays how close you are to your next rank.
 
     // Highest Rank
-    data << (uint8)pTarget->GetHonorMgr().GetHighestRank().rank;
+    honorStats->highestRank = pTarget->GetHonorMgr().GetHighestRank().rank;
 
     // Today Honorable and Dishonorable Kills
-    data << pTarget->GetUInt32Value(PLAYER_FIELD_SESSION_KILLS);
+    honorStats->sessionKills = pTarget->GetUInt32Value(PLAYER_FIELD_SESSION_KILLS);
 
     // Yesterday Honorable Kills
-    data << pTarget->GetUInt16Value(PLAYER_FIELD_YESTERDAY_KILLS, 0);
+    honorStats->yesterdayHK = pTarget->GetUInt16Value(PLAYER_FIELD_YESTERDAY_KILLS, 0);
 
     // Unknown (deprecated, yesterday dishonourable?)
-    data << (uint16)0;
+    honorStats->unknownOld1 = 0;
 
     // Last Week Honorable Kills
-    data << pTarget->GetUInt16Value(PLAYER_FIELD_LAST_WEEK_KILLS, 0);
+    honorStats->lastWeekHK = pTarget->GetUInt16Value(PLAYER_FIELD_LAST_WEEK_KILLS, 0);
 
     // Unknown (deprecated, last week dishonourable?)
-    data << (uint16)0;
+    honorStats->unknownOld2 = 0;
 
 #if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     // This Week Honorable kills
-    data << pTarget->GetUInt16Value(PLAYER_FIELD_THIS_WEEK_KILLS, 0);
+    honorStats->thisWeekHK = pTarget->GetUInt16Value(PLAYER_FIELD_THIS_WEEK_KILLS, 0);
 
     // Unknown (deprecated, this week dishonourable?)
-    data << (uint16)0;
+    honorStats->unknownOld3 = 0;
 #endif
 
     // Lifetime Honorable Kills
-    data << pTarget->GetUInt32Value(PLAYER_FIELD_LIFETIME_HONORBALE_KILLS);
+    honorStats->lifetimeHK = pTarget->GetUInt32Value(PLAYER_FIELD_LIFETIME_HONORBALE_KILLS);
 
     // Lifetime Dishonorable Kills
-    data << pTarget->GetUInt32Value(PLAYER_FIELD_LIFETIME_DISHONORBALE_KILLS);
+    honorStats->lifetimeDHK = pTarget->GetUInt32Value(PLAYER_FIELD_LIFETIME_DISHONORBALE_KILLS);
 
     // Yesterday Honor
-    data << pTarget->GetUInt32Value(PLAYER_FIELD_YESTERDAY_CONTRIBUTION);
+    honorStats->yesterdayHonor = pTarget->GetUInt32Value(PLAYER_FIELD_YESTERDAY_CONTRIBUTION);
 
     // Last Week Honor
-    data << pTarget->GetUInt32Value(PLAYER_FIELD_LAST_WEEK_CONTRIBUTION);
+    honorStats->lastWeekHonor = pTarget->GetUInt32Value(PLAYER_FIELD_LAST_WEEK_CONTRIBUTION);
 
 #if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     // This Week Honor
-    data << pTarget->GetUInt32Value(PLAYER_FIELD_THIS_WEEK_CONTRIBUTION);
+    honorStats->thisWeekHonor = pTarget->GetUInt32Value(PLAYER_FIELD_THIS_WEEK_CONTRIBUTION);
 #endif
 
     // Last Week Standing
-    data << pTarget->GetUInt32Value(PLAYER_FIELD_LAST_WEEK_RANK);
+    honorStats->lastWeekRank = pTarget->GetUInt32Value(PLAYER_FIELD_LAST_WEEK_RANK);
 
 #if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
     // Rank progress bar
-    data << (uint8)pTarget->GetByteValue(PLAYER_FIELD_BYTES2, PLAYER_FIELD_BYTES_2_OFFSET_HONOR_RANK_BAR);
+    honorStats->rankBar = pTarget->GetByteValue(PLAYER_FIELD_BYTES2, PLAYER_FIELD_BYTES_2_OFFSET_HONOR_RANK_BAR);
 #endif
 
-    SendPacket(&data);
+    SendPacket(std::move(honorStats));
 }
 
 void WorldSession::HandleTeleportToUnitOpcode(WorldPackets::Misc::TeleportToUnit const& packet)
@@ -1150,9 +1130,9 @@ void WorldSession::HandleWhoisOpcode(WorldPackets::Query::Whois const& packet)
 
     std::string msg = packet.charName + "'s " + "account is " + acc + ", e-mail: " + email + ", last ip: " + lastIp;
 
-    WorldPacket data(SMSG_WHOIS, msg.size() + 1); // max CString length allowed: 256
-    data << msg;
-    _player->GetSession()->SendPacket(&data);
+    auto whoisPacket = std::make_unique<WorldPackets::Misc::WhoisResponse>();
+    whoisPacket->message = msg;
+    _player->GetSession()->SendPacket(std::move(whoisPacket));
 }
 
 void WorldSession::HandleFarSightOpcode(WorldPackets::Misc::FarSight const& packet)

--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -63,9 +63,9 @@ void WorldSession::HandleTabardVendorActivateOpcode(WorldPackets::Npc::TabardVen
 
 void WorldSession::SendTabardVendorActivate(ObjectGuid guid)
 {
-    WorldPacket data(MSG_TABARDVENDOR_ACTIVATE, 8);
-    data << ObjectGuid(guid);
-    SendPacket(&data);
+    auto tabardVendor = std::make_unique<WorldPackets::Npc::TabardVendorActivateResponse>();
+    tabardVendor->tabardVendorNpcGuid = guid;
+    SendPacket(std::move(tabardVendor));
 }
 
 void WorldSession::HandleBankerActivateOpcode(WorldPackets::Npc::BankerActivate const& packet)
@@ -82,10 +82,11 @@ void WorldSession::HandleBankerActivateOpcode(WorldPackets::Npc::BankerActivate 
 
 void WorldSession::SendShowBank(ObjectGuid guid)
 {
-    WorldPacket data(SMSG_SHOW_BANK, 8);
-    data << ObjectGuid(guid);
     GetPlayer()->m_currentBankerGuid = guid;
-    SendPacket(&data);
+
+    auto packet = std::make_unique<WorldPackets::Npc::ShowBank>();
+    packet->bankerGuid = guid;
+    SendPacket(std::move(packet));
 }
 
 void WorldSession::HandleTrainerListOpcode(WorldPackets::Npc::TrainerList const& packet)
@@ -243,19 +244,19 @@ void WorldSession::SendTrainerList(ObjectGuid guid)
 
 void WorldSession::SendTrainingSuccess(ObjectGuid guid, uint32 spellId)
 {
-    WorldPacket data(SMSG_TRAINER_BUY_SUCCEEDED, 12);
-    data << ObjectGuid(guid);
-    data << uint32(spellId);                                // should be same as in packet from client
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Npc::TrainerBuySucceeded>();
+    packet->trainerGuid = guid;
+    packet->spellId = spellId; // should be same as in packet from client
+    SendPacket(std::move(packet));
 }
 
 void WorldSession::SendTrainingFailure(ObjectGuid guid, uint32 serviceId, uint32 errorCode)
 {
-    WorldPacket data(SMSG_TRAINER_BUY_FAILED, 16);
-    data << ObjectGuid(guid);
-    data << uint32(serviceId);
-    data << uint32(errorCode);
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Npc::TrainerBuyFailed>();
+    packet->trainerGuid = guid;
+    packet->serviceId = serviceId;
+    packet->errorCode = errorCode;
+    SendPacket(std::move(packet));
 }
 
 void WorldSession::HandleTrainerBuySpellOpcode(WorldPackets::Npc::TrainerBuySpell const& packet)
@@ -575,9 +576,9 @@ void WorldSession::SendStablePet(ObjectGuid guid)
 
 void WorldSession::SendStableResult(uint8 res)
 {
-    WorldPacket data(SMSG_STABLE_RESULT, 1);
-    data << uint8(res);
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Npc::StableResult>();
+    packet->result = res;
+    SendPacket(std::move(packet));
 }
 
 bool WorldSession::CheckStableMaster(ObjectGuid guid)

--- a/src/game/Handlers/PetHandler.cpp
+++ b/src/game/Handlers/PetHandler.cpp
@@ -193,12 +193,11 @@ void WorldSession::SendPetNameQuery(ObjectGuid petGuid, uint32 petNumber)
 
     std::string name = pet->GetName();
 
-    WorldPacket data(SMSG_PET_NAME_QUERY_RESPONSE, (4 + 4 + name.size() + 1));
-    data << uint32(petNumber);
-    data << name;
-    data << uint32(pet->GetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP));
-
-    _player->GetSession()->SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Pet::PetNameQueryResponse>();
+    packet->petNumber = petNumber;
+    packet->name = name;
+    packet->nameTimestamp = pet->GetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP);
+    _player->GetSession()->SendPacket(std::move(packet));
 }
 
 void WorldSession::HandlePetSetAction(WorldPackets::Pet::PetSetAction const& packet)
@@ -542,6 +541,8 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPackets::Pet::PetCastSpell cons
 
 void WorldSession::SendPetNameInvalid(uint32 error, std::string const& name)
 {
-    WorldPacket data(SMSG_PET_NAME_INVALID, 0);
-    SendPacket(&data);
+    (void)error; // not read by vanilla client
+    (void)name; // not read by vanilla client
+
+    SendPacket(std::make_unique<WorldPackets::Pet::PetNameInvalid>());
 }

--- a/src/game/Handlers/PetitionsHandler.cpp
+++ b/src/game/Handlers/PetitionsHandler.cpp
@@ -174,26 +174,14 @@ void WorldSession::HandlePetitionQueryOpcode(WorldPackets::Petition::QueryPetiti
     if (!petition)
         return;
 
-    WorldPacket data(SMSG_PETITION_QUERY_RESPONSE, (4 + 8 + petition->GetName().size() + 1 + 2 + 4 * 11));
-    data << uint32(packet.petitionGuid);                    // int m_petitionID;
-    data << ObjectGuid(petition->GetOwnerGuid());           // unsigned __int64 m_petitioner;
-    data << petition->GetName();                            // char m_title[256];
-    data << uint8(0);                                       // char m_bodyText[4096];
-    data << uint32(1);                                      // int m_flags;
-    data << uint32(9);                                      // int m_minSignatures;
-    data << uint32(9);                                      // int m_maxSignatures;
-    data << uint32(0);                                      // int m_deadLine;
-    data << uint32(0);                                      // int m_issueDate;
-    data << uint32(0);                                      // int m_allowedGuildID;
-    data << uint32(0);                                      // int m_allowedClasses;
-    data << uint32(0);                                      // int m_allowedRaces;
-    data << uint16(0);                                      // __int16 m_allowedGender;
-    data << uint32(0);                                      // int m_allowedMinLevel;
-    data << uint32(0);                                      // int m_allowedMaxLevel;
-    data << uint32(0);                                      // char m_choicetext[10][64];
-    // for (int i=0; i<field13; ++i) data << chartSignersName[i];   Probably, names of the petition signers
-    data << uint32(0);                                      // int m_numChoices;
-    SendPacket(&data);
+    auto response = std::make_unique<WorldPackets::Petition::PetitionQueryResponse>();
+    response->petitionGuid = packet.petitionGuid;
+    response->ownerGuid = ObjectGuid(petition->GetOwnerGuid());
+    response->name = petition->GetName();
+    response->flags = 1;
+    response->minSignatures = 9;
+    response->maxSignatures = 9;
+    SendPacket(std::move(response));
 }
 
 void WorldSession::HandlePetitionRenameOpcode(WorldPackets::Petition::PetitionRename const& packet)
@@ -220,10 +208,10 @@ void WorldSession::HandlePetitionRenameOpcode(WorldPackets::Petition::PetitionRe
 
     if (petition->Rename(packet.newName))
     {
-        WorldPacket data(MSG_PETITION_RENAME, (8 + packet.newName.size() + 1));
-        data << ObjectGuid(packet.itemGuid);
-        data << packet.newName;
-        SendPacket(&data);
+        auto renameResult = std::make_unique<WorldPackets::Petition::PetitionRenameResult>();
+        renameResult->itemGuid = packet.itemGuid;
+        renameResult->newName = packet.newName;
+        SendPacket(std::move(renameResult));
     }
 }
 
@@ -243,11 +231,11 @@ void WorldSession::HandlePetitionSignOpcode(WorldPackets::Petition::PetitionSign
 
     if (petition->GetOwnerGuid() == _player->GetObjectGuid())
     {
-        WorldPacket data(SMSG_PETITION_SIGN_RESULTS, (8 + 8 + 4));
-        data << ObjectGuid(packet.itemGuid);
-        data << ObjectGuid(_player->GetObjectGuid());
-        data << uint32(PETITION_SIGN_CANT_SIGN_OWN);
-        SendPacket(&data);
+        auto signPacket = std::make_unique<WorldPackets::Petition::PetitionSignResults>();
+        signPacket->itemGuid = packet.itemGuid;
+        signPacket->playerGuid = _player->GetObjectGuid();
+        signPacket->result = PETITION_SIGN_CANT_SIGN_OWN;
+        SendPacket(std::move(signPacket));
         return;
     }
 
@@ -286,13 +274,13 @@ void WorldSession::HandlePetitionSignOpcode(WorldPackets::Petition::PetitionSign
     //not allow sign another player from already sign player account
     if (PetitionSignature* signature = petition->GetSignatureForPlayer(_player))
     {
-        WorldPacket data(SMSG_PETITION_SIGN_RESULTS, (8 + 8 + 4));
-        data << ObjectGuid(packet.itemGuid);
-        data << ObjectGuid(_player->GetObjectGuid());
-        data << uint32(PETITION_SIGN_ALREADY_SIGNED);
+        auto signPacket = std::make_unique<WorldPackets::Petition::PetitionSignResults>();
+        signPacket->itemGuid = packet.itemGuid;
+        signPacket->playerGuid = _player->GetObjectGuid();
+        signPacket->result = PETITION_SIGN_ALREADY_SIGNED;
 
         // close at signer side
-        SendPacket(&data);
+        SendPacket(std::move(signPacket));
 
         // Update for owner if online. Note: Unsure if this is the correct message,
         // but sending SMSG_PETITION_SIGN_RESULTS does nothing for the owner here
@@ -305,13 +293,13 @@ void WorldSession::HandlePetitionSignOpcode(WorldPackets::Petition::PetitionSign
     {
         sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "PETITION SIGN: %u by %s", petition->GetId(), _player->GetGuidStr().c_str());
 
-        WorldPacket data(SMSG_PETITION_SIGN_RESULTS, (8 + 8 + 4));
-        data << ObjectGuid(packet.itemGuid);
-        data << ObjectGuid(_player->GetObjectGuid());
-        data << uint32(PETITION_SIGN_OK);
+        auto signPacket = std::make_unique<WorldPackets::Petition::PetitionSignResults>();
+        signPacket->itemGuid = packet.itemGuid;
+        signPacket->playerGuid = _player->GetObjectGuid();
+        signPacket->result = PETITION_SIGN_OK;
 
         // close at signer side
-        SendPacket(&data);
+        SendPacket(std::move(signPacket));
 
         // update signs count on charter, required testing...
         //Item *item = _player->GetItemByGuid(petitionguid));
@@ -320,7 +308,13 @@ void WorldSession::HandlePetitionSignOpcode(WorldPackets::Petition::PetitionSign
 
         // update for owner if online
         if (Player* owner = sObjectMgr.GetPlayer(petition->GetOwnerGuid()))
-            owner->GetSession()->SendPacket(&data);
+        {
+            auto ownerPacket = std::make_unique<WorldPackets::Petition::PetitionSignResults>();
+            ownerPacket->itemGuid = packet.itemGuid;
+            ownerPacket->playerGuid = _player->GetObjectGuid();
+            ownerPacket->result = PETITION_SIGN_OK;
+            owner->GetSession()->SendPacket(std::move(ownerPacket));
+        }
     }
 }
 
@@ -337,9 +331,9 @@ void WorldSession::HandlePetitionDeclineOpcode(WorldPackets::Petition::PetitionD
     Player* owner = sObjectMgr.GetPlayer(petition->GetOwnerGuid());
     if (owner)                                              // petition owner online
     {
-        WorldPacket data(MSG_PETITION_DECLINE, 8);
-        data << _player->GetObjectGuid();
-        owner->GetSession()->SendPacket(&data);
+        auto declineResult = std::make_unique<WorldPackets::Petition::PetitionDeclineResult>();
+        declineResult->playerGuid = _player->GetObjectGuid();
+        owner->GetSession()->SendPacket(std::move(declineResult));
     }
 }
 
@@ -429,9 +423,9 @@ void WorldSession::HandleTurnInPetitionOpcode(WorldPackets::Petition::TurnInPeti
     // Collect petition info data
     if (_player->GetGuildId())
     {
-        WorldPacket data(SMSG_TURN_IN_PETITION_RESULTS, 4);
-        data << uint32(PETITION_SIGN_ALREADY_IN_GUILD); // already in guild
-        _player->GetSession()->SendPacket(&data);
+        auto turnInPacket = std::make_unique<WorldPackets::Petition::TurnInPetitionResults>();
+        turnInPacket->result = PETITION_SIGN_ALREADY_IN_GUILD; // already in guild
+        _player->GetSession()->SendPacket(std::move(turnInPacket));
         return;
     }
 
@@ -440,9 +434,9 @@ void WorldSession::HandleTurnInPetitionOpcode(WorldPackets::Petition::TurnInPeti
 
     if (!petition->IsComplete())
     {
-        WorldPacket data(SMSG_TURN_IN_PETITION_RESULTS, 4);
-        data << uint32(PETITION_SIGN_NEED_MORE); // need more signatures...
-        SendPacket(&data);
+        auto turnInPacket = std::make_unique<WorldPackets::Petition::TurnInPetitionResults>();
+        turnInPacket->result = PETITION_SIGN_NEED_MORE; // need more signatures...
+        SendPacket(std::move(turnInPacket));
         return;
     }
 
@@ -475,9 +469,9 @@ void WorldSession::HandleTurnInPetitionOpcode(WorldPackets::Petition::TurnInPeti
     // created
     sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "TURN IN PETITION %u", petitionGuid);
 
-    WorldPacket data(SMSG_TURN_IN_PETITION_RESULTS, 4);
-    data << uint32(PETITION_SIGN_OK);
-    SendPacket(&data);
+    auto turnInPacket = std::make_unique<WorldPackets::Petition::TurnInPetitionResults>();
+    turnInPacket->result = PETITION_SIGN_OK;
+    SendPacket(std::move(turnInPacket));
 }
 
 void WorldSession::HandlePetitionShowListOpcode(WorldPackets::Petition::PetitionShow const& packet)
@@ -500,23 +494,14 @@ void WorldSession::SendPetitionShowList(ObjectGuid guid)
 
     uint8 count = 1;
 
-    WorldPacket data(SMSG_PETITION_SHOWLIST, 8 + 1 + 4 * 6);
-    data << guid;                                           // npc guid
-    data << count;                                          // count; allowed values 1-10
-    data << uint32(1);                                      // index
-    data << uint32(GUILD_CHARTER);                          // charter entry
-    data << uint32(CHARTER_DISPLAY_ID);                     // charter display id
-    data << uint32(GUILD_CHARTER_COST);                     // charter cost
-    data << uint32(1);                                      // unknown
-    //data << uint32(9);                                    // [-ZERO] required signs?
-    //for(uint8 i = 0; i < count; ++i)
-    //{
-    //    data << uint32(i);                        // index
-    //    data << uint32(GUILD_CHARTER);            // charter entry
-    //    data << uint32(CHARTER_DISPLAY_ID);       // charter display id
-    //    data << uint32(GUILD_CHARTER_COST+i);     // charter cost
-    //    data << uint32(1);                        // unknown
-    //}
-    SendPacket(&data);
+    auto showList = std::make_unique<WorldPackets::Petition::PetitionShowList>();
+    showList->npcGuid = guid;
+    showList->count = 1;
+    showList->index = 1;
+    showList->charterEntry = GUILD_CHARTER;
+    showList->charterDisplayId = CHARTER_DISPLAY_ID;
+    showList->charterCost = GUILD_CHARTER_COST;
+    showList->unknown = 1;
+    SendPacket(std::move(showList));
     sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Sent SMSG_PETITION_SHOWLIST");
 }

--- a/src/game/Handlers/PetitionsHandler.cpp
+++ b/src/game/Handlers/PetitionsHandler.cpp
@@ -492,16 +492,16 @@ void WorldSession::SendPetitionShowList(ObjectGuid guid)
     if (GetPlayer()->HasUnitState(UNIT_STATE_FEIGN_DEATH))
         GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
 
-    uint8 count = 1;
+    WorldPackets::Petition::PetitionShowListEntry entry;
+    entry.index = 1;
+    entry.charterEntry = GUILD_CHARTER;
+    entry.charterDisplayId = CHARTER_DISPLAY_ID;
+    entry.charterCost = GUILD_CHARTER_COST;
+    entry.entryFlags = 1; // must be `&1` to show it in the UI
 
     auto showList = std::make_unique<WorldPackets::Petition::PetitionShowList>();
     showList->npcGuid = guid;
-    showList->count = 1;
-    showList->index = 1;
-    showList->charterEntry = GUILD_CHARTER;
-    showList->charterDisplayId = CHARTER_DISPLAY_ID;
-    showList->charterCost = GUILD_CHARTER_COST;
-    showList->unknown = 1;
+    showList->entries = { entry };
     SendPacket(std::move(showList));
     sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Sent SMSG_PETITION_SHOWLIST");
 }

--- a/src/game/Handlers/QueryHandler.cpp
+++ b/src/game/Handlers/QueryHandler.cpp
@@ -39,9 +39,6 @@ void WorldSession::SendNameQueryOpcode(Player* p)
     auto nameResponse = std::make_unique<WorldPackets::Query::NameQueryResponse>();
     nameResponse->playerGuid = p->GetObjectGuid();
     nameResponse->name = p->GetName();
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
-    nameResponse->realmName = "";                           // realm name for cross realm BG usage
-#endif
     nameResponse->race = p->GetRace();
     nameResponse->gender = p->GetGender();
     nameResponse->class_ = p->GetClass();
@@ -56,9 +53,6 @@ void WorldSession::SendNameQueryOpcodeFromDB(ObjectGuid guid)
         auto nameResponse = std::make_unique<WorldPackets::Query::NameQueryResponse>();
         nameResponse->playerGuid = ObjectGuid(HIGHGUID_PLAYER, pData->uiGuid);
         nameResponse->name = pData->sName;
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
-        nameResponse->realmName = "";
-#endif
         nameResponse->race = pData->uiRace;
         nameResponse->gender = pData->uiGender;
         nameResponse->class_ = pData->uiClass;
@@ -92,9 +86,6 @@ void WorldSession::SendNameQueryOpcodeFromDBCallBack(QueryResult* result, uint32
     auto nameResponse = std::make_unique<WorldPackets::Query::NameQueryResponse>();
     nameResponse->playerGuid = ObjectGuid(HIGHGUID_PLAYER, lowguid);
     nameResponse->name = name;
-#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
-    nameResponse->realmName = "";
-#endif
     nameResponse->race = pRace;
     nameResponse->gender = pGender;
     nameResponse->class_ = pClass;

--- a/src/game/Handlers/QueryHandler.cpp
+++ b/src/game/Handlers/QueryHandler.cpp
@@ -36,22 +36,16 @@ void WorldSession::SendNameQueryOpcode(Player* p)
     if (!p)
         return;
 
-    // guess size
+    auto nameResponse = std::make_unique<WorldPackets::Query::NameQueryResponse>();
+    nameResponse->playerGuid = p->GetObjectGuid();
+    nameResponse->name = p->GetName();
 #if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
-    WorldPacket data(SMSG_NAME_QUERY_RESPONSE, (8 + 25 + 1 + 4 + 4 + 4));   // guess size
-    data << ObjectGuid(p->GetObjectGuid());
-    data << p->GetName();                                   // CString(48): played name
-    data << "";                                             // CString(256): realm name for cross realm BG usage
-#else
-    WorldPacket data(SMSG_NAME_QUERY_RESPONSE, (8 + 25 + 4 + 4 + 4));   // guess size
-    data << ObjectGuid(p->GetObjectGuid());
-    data << p->GetName();                                   // CString(48): played name
+    nameResponse->realmName = "";                           // realm name for cross realm BG usage
 #endif
-    data << uint32(p->GetRace());
-    data << uint32(p->GetGender());
-    data << uint32(p->GetClass());
-
-    SendPacket(&data);
+    nameResponse->race = p->GetRace();
+    nameResponse->gender = p->GetGender();
+    nameResponse->class_ = p->GetClass();
+    SendPacket(std::move(nameResponse));
 }
 
 void WorldSession::SendNameQueryOpcodeFromDB(ObjectGuid guid)
@@ -59,34 +53,17 @@ void WorldSession::SendNameQueryOpcodeFromDB(ObjectGuid guid)
     // Using the cache...
     if (PlayerCacheData* pData = sObjectMgr.GetPlayerDataByGUID(guid.GetCounter()))
     {
-        std::string name = pData->sName;
-
+        auto nameResponse = std::make_unique<WorldPackets::Query::NameQueryResponse>();
+        nameResponse->playerGuid = ObjectGuid(HIGHGUID_PLAYER, pData->uiGuid);
+        nameResponse->name = pData->sName;
 #if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
-        WorldPacket data(SMSG_NAME_QUERY_RESPONSE, (8 + (name.size() + 1) + 1 + 4 + 4 + 4));
-        data << ObjectGuid(HIGHGUID_PLAYER, pData->uiGuid);
-        data << name;                                       // CString(48): played name
-        data << "";                                         // CString(256): realm name for cross realm BG usage
-#else
-        WorldPacket data(SMSG_NAME_QUERY_RESPONSE, (8 + (name.size() + 1) + 4 + 4 + 4));
-        data << ObjectGuid(HIGHGUID_PLAYER, pData->uiGuid);
-        data << name;
+        nameResponse->realmName = "";
 #endif
-        data << uint32(pData->uiRace);
-        data << uint32(pData->uiGender);
-        data << uint32(pData->uiClass);
-
-        SendPacket(&data);
+        nameResponse->race = pData->uiRace;
+        nameResponse->gender = pData->uiGender;
+        nameResponse->class_ = pData->uiClass;
+        SendPacket(std::move(nameResponse));
     }
-
-    // The old method was to query the database,
-    // but why would a client request the info of a player who was never logged in during the _current_ server uptime?
-    /*
-    CharacterDatabase.AsyncPQuery(&WorldSession::SendNameQueryOpcodeFromDBCallBack, GetAccountId(),
-    //          0     1     2     3       4
-        "SELECT guid, name, race, gender, class "
-        "FROM characters WHERE guid = '%u'",
-        guid.GetCounter());
-    */
 }
 
 void WorldSession::SendNameQueryOpcodeFromDBCallBack(QueryResult* result, uint32 accountId)
@@ -112,22 +89,17 @@ void WorldSession::SendNameQueryOpcodeFromDBCallBack(QueryResult* result, uint32
         pClass       = fields[4].GetUInt8();
     }
 
-    // guess size
+    auto nameResponse = std::make_unique<WorldPackets::Query::NameQueryResponse>();
+    nameResponse->playerGuid = ObjectGuid(HIGHGUID_PLAYER, lowguid);
+    nameResponse->name = name;
 #if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
-    WorldPacket data(SMSG_NAME_QUERY_RESPONSE, (8 + (name.size() + 1) + 1 + 4 + 4 + 4));
-    data << ObjectGuid(HIGHGUID_PLAYER, lowguid);
-    data << name;
-    data << "";                                            // realm name for cross realm BG usage
-#else
-    WorldPacket data(SMSG_NAME_QUERY_RESPONSE, (8 + (name.size() + 1) + 4 + 4 + 4));
-    data << ObjectGuid(HIGHGUID_PLAYER, lowguid);
-    data << name;
+    nameResponse->realmName = "";
 #endif
-    data << uint32(pRace);                                  // race
-    data << uint32(pGender);                                // gender
-    data << uint32(pClass);                                 // class
+    nameResponse->race = pRace;
+    nameResponse->gender = pGender;
+    nameResponse->class_ = pClass;
+    session->SendPacket(std::move(nameResponse));
 
-    session->SendPacket(&data);
     delete result;
 }
 
@@ -420,14 +392,13 @@ void WorldSession::HandlePageTextQueryOpcode(WorldPackets::Query::QueryPageText 
     while (pageID)
     {
         PageText const* pPage = sPageTextStore.LookupEntry<PageText>(pageID);
-        // guess size
-        WorldPacket data(SMSG_PAGE_TEXT_QUERY_RESPONSE, 50);
-        data << pageID;
+        auto pageResponse = std::make_unique<WorldPackets::Query::PageTextQueryResponse>();
+        pageResponse->pageId = pageID;
 
         if (!pPage)
         {
-            data << "Item page missing.";
-            data << uint32(0);
+            pageResponse->text = "Item page missing.";
+            pageResponse->nextPageId = 0;
             pageID = 0;
         }
         else
@@ -445,17 +416,17 @@ void WorldSession::HandlePageTextQueryOpcode(WorldPackets::Query::QueryPageText 
                 }
             }
 
-            data << text;
-            data << uint32(pPage->next_page);
+            pageResponse->text = text;
+            pageResponse->nextPageId = pPage->next_page;
             pageID = pPage->next_page;
         }
-        SendPacket(&data);
+        SendPacket(std::move(pageResponse));
     }
 }
 
 void WorldSession::SendQueryTimeResponse()
 {
-    WorldPacket data(SMSG_QUERY_TIME_RESPONSE, 4);
-    data << uint32(time(nullptr));
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Query::QueryTimeResponse>();
+    packet->time = static_cast<uint32>(time(nullptr));
+    SendPacket(std::move(packet));
 }

--- a/src/game/Handlers/QuestHandler.cpp
+++ b/src/game/Handlers/QuestHandler.cpp
@@ -634,10 +634,10 @@ void WorldSession::HandleQuestPushResult(WorldPackets::Quest::QuestPushResult co
 
     if (Player* pPlayer = ObjectAccessor::FindPlayer(questShareInfo->PlayerGuid))
     {
-        WorldPacket data(MSG_QUEST_PUSH_RESULT, (8 + 1));
-        data << _player->GetObjectGuid();
-        data << uint8(packet.msg);                             // enum QuestShareMessages
-        pPlayer->GetSession()->SendPacket(&data);
+        auto response = std::make_unique<WorldPackets::Quest::QuestPushResultResponse>();
+        response->senderGuid = _player->GetObjectGuid();
+        response->msg = packet.msg;                                // enum QuestShareMessages
+        pPlayer->GetSession()->SendPacket(std::move(response));
     }
 
     _player->ClearQuestShareInfo();

--- a/src/game/Handlers/SkillHandler.cpp
+++ b/src/game/Handlers/SkillHandler.cpp
@@ -36,10 +36,10 @@ void WorldSession::HandleLearnTalentOpcode(WorldPackets::Skill::LearnTalent cons
 
 void WorldSession::HandleTalentWipeConfirmOpcode(WorldPackets::Skill::TalentWipeConfirm const& packet)
 {
-    Creature* unit = GetPlayer()->GetNPCIfCanInteractWith(packet.guid, UNIT_NPC_FLAG_TRAINER);
+    Creature* unit = GetPlayer()->GetNPCIfCanInteractWith(packet.trainerGuid, UNIT_NPC_FLAG_TRAINER);
     if (!unit)
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "WORLD: HandleTalentWipeConfirmOpcode - %s not found or you can't interact with him.", packet.guid.GetString().c_str());
+        sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "WORLD: HandleTalentWipeConfirmOpcode - %s not found or you can't interact with him.", packet.trainerGuid.GetString().c_str());
         return;
     }
 
@@ -47,16 +47,13 @@ void WorldSession::HandleTalentWipeConfirmOpcode(WorldPackets::Skill::TalentWipe
     if (GetPlayer()->HasUnitState(UNIT_STATE_FEIGN_DEATH))
         GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
 
-    if (!(_player->ResetTalents()))
+    if (!_player->ResetTalents()) // TODO Move money check into this function and remove optional argument from `ResetTalents`
     {
-        WorldPacket data(MSG_TALENT_WIPE_CONFIRM, 8 + 4);   //you have not any talent
-        data << uint64(0);
-        data << uint32(0);
-        SendPacket(&data);
+        GetPlayer()->SendTalentWipeConfirm(ObjectGuid::Empty); // "You have not spent any talent points"
         return;
     }
 
-    unit->CastSpell(_player, 14867, true);                  //spell: "Untalent Visual Effect"
+    unit->CastSpell(_player, 14867, true); // spell: "Untalent Visual Effect"
 }
 
 void WorldSession::HandleUnlearnSkillOpcode(WorldPackets::Skill::UnlearnSkill const& packet)

--- a/src/game/Handlers/SpellHandler.cpp
+++ b/src/game/Handlers/SpellHandler.cpp
@@ -285,11 +285,8 @@ void WorldSession::HandleCastSpellOpcode(WorldPackets::Spell::CastSpell const& p
         // spells on yourself is frequently used within the core itself for certain mechanics.
         if (target == _player && IsExplicitlySelectedUnitTarget(spellInfo->EffectImplicitTargetA[0]) && !spellInfo->IsPositiveSpell(_player, target))
         {
-            WorldPacket data(SMSG_CAST_RESULT, (4 + 1 + 1));
-            data << uint32(packet.spellId);
-            data << uint8(2); // status = fail
-            data << uint8(SPELL_FAILED_BAD_TARGETS);
-            SendPacket(&data);
+            auto castPacket = std::make_unique<WorldPackets::Spell::CastResultSimpleFailure>(packet.spellId, SPELL_FAILED_BAD_TARGETS);
+            SendPacket(std::move(castPacket));
             return;
         }
 

--- a/src/game/Handlers/SpellHandler.cpp
+++ b/src/game/Handlers/SpellHandler.cpp
@@ -285,7 +285,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPackets::Spell::CastSpell const& p
         // spells on yourself is frequently used within the core itself for certain mechanics.
         if (target == _player && IsExplicitlySelectedUnitTarget(spellInfo->EffectImplicitTargetA[0]) && !spellInfo->IsPositiveSpell(_player, target))
         {
-            auto castPacket = std::make_unique<WorldPackets::Spell::CastResultSimpleFailure>(packet.spellId, SPELL_FAILED_BAD_TARGETS);
+            auto castPacket = std::make_unique<WorldPackets::Spell::CastResultSimpleFailure>(spellInfo, SPELL_FAILED_BAD_TARGETS);
             SendPacket(std::move(castPacket));
             return;
         }

--- a/src/game/Handlers/TaxiHandler.cpp
+++ b/src/game/Handlers/TaxiHandler.cpp
@@ -51,10 +51,10 @@ void WorldSession::SendTaxiStatus(ObjectGuid guid)
     if (curloc == 0)
         return;
 
-    WorldPacket data(SMSG_TAXINODE_STATUS, 9);
-    data << ObjectGuid(guid);
-    data << uint8(GetPlayer()->m_taxi.IsTaximaskNodeKnown(curloc) ? 1 : 0);
-    SendPacket(&data);
+    auto taxiPacket = std::make_unique<WorldPackets::Taxi::TaxiNodeStatus>();
+    taxiPacket->guid = guid;
+    taxiPacket->known = GetPlayer()->m_taxi.IsTaximaskNodeKnown(curloc) ? 1 : 0;
+    SendPacket(std::move(taxiPacket));
 }
 
 void WorldSession::HandleTaxiQueryAvailableNodes(WorldPackets::Taxi::TaxiQueryAvailableNodes const& packet)
@@ -124,13 +124,12 @@ bool WorldSession::SendLearnNewTaxiNode(Creature* unit)
 
     if (GetPlayer()->m_taxi.SetTaximaskNode(curloc))
     {
-        WorldPacket msg(SMSG_NEW_TAXI_PATH, 0);
-        SendPacket(&msg);
+        SendPacket(std::make_unique<WorldPackets::Taxi::NewTaxiPath>());
 
-        WorldPacket update(SMSG_TAXINODE_STATUS, 9);
-        update << ObjectGuid(unit->GetObjectGuid());
-        update << uint8(1);
-        SendPacket(&update);
+        auto taxiStatus = std::make_unique<WorldPackets::Taxi::TaxiNodeStatus>();
+        taxiStatus->guid = unit->GetObjectGuid();
+        taxiStatus->known = 1;
+        SendPacket(std::move(taxiStatus));
 
         return true;
     }

--- a/src/game/Handlers/TaxiHandler.cpp
+++ b/src/game/Handlers/TaxiHandler.cpp
@@ -128,7 +128,7 @@ bool WorldSession::SendLearnNewTaxiNode(Creature* unit)
 
         auto taxiStatus = std::make_unique<WorldPackets::Taxi::TaxiNodeStatus>();
         taxiStatus->guid = unit->GetObjectGuid();
-        taxiStatus->known = 1;
+        taxiStatus->known = true;
         SendPacket(std::move(taxiStatus));
 
         return true;

--- a/src/game/Handlers/TradeHandler.cpp
+++ b/src/game/Handlers/TradeHandler.cpp
@@ -36,38 +36,9 @@
 
 void WorldSession::SendTradeStatus(TradeStatus status)
 {
-    WorldPacket data;
-
-    switch (status)
-    {
-        case TRADE_STATUS_BEGIN_TRADE:
-            data.Initialize(SMSG_TRADE_STATUS, 4 + 8);
-            data << uint32(status);
-            data << uint64(0);
-            break;
-        case TRADE_STATUS_OPEN_WINDOW:
-            data.Initialize(SMSG_TRADE_STATUS, 4 + 4);
-            data << uint32(status);
-            break;
-        case TRADE_STATUS_CLOSE_WINDOW:
-            data.Initialize(SMSG_TRADE_STATUS, 4 + 4 + 1 + 4);
-            data << uint32(status);
-            data << uint32(0);
-            data << uint8(0);
-            data << uint32(0);
-            break;
-        case TRADE_STATUS_ONLY_CONJURED:
-            data.Initialize(SMSG_TRADE_STATUS, 4 + 1);
-            data << uint32(status);
-            data << uint8(0);
-            break;
-        default:
-            data.Initialize(SMSG_TRADE_STATUS, 4);
-            data << uint32(status);
-            break;
-    }
-
-    SendPacket(&data);
+    auto tradePacket = std::make_unique<WorldPackets::Trade::TradeStatus>();
+    tradePacket->status = status;
+    SendPacket(std::move(tradePacket));
 }
 
 void WorldSession::HandleIgnoreTradeOpcode(NullClientPacket const& /*packet*/)
@@ -683,10 +654,10 @@ void WorldSession::HandleInitiateTradeOpcode(WorldPackets::Trade::InitiateTrade 
     _player->m_trade->SetScamPreventionDelay(200);
     pOther->m_trade->SetScamPreventionDelay(200);
 
-    WorldPacket data(SMSG_TRADE_STATUS, 12);
-    data << uint32(TRADE_STATUS_BEGIN_TRADE);
-    data << ObjectGuid(_player->GetObjectGuid());
-    pOther->GetSession()->SendPacket(&data);
+    auto tradePacket = std::make_unique<WorldPackets::Trade::TradeStatus>();
+    tradePacket->status = TRADE_STATUS_BEGIN_TRADE;
+    tradePacket->playerGuid = _player->GetObjectGuid();
+    pOther->GetSession()->SendPacket(std::move(tradePacket));
 }
 
 void WorldSession::HandleSetTradeGoldOpcode(WorldPackets::Trade::SetTradeGold const& packet)

--- a/src/game/LFG/LFGHandler.cpp
+++ b/src/game/LFG/LFGHandler.cpp
@@ -126,15 +126,21 @@ void WorldSession::HandleMeetingStoneInfoOpcode(NullClientPacket const& /*packet
 
 void WorldSession::SendMeetingstoneFailed(uint8 status)
 {
-    WorldPacket data(SMSG_MEETINGSTONE_JOINFAILED, 1);
-    data << uint8(status);
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Misc::MeetingstoneJoinFailed>();
+    packet->reason = status;
+    SendPacket(std::move(packet));
 }
 
 void WorldSession::SendMeetingstoneSetqueue(uint32 areaid, uint8 status)
 {
-    WorldPacket data(SMSG_MEETINGSTONE_SETQUEUE, 5);
-    data << uint32(areaid);
-    data << uint8(status);
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Misc::MeetingstoneSetQueue>();
+
+    packet->areaId = areaid;
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_4_2
+    packet->idempotencyToken = 0; // TODO: Must forward this but there are soo many callsites of `SendMeetingstoneSetqueue`
+#else
+    packet->status = status;
+#endif
+
+    SendPacket(std::move(packet));
 }

--- a/src/game/LFG/LFGMgr.cpp
+++ b/src/game/LFG/LFGMgr.cpp
@@ -285,15 +285,16 @@ void LFGMgr::UpdateGroup(Group* group, bool join, ObjectGuid playerGuid)
 
 void LFGMgr::BuildSetQueuePacket(WorldPacket& data, uint32 areaId, uint8 status)
 {
-#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_4_2
-    data.Initialize(SMSG_MEETINGSTONE_SETQUEUE, 5);
-    data << uint32(areaId);
-    data << uint8(status);
+    WorldPackets::Misc::MeetingstoneSetQueue packet;
+    packet.areaId = areaId;
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_4_2
+    packet.idempotencyToken = 0; // TODO: Must forward this but there are soo many callsites of `BuildSetQueuePacket`
 #else
-    data.Initialize(SMSG_MEETINGSTONE_SETQUEUE, 12);
-    data << uint64(status);
-    data << uint32(areaId);
+    packet.status = status;
 #endif
+
+    // TODO Use broadcaster which does the binary conversion automatically
+    packet.AppendBodyTo(data);
 }
 
 void LFGMgr::BuildMemberAddedPacket(WorldPacket& data, ObjectGuid plrGuid)

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -3486,8 +3486,7 @@ void Map::CrashUnload()
 
 
             // Go back to character selection
-            WorldPacket data(SMSG_LOGOUT_COMPLETE, 0);
-            session->SendPacket(&data);
+            session->SendPacket(std::make_unique<WorldPackets::Misc::LogoutComplete>());
             session->LogoutPlayer(false);
         }
     }

--- a/src/game/ObjectGuid.cpp
+++ b/src/game/ObjectGuid.cpp
@@ -26,6 +26,8 @@
 
 #include <sstream>
 
+ObjectGuid const ObjectGuid::Empty = ObjectGuid{};
+
 char const* ObjectGuid::GetTypeName(HighGuid high)
 {
     switch (high)

--- a/src/game/ObjectGuid.h
+++ b/src/game/ObjectGuid.h
@@ -124,10 +124,12 @@ struct PackedGuidReader
 class ObjectGuid
 {
     public:                                                 // constructors
-        ObjectGuid() : m_guid(0) {}
-        ObjectGuid(uint64 const& guid) : m_guid(guid) {}    // temporary allowed implicit cast, really bad in connection with operator uint64()
-        ObjectGuid(HighGuid hi, uint32 entry, uint32 counter) : m_guid(counter ? uint64(counter) | (uint64(entry) << 24) | (uint64(hi) << 48) : 0) {}
-        ObjectGuid(HighGuid hi, uint32 counter) : m_guid(counter ? uint64(counter) | (uint64(hi) << 48) : 0) {}
+        constexpr ObjectGuid() : m_guid(0) {}
+        constexpr ObjectGuid(uint64 const& guid) : m_guid(guid) {}    // temporary allowed implicit cast, really bad in connection with operator uint64()
+        constexpr ObjectGuid(HighGuid hi, uint32 entry, uint32 counter) : m_guid(counter ? uint64(counter) | (uint64(entry) << 24) | (uint64(hi) << 48) : 0) {}
+        constexpr ObjectGuid(HighGuid hi, uint32 counter) : m_guid(counter ? uint64(counter) | (uint64(hi) << 48) : 0) {}
+
+        static ObjectGuid const Empty;
 
     //private:
         explicit ObjectGuid(uint32 const& lowGuid) : m_guid(lowGuid) {} // Besoin dans OutdoorPvP par exemple
@@ -138,18 +140,20 @@ class ObjectGuid
 
     public:                                                 // modifiers
         PackedGuidReader ReadAsPacked() { return PackedGuidReader(*this); }
+        PackedGuid WriteAsPacked() const;
 
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
-        // TODO: Remove `ReadAsPacked` when transformation is done
+        // TODO: Remove `ReadAsPacked` & `WriteAsPacked` when transformation is done
         PackedGuidReader ReadAsPackedClientBuildAware() { return PackedGuidReader(*this); }
+        PackedGuid WriteAsPackedClientBuildAware() const;
 #else
         ObjectGuid& ReadAsPackedClientBuildAware() { return *this; }
+        uint64 WriteAsPackedClientBuildAware() const { return GetRawValue(); }
 #endif
 
         void Set(uint64 const& guid);
         void Clear() { m_guid = 0; }
 
-        PackedGuid WriteAsPacked() const;
     public:                                                 // accessors
         uint64 const& GetRawValue() const { return m_guid; }
         static HighGuid GetHigh(uint64 guid) { return HighGuid((guid >> 48) & 0x0000FFFF); }
@@ -335,5 +339,8 @@ ByteBuffer& operator<< (ByteBuffer& buf, PackedGuid const& guid);
 ByteBuffer& operator>> (ByteBuffer& buf, PackedGuidReader const& guid);
 
 inline PackedGuid ObjectGuid::WriteAsPacked() const { return PackedGuid(*this); }
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
+inline PackedGuid ObjectGuid::WriteAsPackedClientBuildAware() const { return WriteAsPacked(); }
+#endif
 
 #endif

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -6854,8 +6854,7 @@ void Player::CheckDuelDistance(time_t currTime)
         {
             m_duel->outOfBound = currTime;
 
-            WorldPacket data(SMSG_DUEL_OUTOFBOUNDS, 0);
-            GetSession()->SendPacket(&data);
+            GetSession()->SendPacket(std::make_unique<WorldPackets::Duel::DuelOutOfBounds>());
         }
     }
     else
@@ -6865,8 +6864,7 @@ void Player::CheckDuelDistance(time_t currTime)
         {
             m_duel->outOfBound = 0;
 
-            WorldPacket data(SMSG_DUEL_INBOUNDS, 0);
-            GetSession()->SendPacket(&data);
+            GetSession()->SendPacket(std::make_unique<WorldPackets::Duel::DuelInBounds>());
         }
         else if (currTime >= (m_duel->outOfBound + 10))
         {
@@ -8159,15 +8157,14 @@ void Player::SendLoot(ObjectGuid guid, LootType lootType, Player const* pVictim)
 
 void Player::SendNotifyLootMoneyRemoved() const
 {
-    WorldPacket data(SMSG_LOOT_CLEAR_MONEY, 0);
-    GetSession()->SendPacket(&data);
+    GetSession()->SendPacket(std::make_unique<WorldPackets::Loot::LootClearMoney>());
 }
 
 void Player::SendLootMoneyNotify(uint32 amount) const
 {
-    WorldPacket data(SMSG_LOOT_MONEY_NOTIFY, 4);
-    data << uint32(amount);
-    GetSession()->SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Loot::LootMoneyNotify>();
+    packet->amount = amount;
+    GetSession()->SendPacket(std::move(packet));
 }
 
 void Player::SendNotifyLootItemRemoved(uint8 lootSlot) const
@@ -8419,12 +8416,12 @@ void Player::SetBindPoint(ObjectGuid guid) const
 #endif
 }
 
-void Player::SendTalentWipeConfirm(ObjectGuid guid) const
+void Player::SendTalentWipeConfirm(ObjectGuid trainerGuid) const
 {
-    WorldPacket data(MSG_TALENT_WIPE_CONFIRM, (8 + 4));
-    data << ObjectGuid(guid);
-    data << uint32(GetResetTalentsCost());
-    GetSession()->SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Skill::TalentWipeConfirmResponse>();
+    packet->trainerGuid = trainerGuid;
+    packet->cost = GetResetTalentsCost();
+    GetSession()->SendPacket(std::move(packet));
 }
 
 void Player::SendPetSkillWipeConfirm() const
@@ -13464,8 +13461,7 @@ bool Player::SatisfyQuestLog(bool msg) const
 
     if (msg)
     {
-        WorldPacket data(SMSG_QUESTLOG_FULL, 0);
-        GetSession()->SendPacket(&data);
+        GetSession()->SendPacket(std::make_unique<WorldPackets::Quest::QuestLogFull>());
     }
     return false;
 }
@@ -17142,38 +17138,32 @@ void Player::SavePositionInDB(ObjectGuid guid, uint32 mapId, float x, float y, f
 
 void Player::SendAttackSwingNotInRange() const
 {
-    WorldPacket data(SMSG_ATTACKSWING_NOTINRANGE, 0);
-    GetSession()->SendPacket(&data);
+    GetSession()->SendPacket(std::make_unique<WorldPackets::Combat::AttackSwingNotInRange>());
 }
 
 void Player::SendAttackSwingNotStanding() const
 {
-    WorldPacket data(SMSG_ATTACKSWING_NOTSTANDING, 0);
-    GetSession()->SendPacket(&data);
+    GetSession()->SendPacket(std::make_unique<WorldPackets::Combat::AttackSwingNotStanding>());
 }
 
 void Player::SendAttackSwingDeadTarget() const
 {
-    WorldPacket data(SMSG_ATTACKSWING_DEADTARGET, 0);
-    GetSession()->SendPacket(&data);
+    GetSession()->SendPacket(std::make_unique<WorldPackets::Combat::AttackSwingDeadTarget>());
 }
 
 void Player::SendAttackSwingCantAttack() const
 {
-    WorldPacket data(SMSG_ATTACKSWING_CANT_ATTACK, 0);
-    GetSession()->SendPacket(&data);
+    GetSession()->SendPacket(std::make_unique<WorldPackets::Combat::AttackSwingCantAttack>());
 }
 
 void Player::SendAttackSwingCancelAttack() const
 {
-    WorldPacket data(SMSG_CANCEL_COMBAT, 0);
-    GetSession()->SendPacket(&data);
+    GetSession()->SendPacket(std::make_unique<WorldPackets::Combat::CancelCombat>());
 }
 
 void Player::SendAttackSwingBadFacingAttack() const
 {
-    WorldPacket data(SMSG_ATTACKSWING_BADFACING, 0);
-    GetSession()->SendPacket(&data);
+    GetSession()->SendPacket(std::make_unique<WorldPackets::Combat::AttackSwingBadFacing>());
 }
 
 void Player::SendAutoRepeatCancel() const
@@ -21600,7 +21590,6 @@ bool Player::ChangeReputationsForRace(uint8 oldRace, uint8 newRace)
     if (!changeTeam)
         return true;
     Team newTeam = TeamForRace(newRace);
-#define SWAP_TYPE(type, val1, val2) { type tmp; tmp = val1; val1 = val2; val2 = tmp; }
     // Certaines reputs a inverser
     for (std::map<uint32, uint32>::const_iterator it = sObjectMgr.factionchange_reputations.begin(); it != sObjectMgr.factionchange_reputations.end(); ++it)
     {
@@ -21614,8 +21603,8 @@ bool Player::ChangeReputationsForRace(uint8 oldRace, uint8 newRace)
         if (!pNew || !pOld)
             continue;
         CHANGERACE_LOG("Changement reputation %u (%i) <-> %u (%i)", my_new_reputation->ID, pNew->Standing, my_old_reputation->ID, pOld->Standing);
-        SWAP_TYPE(uint32, pNew->Flags, pOld->Flags);
-        SWAP_TYPE(int32, pNew->Standing, pOld->Standing);
+        std::swap(pNew->Flags, pOld->Flags);
+        std::swap(pNew->Standing, pOld->Standing);
         pOld->needSave = true;
         pNew->needSave = true;
         GetReputationMgr().SendState(pOld);
@@ -22033,8 +22022,7 @@ void Player::TaxiStepFinished(bool lastPointReached)
         {
             if (m_taxi.SetTaximaskNode(sourcenode))
             {
-                WorldPacket data(SMSG_NEW_TAXI_PATH, 0);
-                GetSession()->SendPacket(&data);
+                GetSession()->SendPacket(std::make_unique<WorldPackets::Taxi::NewTaxiPath>());
             }
         }
 

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1411,7 +1411,7 @@ class Player final: public Unit
         uint32 GetResetTalentsCost() const;
         void UpdateResetTalentsMultiplier() const;
         uint32 CalculateTalentsPoints() const;
-        void SendTalentWipeConfirm(ObjectGuid guid) const;
+        void SendTalentWipeConfirm(ObjectGuid trainerGuid) const;
     public:
         uint32 GetFreeTalentPoints() const { return GetUInt32Value(PLAYER_CHARACTER_POINTS1); }
         void SetFreeTalentPoints(uint32 points) { SetUInt32Value(PLAYER_CHARACTER_POINTS1, points); }

--- a/src/game/Objects/PlayerTaxi.h
+++ b/src/game/Objects/PlayerTaxi.h
@@ -54,6 +54,7 @@ public:
             return false;
     }
     void AppendTaximaskTo(ByteBuffer& data, bool all);
+    TaxiMask const& GetTaxiMask() const { return m_taximask; }
 
     // Destinations
     bool LoadTaxiDestinationsFromString(std::string const& values, Team team);

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -657,7 +657,7 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
         if (damagetype != SELF_DAMAGE)
 #endif
             RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
-        
+
         // feign death does not break from environmental damage, tested on classic
         if (damagetype != SELF_DAMAGE)
             RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
@@ -892,7 +892,7 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
                     // skip channeled spell (processed differently below)
                     if (i == CURRENT_CHANNELED_SPELL)
                         continue;
-    
+
                     if (Spell* spell = pVictim->GetCurrentSpell(CurrentSpellTypes(i)))
                     {
                         if (spell->getState() == SPELL_STATE_PREPARING)

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -9266,7 +9266,7 @@ void Unit::SendPetCastFail(uint32 spellid, SpellCastResult msg)
     {
         WorldPacket data(SMSG_PET_CAST_FAILED, 4 + 1 + 1);
         data << uint32(spellid);
-        data << uint8(2); // 1.12: for SMSG_CAST_RESULT probably 2 = failure, 0 = success.
+        data << static_cast<uint8>(SPELL_RESULT_STATUS_FAIL);
         data << uint8(msg);
         pOwner->GetSession()->SendPacket(&data);
     }

--- a/src/game/ReputationMgr.cpp
+++ b/src/game/ReputationMgr.cpp
@@ -249,7 +249,7 @@ bool ReputationMgr::SetReputation(FactionEntry const* factionEntry, int32 standi
             }
         }
     }
-    
+
     // spillover done, update faction itself
     bool res = false;
     FactionStateList::iterator faction = m_factions.find(factionEntry->reputationListID);

--- a/src/game/Server/Packet.h
+++ b/src/game/Server/Packet.h
@@ -21,6 +21,13 @@ public:
     uint16 GetOpcode() const { return opcode; }
 };
 
+class ServerPacket : public Packet
+{
+public:
+    explicit ServerPacket(uint16 opcode) : Packet(opcode) {}
+    virtual void AppendBodyTo(ByteBuffer& buffer) const = 0;
+};
+
 class ClientPacket : public Packet
 {
 public:

--- a/src/game/Server/Packets/AuctionHouse.cpp
+++ b/src/game/Server/Packets/AuctionHouse.cpp
@@ -62,3 +62,36 @@ void WorldPackets::AuctionHouse::AuctionListItems::ReadFromWorldPacket(WorldPack
     recv_data >> usable;
 }
 
+void WorldPackets::AuctionHouse::AuctionRemovedNotification::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << auctionId;
+    buffer << itemTemplate;
+    buffer << randomPropertyId;
+}
+
+void WorldPackets::AuctionHouse::AuctionHelloResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << auctioneerGuid;
+    buffer << houseId;
+}
+
+void WorldPackets::AuctionHouse::AuctionBidderNotification::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << houseId;
+    buffer << auctionId;
+    buffer << bidderGuid;
+    buffer << bidOrZero;
+    buffer << outBid;
+    buffer << itemTemplate;
+    buffer << randomPropertyId;
+}
+
+void WorldPackets::AuctionHouse::AuctionOwnerNotification::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << auctionId;
+    buffer << bid;
+    buffer << outBid;
+    buffer << bidderGuid;
+    buffer << itemTemplate;
+    buffer << randomPropertyId;
+}

--- a/src/game/Server/Packets/AuctionHouse.h
+++ b/src/game/Server/Packets/AuctionHouse.h
@@ -89,6 +89,57 @@ namespace WorldPackets { namespace AuctionHouse
         explicit AuctionListItems() : ClientPacket(CMSG_AUCTION_LIST_ITEMS) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class AuctionRemovedNotification final : public ServerPacket
+    {
+    public:
+        uint32 auctionId = 0;
+        uint32 itemTemplate = 0;
+        uint32 randomPropertyId = 0; // random property (value > 0) or suffix (value < 0)
+
+        explicit AuctionRemovedNotification() : ServerPacket(SMSG_AUCTION_REMOVED_NOTIFICATION) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AuctionHelloResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid auctioneerGuid;
+        uint32 houseId = 0;
+
+        explicit AuctionHelloResponse() : ServerPacket(MSG_AUCTION_HELLO) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AuctionBidderNotification final : public ServerPacket
+    {
+    public:
+        uint32 houseId = 0;
+        uint32 auctionId = 0;
+        ObjectGuid bidderGuid;
+        uint32 bidOrZero = 0;   // if 0, client shows ERR_AUCTION_WON_S, else ERR_AUCTION_OUTBID_S
+        uint32 outBid = 0;
+        uint32 itemTemplate = 0;
+        uint32 randomPropertyId = 0;
+
+        explicit AuctionBidderNotification() : ServerPacket(SMSG_AUCTION_BIDDER_NOTIFICATION) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AuctionOwnerNotification final : public ServerPacket
+    {
+    public:
+        uint32 auctionId = 0;
+        uint32 bid = 0;
+        uint32 outBid = 0;
+        ObjectGuid bidderGuid;
+        uint32 itemTemplate = 0;
+        uint32 randomPropertyId = 0;
+
+        explicit AuctionOwnerNotification() : ServerPacket(SMSG_AUCTION_OWNER_NOTIFICATION) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
 }} // namespace WorldPackets::AuctionHouse
 
 #endif // MANGOS_PACKETS_AUCTIONHOUSE_H

--- a/src/game/Server/Packets/Battleground.cpp
+++ b/src/game/Server/Packets/Battleground.cpp
@@ -55,3 +55,10 @@ void WorldPackets::Battleground::BattlefieldJoin::ReadFromWorldPacket(WorldPacke
 {
     recv_data >> mapId;
 }
+
+void WorldPackets::Battleground::GroupJoinedBattleground::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << result;
+}
+
+

--- a/src/game/Server/Packets/Battleground.h
+++ b/src/game/Server/Packets/Battleground.h
@@ -95,6 +95,17 @@ namespace WorldPackets { namespace Battleground
         explicit BattlefieldJoin() : ClientPacket(CMSG_BATTLEFIELD_JOIN) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class GroupJoinedBattleground final : public ServerPacket
+    {
+    public:
+        uint32 result = 0;
+
+        explicit GroupJoinedBattleground() : ServerPacket(SMSG_GROUP_JOINED_BATTLEGROUND) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Battleground
 
 #endif // MANGOS_PACKETS_BATTLEGROUND_H

--- a/src/game/Server/Packets/Channel.cpp
+++ b/src/game/Server/Packets/Channel.cpp
@@ -90,3 +90,9 @@ void WorldPackets::Channel::ChannelModerate::ReadFromWorldPacket(WorldPacket& re
 {
     recv_data >> channelName;
 }
+
+void WorldPackets::Channel::ChannelNotify::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << uint8(type);
+    buffer << channelName;
+}

--- a/src/game/Server/Packets/Channel.cpp
+++ b/src/game/Server/Packets/Channel.cpp
@@ -93,6 +93,6 @@ void WorldPackets::Channel::ChannelModerate::ReadFromWorldPacket(WorldPacket& re
 
 void WorldPackets::Channel::ChannelNotify::AppendBodyTo(ByteBuffer& buffer) const
 {
-    buffer << uint8(type);
+    buffer << type;
     buffer << channelName;
 }

--- a/src/game/Server/Packets/Channel.h
+++ b/src/game/Server/Packets/Channel.h
@@ -159,6 +159,17 @@ namespace WorldPackets { namespace Channel
         explicit ChannelModerate() : ClientPacket(CMSG_CHANNEL_MODERATE) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class ChannelNotify final : public ServerPacket
+    {
+    public:
+        uint8 type = 0;
+        std::string channelName;
+
+        explicit ChannelNotify() : ServerPacket(SMSG_CHANNEL_NOTIFY) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
 }} // namespace WorldPackets::Channel
 
 #endif // MANGOS_PACKETS_CHANNEL_H

--- a/src/game/Server/Packets/Character.cpp
+++ b/src/game/Server/Packets/Character.cpp
@@ -1,4 +1,5 @@
 #include "Character.h"
+#include "SharedDefines.h"
 
 void WorldPackets::Character::CharCreate::ReadFromWorldPacket(WorldPacket& recv_data)
 {
@@ -32,3 +33,29 @@ void WorldPackets::Character::CharRename::ReadFromWorldPacket(WorldPacket& recv_
     recv_data >> guid;
     recv_data >> newname;
 }
+
+void WorldPackets::Character::CharCreateResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << result;
+}
+
+void WorldPackets::Character::CharDeleteResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << result;
+}
+
+void WorldPackets::Character::CharacterLoginFailed::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << result;
+}
+
+void WorldPackets::Character::LoginVerifyWorld::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << location.mapId;
+    buffer << location.x;
+    buffer << location.y;
+    buffer << location.z;
+    buffer << location.o;
+}
+
+

--- a/src/game/Server/Packets/Character.h
+++ b/src/game/Server/Packets/Character.h
@@ -3,9 +3,48 @@
 
 #include "Packet.h"
 #include "ObjectGuid.h"
+#include "SharedDefines.h"
+
+#include <string>
+#include <vector>
 
 namespace WorldPackets { namespace Character
 {
+    static constexpr uint8 CHAR_ENUM_EQUIPMENT_SLOTS = 20; // INVENTORY_SLOT_BAG_START + 1
+
+    struct CharEnumEquipmentSlot
+    {
+        uint32 displayInfoId = 0;
+        uint8  inventoryType = 0;
+    };
+
+    struct CharEnumData
+    {
+        ObjectGuid guid;
+        std::string name;
+        uint8  race = 0;
+        uint8  class_ = 0;
+        uint8  gender = 0;
+        uint8  skin = 0;
+        uint8  face = 0;
+        uint8  hairStyle = 0;
+        uint8  hairColor = 0;
+        uint8  facialHair = 0;
+        uint8  level = 0;
+        uint32 zone = 0;
+        uint32 map = 0;
+        float  x = 0.f;
+        float  y = 0.f;
+        float  z = 0.f;
+        uint32 guildId = 0;
+        uint32 charFlags = 0;
+        uint8  firstLogin = 0;
+        uint32 petDisplayId = 0;
+        uint32 petLevel = 0;
+        uint32 petFamily = 0;
+        CharEnumEquipmentSlot equipment[CHAR_ENUM_EQUIPMENT_SLOTS] = {};
+    };
+
     class CharCreate final : public ClientPacket
     {
     public:
@@ -45,6 +84,44 @@ namespace WorldPackets { namespace Character
         explicit CharRename() : ClientPacket(CMSG_CHAR_RENAME) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class CharCreateResponse final : public ServerPacket
+    {
+    public:
+        uint8 result = 0;
+
+        explicit CharCreateResponse() : ServerPacket(SMSG_CHAR_CREATE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class CharDeleteResponse final : public ServerPacket
+    {
+    public:
+        uint8 result = 0;
+
+        explicit CharDeleteResponse() : ServerPacket(SMSG_CHAR_DELETE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class CharacterLoginFailed final : public ServerPacket
+    {
+    public:
+        uint8 result = 0;
+
+        explicit CharacterLoginFailed() : ServerPacket(SMSG_CHARACTER_LOGIN_FAILED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class LoginVerifyWorld final : public ServerPacket
+    {
+    public:
+        WorldLocation location;
+
+        explicit LoginVerifyWorld() : ServerPacket(SMSG_LOGIN_VERIFY_WORLD) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Character
 
 #endif // MANGOS_PACKETS_CHARACTER_H

--- a/src/game/Server/Packets/Chat.cpp
+++ b/src/game/Server/Packets/Chat.cpp
@@ -10,3 +10,20 @@ void WorldPackets::Chat::ChatMessage::ReadFromWorldPacket(WorldPacket& recv_data
 
     recv_data >> message;
 }
+
+// --- Server Packets ---
+
+void WorldPackets::Chat::ChatWrongFaction::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
+void WorldPackets::Chat::ChatRestricted::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+#endif
+
+void WorldPackets::Chat::ChatPlayerNotFound::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << name;
+}

--- a/src/game/Server/Packets/Chat.h
+++ b/src/game/Server/Packets/Chat.h
@@ -17,6 +17,33 @@ namespace WorldPackets { namespace Chat
         explicit ChatMessage() : ClientPacket(CMSG_MESSAGECHAT), type(0), lang(0) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class ChatWrongFaction final : public ServerPacket
+    {
+    public:
+        explicit ChatWrongFaction() : ServerPacket(SMSG_CHAT_WRONG_FACTION) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
+    class ChatRestricted final : public ServerPacket
+    {
+    public:
+        explicit ChatRestricted() : ServerPacket(SMSG_CHAT_RESTRICTED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+#endif
+
+    class ChatPlayerNotFound final : public ServerPacket
+    {
+    public:
+        std::string name;
+
+        explicit ChatPlayerNotFound() : ServerPacket(SMSG_CHAT_PLAYER_NOT_FOUND) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Chat
 
 #endif // MANGOS_PACKETS_CHAT_H

--- a/src/game/Server/Packets/Combat.cpp
+++ b/src/game/Server/Packets/Combat.cpp
@@ -9,3 +9,36 @@ void WorldPackets::Combat::SetSheathed::ReadFromWorldPacket(WorldPacket& recv_da
 {
     recv_data >> sheathed;
 }
+
+// --- Server Packets ---
+
+void WorldPackets::Combat::AttackSwingNotInRange::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Combat::AttackSwingNotStanding::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Combat::AttackSwingDeadTarget::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Combat::AttackSwingCantAttack::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Combat::CancelCombat::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Combat::AttackSwingBadFacing::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Combat::AttackStop::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << attackerGuid.WriteAsPackedClientBuildAware();
+    buffer << victimGuid.WriteAsPackedClientBuildAware();
+    buffer << static_cast<uint32>(isDead); // is 32bit on client
+}

--- a/src/game/Server/Packets/Combat.h
+++ b/src/game/Server/Packets/Combat.h
@@ -23,6 +23,61 @@ namespace WorldPackets { namespace Combat
         explicit SetSheathed() : ClientPacket(CMSG_SETSHEATHED) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class AttackSwingNotInRange final : public ServerPacket
+    {
+    public:
+        explicit AttackSwingNotInRange() : ServerPacket(SMSG_ATTACKSWING_NOTINRANGE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AttackSwingNotStanding final : public ServerPacket
+    {
+    public:
+        explicit AttackSwingNotStanding() : ServerPacket(SMSG_ATTACKSWING_NOTSTANDING) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AttackSwingDeadTarget final : public ServerPacket
+    {
+    public:
+        explicit AttackSwingDeadTarget() : ServerPacket(SMSG_ATTACKSWING_DEADTARGET) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AttackSwingCantAttack final : public ServerPacket
+    {
+    public:
+        explicit AttackSwingCantAttack() : ServerPacket(SMSG_ATTACKSWING_CANT_ATTACK) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class CancelCombat final : public ServerPacket
+    {
+    public:
+        explicit CancelCombat() : ServerPacket(SMSG_CANCEL_COMBAT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AttackSwingBadFacing final : public ServerPacket
+    {
+    public:
+        explicit AttackSwingBadFacing() : ServerPacket(SMSG_ATTACKSWING_BADFACING) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class AttackStop final : public ServerPacket
+    {
+    public:
+        ObjectGuid attackerGuid;
+        ObjectGuid victimGuid;
+        bool isDead = false;
+
+        explicit AttackStop() : ServerPacket(SMSG_ATTACKSTOP) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Combat
 
 #endif // MANGOS_PACKETS_COMBAT_H

--- a/src/game/Server/Packets/Duel.cpp
+++ b/src/game/Server/Packets/Duel.cpp
@@ -9,3 +9,13 @@ void WorldPackets::Duel::DuelCancelled::ReadFromWorldPacket(WorldPacket& recv_da
 {
     recv_data >> playerGuid;
 }
+
+// --- Server Packets ---
+
+void WorldPackets::Duel::DuelOutOfBounds::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Duel::DuelInBounds::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}

--- a/src/game/Server/Packets/Duel.h
+++ b/src/game/Server/Packets/Duel.h
@@ -23,6 +23,22 @@ namespace WorldPackets { namespace Duel
         explicit DuelCancelled() : ClientPacket(CMSG_DUEL_CANCELLED) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class DuelOutOfBounds final : public ServerPacket
+    {
+    public:
+        explicit DuelOutOfBounds() : ServerPacket(SMSG_DUEL_OUTOFBOUNDS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class DuelInBounds final : public ServerPacket
+    {
+    public:
+        explicit DuelInBounds() : ServerPacket(SMSG_DUEL_INBOUNDS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Duel
 
 #endif // MANGOS_PACKETS_DUEL_H

--- a/src/game/Server/Packets/GmTicket.cpp
+++ b/src/game/Server/Packets/GmTicket.cpp
@@ -40,3 +40,25 @@ void WorldPackets::GmTicket::GMSurveySubmit::ReadFromWorldPacket(WorldPacket& re
     recv_data >> comment;
 }
 #endif
+
+void WorldPackets::GmTicket::GmTicketUpdateTextResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << response;
+}
+
+void WorldPackets::GmTicket::GmTicketDeleteTicketResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << response;
+}
+
+void WorldPackets::GmTicket::GmTicketCreateResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << response;
+}
+
+void WorldPackets::GmTicket::GmTicketSystemStatus::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << status;
+}
+
+

--- a/src/game/Server/Packets/GmTicket.h
+++ b/src/game/Server/Packets/GmTicket.h
@@ -3,7 +3,6 @@
 
 #include "Packet.h"
 #include "SharedDefines.h"
-#include "nonstd/optional.hpp"
 #include <string>
 #include <vector>
 

--- a/src/game/Server/Packets/GmTicket.h
+++ b/src/game/Server/Packets/GmTicket.h
@@ -3,6 +3,7 @@
 
 #include "Packet.h"
 #include "SharedDefines.h"
+#include "nonstd/optional.hpp"
 #include <string>
 #include <vector>
 
@@ -50,6 +51,44 @@ namespace WorldPackets { namespace GmTicket
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
 #endif
+
+    // --- Server Packets ---
+
+    class GmTicketUpdateTextResponse final : public ServerPacket
+    {
+    public:
+        uint32 response = 0;
+
+        explicit GmTicketUpdateTextResponse() : ServerPacket(SMSG_GMTICKET_UPDATETEXT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GmTicketDeleteTicketResponse final : public ServerPacket
+    {
+    public:
+        uint32 response = 0;
+
+        explicit GmTicketDeleteTicketResponse() : ServerPacket(SMSG_GMTICKET_DELETETICKET) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GmTicketCreateResponse final : public ServerPacket
+    {
+    public:
+        uint32 response = 0;
+
+        explicit GmTicketCreateResponse() : ServerPacket(SMSG_GMTICKET_CREATE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GmTicketSystemStatus final : public ServerPacket
+    {
+    public:
+        uint32 status = 0;
+
+        explicit GmTicketSystemStatus() : ServerPacket(SMSG_GMTICKET_SYSTEMSTATUS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
 
 }} // namespace WorldPackets::GmTicket
 

--- a/src/game/Server/Packets/Group.cpp
+++ b/src/game/Server/Packets/Group.cpp
@@ -1,4 +1,5 @@
 #include "Group.h"
+#include "Group/Group.h"
 
 void WorldPackets::Group::GroupInvite::ReadFromWorldPacket(WorldPacket& recv_data)
 {
@@ -88,5 +89,45 @@ void WorldPackets::Group::RaidReadyCheck::ReadFromWorldPacket(WorldPacket& recv_
         recv_data >> s;
         state = s;
     }
+}
+#endif
+
+void WorldPackets::Group::PartyCommandResult::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << operation;
+    buffer << memberName;
+    buffer << result;
+}
+
+void WorldPackets::Group::GroupInviteNotification::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << inviterName;
+}
+
+void WorldPackets::Group::GroupDeclineNotification::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << playerName;
+}
+
+void WorldPackets::Group::GroupUninviteNotification::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Group::GroupDestroyed::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2
+void WorldPackets::Group::RaidReadyCheckResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << senderGuid;
+    buffer << state;
+}
+
+void WorldPackets::Group::RaidTargetUpdateDelta::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << uint8(0); // 0 = delta update
+    buffer << iconId;
+    buffer << targetGuid;
 }
 #endif

--- a/src/game/Server/Packets/Group.h
+++ b/src/game/Server/Packets/Group.h
@@ -150,17 +150,6 @@ namespace WorldPackets { namespace Group
 
     // --- Server Packets ---
 
-    static constexpr uint8 PARTY_MAX_POSITIVE_AURAS = 32;  // MAX_POSITIVE_AURAS
-    static constexpr uint8 PARTY_MAX_NEGATIVE_AURAS = 16;  // MAX_AURAS - MAX_POSITIVE_AURAS
-
-    struct PartyMemberAuraData
-    {
-        uint32 positiveAuraMask = 0;
-        uint16 positiveAuras[PARTY_MAX_POSITIVE_AURAS] = {};
-        uint16 negativeAuraMask = 0;
-        uint16 negativeAuras[PARTY_MAX_NEGATIVE_AURAS] = {};
-    };
-
     class PartyCommandResult final : public ServerPacket
     {
     public:

--- a/src/game/Server/Packets/Group.h
+++ b/src/game/Server/Packets/Group.h
@@ -5,6 +5,9 @@
 #include "ObjectGuid.h"
 #include "nonstd/optional.hpp"
 
+#include <string>
+#include <vector>
+
 namespace WorldPackets { namespace Group
 {
     class GroupInvite final : public ClientPacket
@@ -142,6 +145,85 @@ namespace WorldPackets { namespace Group
 
         explicit RaidReadyCheck() : ClientPacket(MSG_RAID_READY_CHECK) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
+    };
+#endif
+
+    // --- Server Packets ---
+
+    static constexpr uint8 PARTY_MAX_POSITIVE_AURAS = 32;  // MAX_POSITIVE_AURAS
+    static constexpr uint8 PARTY_MAX_NEGATIVE_AURAS = 16;  // MAX_AURAS - MAX_POSITIVE_AURAS
+
+    struct PartyMemberAuraData
+    {
+        uint32 positiveAuraMask = 0;
+        uint16 positiveAuras[PARTY_MAX_POSITIVE_AURAS] = {};
+        uint16 negativeAuraMask = 0;
+        uint16 negativeAuras[PARTY_MAX_NEGATIVE_AURAS] = {};
+    };
+
+    class PartyCommandResult final : public ServerPacket
+    {
+    public:
+        uint32 operation = 0;
+        std::string memberName; // max len 48
+        uint32 result = 0;
+
+        explicit PartyCommandResult() : ServerPacket(SMSG_PARTY_COMMAND_RESULT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GroupInviteNotification final : public ServerPacket
+    {
+    public:
+        std::string inviterName;
+
+        explicit GroupInviteNotification() : ServerPacket(SMSG_GROUP_INVITE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GroupDeclineNotification final : public ServerPacket
+    {
+    public:
+        std::string playerName;
+
+        explicit GroupDeclineNotification() : ServerPacket(SMSG_GROUP_DECLINE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GroupUninviteNotification final : public ServerPacket
+    {
+    public:
+        explicit GroupUninviteNotification() : ServerPacket(SMSG_GROUP_UNINVITE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GroupDestroyed final : public ServerPacket
+    {
+    public:
+        explicit GroupDestroyed() : ServerPacket(SMSG_GROUP_DESTROYED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2
+    class RaidReadyCheckResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid senderGuid;  // guid of the player who answered
+        uint8 state = 0;        // ready state
+
+        explicit RaidReadyCheckResponse() : ServerPacket(MSG_RAID_READY_CHECK) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    // Delta update: a single icon was changed (mode byte = 0)
+    class RaidTargetUpdateDelta final : public ServerPacket
+    {
+    public:
+        uint8 iconId = 0;
+        ObjectGuid targetGuid;
+
+        explicit RaidTargetUpdateDelta() : ServerPacket(MSG_RAID_TARGET_UPDATE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
     };
 #endif
 

--- a/src/game/Server/Packets/Guild.cpp
+++ b/src/game/Server/Packets/Guild.cpp
@@ -81,3 +81,36 @@ void WorldPackets::Guild::GuildRank::ReadFromWorldPacket(WorldPacket& recv_data)
     recv_data >> rights;
     recv_data >> rankName;
 }
+
+void WorldPackets::Guild::GuildInviteNotification::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << inviterName;
+    buffer << guildName;
+}
+
+void WorldPackets::Guild::GuildDeclineNotification::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << playerName;
+}
+
+void WorldPackets::Guild::GuildCommandResult::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << command;
+    buffer << str;
+    buffer << result;
+}
+
+void WorldPackets::Guild::GuildInfo::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << guildName;
+    buffer << createdDay;
+    buffer << createdMonth;
+    buffer << createdYear;
+    buffer << memberCount;
+    buffer << accountCount;
+}
+
+void WorldPackets::Guild::SaveGuildEmblemResult::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << error;
+}

--- a/src/game/Server/Packets/Guild.h
+++ b/src/game/Server/Packets/Guild.h
@@ -142,6 +142,60 @@ namespace WorldPackets { namespace Guild
         explicit GuildRank() : ClientPacket(CMSG_GUILD_RANK) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class GuildInviteNotification final : public ServerPacket
+    {
+    public:
+        std::string inviterName;
+        std::string guildName;
+
+        explicit GuildInviteNotification() : ServerPacket(SMSG_GUILD_INVITE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GuildDeclineNotification final : public ServerPacket
+    {
+    public:
+        std::string playerName;
+
+        explicit GuildDeclineNotification() : ServerPacket(SMSG_GUILD_DECLINE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GuildCommandResult final : public ServerPacket
+    {
+    public:
+        uint32 command = 0;
+        std::string str;
+        uint32 result = 0;
+
+        explicit GuildCommandResult() : ServerPacket(SMSG_GUILD_COMMAND_RESULT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class GuildInfo final : public ServerPacket
+    {
+    public:
+        std::string guildName;
+        uint32 createdDay = 0;
+        uint32 createdMonth = 0;
+        uint32 createdYear = 0;
+        uint32 memberCount = 0;
+        uint32 accountCount = 0;
+
+        explicit GuildInfo() : ServerPacket(SMSG_GUILD_INFO) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class SaveGuildEmblemResult final : public ServerPacket
+    {
+    public:
+        uint32 error = 0;
+
+        explicit SaveGuildEmblemResult() : ServerPacket(MSG_SAVE_GUILD_EMBLEM) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
 }} // namespace WorldPackets::Guild
 
 #endif // MANGOS_PACKETS_GUILD_H

--- a/src/game/Server/Packets/Item.cpp
+++ b/src/game/Server/Packets/Item.cpp
@@ -131,3 +131,39 @@ void WorldPackets::Item::BuybackItem::ReadFromWorldPacket(WorldPacket& recv_data
     recv_data >> slot;
 #endif
 }
+
+void WorldPackets::Item::BuyBankSlotResult::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << result;
+}
+
+void WorldPackets::Item::ItemNameQueryResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << itemId;
+    buffer << name;
+}
+
+void WorldPackets::Item::ReadItemOk::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << itemGuid;
+    buffer << itemGuid;
+}
+
+void WorldPackets::Item::ReadItemFailed::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << itemGuid;
+    buffer << reason;
+    buffer << itemGuid;
+}
+
+void WorldPackets::Item::ItemEnchantTimeUpdate::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << itemGuid;
+    buffer << slot;
+    buffer << duration;
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2
+    buffer << playerGuid;
+#endif
+}
+
+

--- a/src/game/Server/Packets/Item.h
+++ b/src/game/Server/Packets/Item.h
@@ -3,6 +3,8 @@
 
 #include "Packet.h"
 #include "ObjectGuid.h"
+#include <string>
+#include <vector>
 
 namespace WorldPackets { namespace Item
 {
@@ -209,6 +211,60 @@ namespace WorldPackets { namespace Item
         explicit BuybackItem() : ClientPacket(CMSG_BUYBACK_ITEM) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class BuyBankSlotResult final : public ServerPacket
+    {
+    public:
+        uint32 result = 0;
+
+        explicit BuyBankSlotResult() : ServerPacket(SMSG_BUY_BANK_SLOT_RESULT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class ItemNameQueryResponse final : public ServerPacket
+    {
+    public:
+        uint32 itemId = 0;
+        std::string name;
+
+        explicit ItemNameQueryResponse() : ServerPacket(SMSG_ITEM_NAME_QUERY_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class ReadItemOk final : public ServerPacket
+    {
+    public:
+        ObjectGuid itemGuid;
+
+        explicit ReadItemOk() : ServerPacket(SMSG_READ_ITEM_OK) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class ReadItemFailed final : public ServerPacket
+    {
+    public:
+        ObjectGuid itemGuid;
+        uint8 reason = 0;
+
+        explicit ReadItemFailed() : ServerPacket(SMSG_READ_ITEM_FAILED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class ItemEnchantTimeUpdate final : public ServerPacket
+    {
+    public:
+        ObjectGuid itemGuid;
+        uint32 slot = 0;
+        uint32 duration = 0;
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_10_2
+        ObjectGuid playerGuid;
+#endif
+
+        explicit ItemEnchantTimeUpdate() : ServerPacket(SMSG_ITEM_ENCHANT_TIME_UPDATE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Item
 
 #endif // MANGOS_PACKETS_ITEM_H

--- a/src/game/Server/Packets/Loot.cpp
+++ b/src/game/Server/Packets/Loot.cpp
@@ -28,3 +28,59 @@ void WorldPackets::Loot::LootMasterGive::ReadFromWorldPacket(WorldPacket& recv_d
     recv_data >> slotId;
     recv_data >> playerGuid;
 }
+
+// --- Server Packets ---
+
+void WorldPackets::Loot::LootClearMoney::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Loot::LootMoneyNotify::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << amount;
+}
+
+void WorldPackets::Loot::LootStartRoll::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << lootedTargetGuid;
+    buffer << itemSlot;
+    buffer << itemEntryId;
+    buffer << randomSuffix;
+    buffer << itemRandomPropId;
+    buffer << countdownTime;
+}
+
+void WorldPackets::Loot::LootRollResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << lootedTargetGuid;
+    buffer << itemSlot;
+    buffer << rollerGuid;
+    buffer << itemEntryId;
+    buffer << randomSuffix;
+    buffer << itemRandomPropId;
+    buffer << rollNumber;
+    buffer << rollType;
+}
+
+void WorldPackets::Loot::LootRollWon::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << lootedTargetGuid;
+    buffer << itemSlot;
+    buffer << itemEntryId;
+    buffer << randomSuffix;
+    buffer << itemRandomPropId;
+    buffer << winnerGuid;
+    buffer << rollNumber;
+    buffer << rollType;
+}
+
+void WorldPackets::Loot::LootAllPassed::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << lootedTargetGuid;
+    buffer << itemSlot;
+    buffer << itemEntryId;
+    buffer << itemRandomPropId;
+    buffer << randomSuffixId;
+}
+
+

--- a/src/game/Server/Packets/Loot.h
+++ b/src/game/Server/Packets/Loot.h
@@ -5,6 +5,8 @@
 #include "ObjectGuid.h"
 #include "SharedDefines.h"
 
+#include <vector>
+
 namespace WorldPackets { namespace Loot
 {
     class AutoStoreLootItem final : public ClientPacket
@@ -55,6 +57,83 @@ namespace WorldPackets { namespace Loot
         explicit LootMasterGive() : ClientPacket(CMSG_LOOT_MASTER_GIVE) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class LootClearMoney final : public ServerPacket
+    {
+    public:
+        explicit LootClearMoney() : ServerPacket(SMSG_LOOT_CLEAR_MONEY) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class LootMoneyNotify final : public ServerPacket
+    {
+    public:
+        uint32 amount = 0;
+
+        explicit LootMoneyNotify() : ServerPacket(SMSG_LOOT_MONEY_NOTIFY) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class LootStartRoll final : public ServerPacket
+    {
+    public:
+        ObjectGuid lootedTargetGuid;         // creature guid being looted
+        uint32 itemSlot = 0;                 // item slot in loot
+        uint32 itemEntryId = 0;              // the itemEntryId for the item that shall be rolled for
+        uint32 randomSuffix = 0;             // randomSuffix - not used
+        uint32 itemRandomPropId = 0;         // item random property ID
+        uint32 countdownTime = 0;            // the countdown time to choose "need" or "greed"
+
+        explicit LootStartRoll() : ServerPacket(SMSG_LOOT_START_ROLL) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class LootRollResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid lootedTargetGuid;         // creature guid being looted
+        uint32 itemSlot = 0;
+        ObjectGuid rollerGuid;               // the player who rolled
+        uint32 itemEntryId = 0;              // the itemEntryId for the item that shall be rolled for
+        uint32 randomSuffix = 0;             // randomSuffix - not used
+        uint32 itemRandomPropId = 0;         // Item random property ID
+        uint8 rollNumber = 0;                // 0: "Need for..." > 127: "you passed on..."
+        uint8 rollType = 0;                  // 0: need, 1: need roll, 2: greed roll
+
+        explicit LootRollResponse() : ServerPacket(SMSG_LOOT_ROLL) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class LootRollWon final : public ServerPacket
+    {
+    public:
+        ObjectGuid lootedTargetGuid;         // creature guid being looted
+        uint32 itemSlot = 0;                 // item slot in loot
+        uint32 itemEntryId = 0;              // the itemEntryId for the item that shall be rolled for
+        uint32 randomSuffix = 0;             // randomSuffix - not used
+        uint32 itemRandomPropId = 0;         // Item random property
+        ObjectGuid winnerGuid;               // guid of the player who won
+        uint8 rollNumber = 0;                // rollnumber related to SMSG_LOOT_ROLL
+        uint8 rollType = 0;                  // Rolltype related to SMSG_LOOT_ROLL
+
+        explicit LootRollWon() : ServerPacket(SMSG_LOOT_ROLL_WON) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class LootAllPassed final : public ServerPacket
+    {
+    public:
+        ObjectGuid lootedTargetGuid;         // creature guid being looted
+        uint32 itemSlot = 0;                 // item slot in loot
+        uint32 itemEntryId = 0;              // The itemEntryId for the item that shall be rolled for
+        uint32 itemRandomPropId = 0;         // Item random property ID
+        uint32 randomSuffixId = 0;           // Item random suffix ID - not used
+
+        explicit LootAllPassed() : ServerPacket(SMSG_LOOT_ALL_PASSED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Loot
 
 #endif // MANGOS_PACKETS_LOOT_H

--- a/src/game/Server/Packets/Mail.cpp
+++ b/src/game/Server/Packets/Mail.cpp
@@ -63,3 +63,23 @@ void WorldPackets::Mail::MailCreateTextItem::ReadFromWorldPacket(WorldPacket& re
     recv_data >> mailTemplateId;
 #endif
 }
+
+// --- Server Packets ---
+
+void WorldPackets::Mail::ReceivedMail::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << notifyDelay;
+}
+
+void WorldPackets::Mail::ItemTextQueryResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << itemTextId;
+    buffer << text;
+}
+
+void WorldPackets::Mail::QueryNextMailTimeResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << nextMailTime;
+}
+
+

--- a/src/game/Server/Packets/Mail.h
+++ b/src/game/Server/Packets/Mail.h
@@ -4,6 +4,8 @@
 #include "Packet.h"
 #include "SharedDefines.h"
 #include "ObjectGuid.h"
+#include <string>
+#include <vector>
 
 namespace WorldPackets { namespace Mail
 {
@@ -96,6 +98,36 @@ namespace WorldPackets { namespace Mail
         explicit MailCreateTextItem() : ClientPacket(CMSG_MAIL_CREATE_TEXT_ITEM) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class ReceivedMail final : public ServerPacket
+    {
+    public:
+        uint32 notifyDelay = 0;
+
+        explicit ReceivedMail() : ServerPacket(SMSG_RECEIVED_MAIL) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class ItemTextQueryResponse final : public ServerPacket
+    {
+    public:
+        uint32 itemTextId = 0;
+        std::string text;
+
+        explicit ItemTextQueryResponse() : ServerPacket(SMSG_ITEM_TEXT_QUERY_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class QueryNextMailTimeResponse final : public ServerPacket
+    {
+    public:
+        float nextMailTime = 0.0f;
+
+        explicit QueryNextMailTimeResponse() : ServerPacket(MSG_QUERY_NEXT_MAIL_TIME) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Mail
 
 #endif // MANGOS_PACKETS_MAIL_H

--- a/src/game/Server/Packets/Misc.cpp
+++ b/src/game/Server/Packets/Misc.cpp
@@ -249,3 +249,114 @@ void WorldPackets::Misc::WardenData::ReadFromWorldPacket(WorldPacket& recv_data)
         recv_data.read(data.data(), data.size());
 }
 #endif
+
+// --- Server Packets ---
+
+void WorldPackets::Misc::LogoutComplete::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Misc::LogoutCancelAck::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Misc::StandStateUpdate::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << standState;
+}
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_7_1
+void WorldPackets::Misc::PlayTimeWarning::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << flag;
+    buffer << timeLeftInSeconds;
+}
+#endif
+
+void WorldPackets::Misc::LogoutResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << reason;
+    buffer << instant;
+}
+
+void WorldPackets::Misc::PlayedTime::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << totalPlayedTime;
+    buffer << levelPlayedTime;
+}
+
+void WorldPackets::Misc::InspectResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << guid;
+}
+
+void WorldPackets::Misc::WhoisResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << message;
+}
+
+void WorldPackets::Misc::UpdateAccountDataResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << type;
+    buffer << decompressedLength;
+    buffer.append(compressedData.data(), compressedData.size());
+}
+
+void WorldPackets::Misc::InspectHonorStatsResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << playerGuid;
+    buffer << highestRank;
+    buffer << sessionKills;
+    buffer << yesterdayHK;
+    buffer << unknownOld1;
+    buffer << lastWeekHK;
+    buffer << unknownOld2;
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+    buffer << thisWeekHK;
+    buffer << unknownOld3;
+#endif
+    buffer << lifetimeHK;
+    buffer << lifetimeDHK;
+    buffer << yesterdayHonor;
+    buffer << lastWeekHonor;
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+    buffer << thisWeekHonor;
+#endif
+    buffer << lastWeekRank;
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+    buffer << rankBar;
+#endif
+}
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_7_1
+void WorldPackets::Misc::WeatherUpdate::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << weatherType;
+    buffer << grade;
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
+    buffer << soundId;
+#endif
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_9_4
+    buffer << instantChange;
+#endif
+}
+#endif
+
+void WorldPackets::Misc::ServerMessage::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << messageType;
+    buffer << text;
+}
+
+void WorldPackets::Misc::MeetingstoneJoinFailed::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << reason;
+}
+
+void WorldPackets::Misc::MeetingstoneSetQueue::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << areaId;
+    buffer << status;
+}
+
+

--- a/src/game/Server/Packets/Misc.h
+++ b/src/game/Server/Packets/Misc.h
@@ -370,6 +370,174 @@ namespace WorldPackets { namespace Misc
     };
 #endif
 
+    // --- Server Packets ---
+
+    class LogoutComplete final : public ServerPacket
+    {
+    public:
+        explicit LogoutComplete() : ServerPacket(SMSG_LOGOUT_COMPLETE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class LogoutCancelAck final : public ServerPacket
+    {
+    public:
+        explicit LogoutCancelAck() : ServerPacket(SMSG_LOGOUT_CANCEL_ACK) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class StandStateUpdate final : public ServerPacket
+    {
+    public:
+        uint8 standState = 0;
+
+        explicit StandStateUpdate() : ServerPacket(SMSG_STANDSTATE_UPDATE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_7_1
+    class PlayTimeWarning final : public ServerPacket
+    {
+    public:
+        uint32 flag = 0;
+        int32 timeLeftInSeconds = 0;
+
+        explicit PlayTimeWarning() : ServerPacket(SMSG_PLAY_TIME_WARNING) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+#endif
+
+    class LogoutResponse final : public ServerPacket
+    {
+    public:
+        uint32 reason = 0;
+        uint8 instant = 0;
+
+        explicit LogoutResponse() : ServerPacket(SMSG_LOGOUT_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class PlayedTime final : public ServerPacket
+    {
+    public:
+        uint32 totalPlayedTime = 0;
+        uint32 levelPlayedTime = 0;
+
+        explicit PlayedTime() : ServerPacket(SMSG_PLAYED_TIME) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class InspectResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid guid;
+
+        explicit InspectResponse() : ServerPacket(SMSG_INSPECT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class WhoisResponse final : public ServerPacket
+    {
+    public:
+        std::string message; // max CString length allowed: 256
+
+        explicit WhoisResponse() : ServerPacket(SMSG_WHOIS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class UpdateAccountDataResponse final : public ServerPacket
+    {
+    public:
+        uint32 type = 0;
+        uint32 decompressedLength = 0;
+        std::vector<uint8> compressedData;
+
+        explicit UpdateAccountDataResponse() : ServerPacket(SMSG_UPDATE_ACCOUNT_DATA) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class InspectHonorStatsResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid playerGuid;
+        uint8 highestRank = 0;          // Highest Rank
+        uint32 sessionKills = 0;        // Today Honorable and Dishonorable Kills
+        uint16 yesterdayHK = 0;         // Yesterday Honorable Kills
+        uint16 unknownOld1 = 0;         // Unknown (deprecated, yesterday dishonourable?)
+        uint16 lastWeekHK = 0;          // Last Week Honorable Kills
+        uint16 unknownOld2 = 0;         // Unknown (deprecated, last week dishonourable?)
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+        uint16 thisWeekHK = 0;          // This Week Honorable kills
+        uint16 unknownOld3 = 0;         // Unknown (deprecated, this week dishonourable?)
+#endif
+        uint32 lifetimeHK = 0;          // Lifetime Honorable Kills
+        uint32 lifetimeDHK = 0;         // Lifetime Dishonorable Kills
+        uint32 yesterdayHonor = 0;      // Yesterday Honor
+        uint32 lastWeekHonor = 0;       // Last Week Honor
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+        uint32 thisWeekHonor = 0;       // This Week Honor
+#endif
+        uint32 lastWeekRank = 0;        // Last Week Standing
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_6_1
+        uint8 rankBar = 0;              // Rank progress bar
+#endif
+
+        explicit InspectHonorStatsResponse() : ServerPacket(MSG_INSPECT_HONOR_STATS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_7_1
+    class WeatherUpdate final : public ServerPacket
+    {
+    public:
+        uint32 weatherType = 0;
+        float grade = 0.0f;
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
+        uint32 soundId = 0;
+#endif
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_9_4
+        bool instantChange = false;     // true = instant change, false = smooth change
+#endif
+
+        explicit WeatherUpdate() : ServerPacket(SMSG_WEATHER) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+#endif
+
+    class ServerMessage final : public ServerPacket
+    {
+    public:
+        uint32 messageType = 0;
+        std::string text;
+
+        explicit ServerMessage() : ServerPacket(SMSG_SERVER_MESSAGE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class MeetingstoneJoinFailed final : public ServerPacket
+    {
+    public:
+        uint8 reason = 0;
+
+        explicit MeetingstoneJoinFailed() : ServerPacket(SMSG_MEETINGSTONE_JOINFAILED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class MeetingstoneSetQueue final : public ServerPacket
+    {
+    public:
+        uint32 areaId = 0;
+
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_4_2
+        uint64 idempotencyToken = 0; // Guess: Incrementing counter. Must change for every response. TODO: Maybe use ms timestamp to enforce a new id on every packet
+#else
+        uint8 status = 0;
+#endif
+
+        explicit MeetingstoneSetQueue() : ServerPacket(SMSG_MEETINGSTONE_SETQUEUE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Misc
 
 #endif // MANGOS_PACKETS_MISC_H

--- a/src/game/Server/Packets/Npc.cpp
+++ b/src/game/Server/Packets/Npc.cpp
@@ -84,3 +84,39 @@ void WorldPackets::Npc::GossipSelectOption::ReadFromWorldPacket(WorldPacket& rec
         recv_data >> code;
     }
 }
+
+// --- Server Packets ---
+
+void WorldPackets::Npc::GossipComplete::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Npc::ShowBank::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << bankerGuid;
+}
+
+void WorldPackets::Npc::StableResult::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << result;
+}
+
+void WorldPackets::Npc::TrainerBuySucceeded::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << trainerGuid;
+    buffer << spellId;
+}
+
+void WorldPackets::Npc::TrainerBuyFailed::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << trainerGuid;
+    buffer << serviceId;
+    buffer << errorCode;
+}
+
+void WorldPackets::Npc::TabardVendorActivateResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << tabardVendorNpcGuid;
+}
+
+

--- a/src/game/Server/Packets/Npc.h
+++ b/src/game/Server/Packets/Npc.h
@@ -4,6 +4,7 @@
 #include "Packet.h"
 #include "ObjectGuid.h"
 #include <string>
+#include <vector>
 
 namespace WorldPackets { namespace Npc
 {
@@ -148,6 +149,63 @@ namespace WorldPackets { namespace Npc
         explicit GossipSelectOption() : ClientPacket(CMSG_GOSSIP_SELECT_OPTION) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class GossipComplete final : public ServerPacket
+    {
+    public:
+        explicit GossipComplete() : ServerPacket(SMSG_GOSSIP_COMPLETE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class ShowBank final : public ServerPacket
+    {
+    public:
+        ObjectGuid bankerGuid;
+
+        explicit ShowBank() : ServerPacket(SMSG_SHOW_BANK) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class StableResult final : public ServerPacket
+    {
+    public:
+        uint8 result = 0;
+
+        explicit StableResult() : ServerPacket(SMSG_STABLE_RESULT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class TrainerBuySucceeded final : public ServerPacket
+    {
+    public:
+        ObjectGuid trainerGuid;
+        uint32 spellId = 0;
+
+        explicit TrainerBuySucceeded() : ServerPacket(SMSG_TRAINER_BUY_SUCCEEDED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class TrainerBuyFailed final : public ServerPacket
+    {
+    public:
+        ObjectGuid trainerGuid;
+        uint32 serviceId = 0;
+        uint32 errorCode = 0;
+
+        explicit TrainerBuyFailed() : ServerPacket(SMSG_TRAINER_BUY_FAILED) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class TabardVendorActivateResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid tabardVendorNpcGuid;
+
+        explicit TabardVendorActivateResponse() : ServerPacket(MSG_TABARDVENDOR_ACTIVATE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Npc
 
 #endif // MANGOS_PACKETS_NPC_H

--- a/src/game/Server/Packets/Pet.cpp
+++ b/src/game/Server/Packets/Pet.cpp
@@ -69,3 +69,16 @@ void WorldPackets::Pet::PetCastSpell::ReadFromWorldPacket(WorldPacket& recv_data
     recv_data >> targets;
 }
 #endif
+
+// --- Server Packets ---
+
+void WorldPackets::Pet::PetNameInvalid::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+void WorldPackets::Pet::PetNameQueryResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << petNumber;
+    buffer << name;
+    buffer << nameTimestamp;
+}

--- a/src/game/Server/Packets/Pet.h
+++ b/src/game/Server/Packets/Pet.h
@@ -122,6 +122,26 @@ namespace WorldPackets { namespace Pet
     };
 #endif
 
+    // --- Server Packets ---
+
+    class PetNameInvalid final : public ServerPacket
+    {
+    public:
+        explicit PetNameInvalid() : ServerPacket(SMSG_PET_NAME_INVALID) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class PetNameQueryResponse final : public ServerPacket
+    {
+    public:
+        uint32 petNumber = 0;
+        std::string name;
+        uint32 nameTimestamp = 0;
+
+        explicit PetNameQueryResponse() : ServerPacket(SMSG_PET_NAME_QUERY_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Pet
 
 #endif // MANGOS_PACKETS_PET_H

--- a/src/game/Server/Packets/Petition.cpp
+++ b/src/game/Server/Packets/Petition.cpp
@@ -65,3 +65,60 @@ void WorldPackets::Petition::PetitionBuy::ReadFromWorldPacket(WorldPacket& recv_
     recv_data.read_skip<uint32>();                          // index (unused)
     recv_data.read_skip<uint32>();                          // 0
 }
+
+void WorldPackets::Petition::PetitionSignResults::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << itemGuid;
+    buffer << playerGuid;
+    buffer << result;
+}
+
+void WorldPackets::Petition::TurnInPetitionResults::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << result;
+}
+
+void WorldPackets::Petition::PetitionQueryResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << petitionGuid;
+    buffer << ownerGuid;
+    buffer << name;
+    buffer << uint8(0);                                     // bodyText
+    buffer << flags;
+    buffer << minSignatures;
+    buffer << maxSignatures;
+    buffer << uint32(0);                                    // deadLine
+    buffer << uint32(0);                                    // issueDate
+    buffer << uint32(0);                                    // allowedGuildID
+    buffer << uint32(0);                                    // allowedClasses
+    buffer << uint32(0);                                    // allowedRaces
+    buffer << uint16(0);                                    // allowedGender
+    buffer << uint32(0);                                    // allowedMinLevel
+    buffer << uint32(0);                                    // allowedMaxLevel
+    buffer << uint32(0);                                    // choicetext
+    buffer << uint32(0);                                    // numChoices
+}
+
+void WorldPackets::Petition::PetitionRenameResult::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << itemGuid;
+    buffer << newName;
+}
+
+void WorldPackets::Petition::PetitionDeclineResult::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << playerGuid;
+}
+
+void WorldPackets::Petition::PetitionShowList::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << npcGuid;
+    buffer << count;
+    buffer << index;
+    buffer << charterEntry;
+    buffer << charterDisplayId;
+    buffer << charterCost;
+    buffer << unknown;
+}
+
+

--- a/src/game/Server/Packets/Petition.cpp
+++ b/src/game/Server/Packets/Petition.cpp
@@ -83,20 +83,22 @@ void WorldPackets::Petition::PetitionQueryResponse::AppendBodyTo(ByteBuffer& buf
     buffer << petitionGuid;
     buffer << ownerGuid;
     buffer << name;
-    buffer << uint8(0);                                     // bodyText
+    buffer << bodyText;
     buffer << flags;
     buffer << minSignatures;
     buffer << maxSignatures;
-    buffer << uint32(0);                                    // deadLine
-    buffer << uint32(0);                                    // issueDate
-    buffer << uint32(0);                                    // allowedGuildID
-    buffer << uint32(0);                                    // allowedClasses
-    buffer << uint32(0);                                    // allowedRaces
-    buffer << uint16(0);                                    // allowedGender
-    buffer << uint32(0);                                    // allowedMinLevel
-    buffer << uint32(0);                                    // allowedMaxLevel
-    buffer << uint32(0);                                    // choicetext
-    buffer << uint32(0);                                    // numChoices
+    buffer << deadlineTimestamp;
+    buffer << creationTimestamp;
+    buffer << allowedGuildID;
+    buffer << allowedClasses;
+    buffer << allowedRaces;
+    buffer << allowedGender;
+    buffer << allowedMinLevel;
+    buffer << allowedMaxLevel;
+    buffer << static_cast<uint32>(choices.size());
+    for (const auto& choice : choices)
+        buffer << choice;
+    buffer << defaultChoice;
 }
 
 void WorldPackets::Petition::PetitionRenameResult::AppendBodyTo(ByteBuffer& buffer) const
@@ -113,12 +115,15 @@ void WorldPackets::Petition::PetitionDeclineResult::AppendBodyTo(ByteBuffer& buf
 void WorldPackets::Petition::PetitionShowList::AppendBodyTo(ByteBuffer& buffer) const
 {
     buffer << npcGuid;
-    buffer << count;
-    buffer << index;
-    buffer << charterEntry;
-    buffer << charterDisplayId;
-    buffer << charterCost;
-    buffer << unknown;
+    buffer << static_cast<uint8>(entries.size());
+    for (const auto& entry : entries)
+    {
+        buffer << entry.index;
+        buffer << entry.charterEntry;
+        buffer << entry.charterDisplayId;
+        buffer << entry.charterCost;
+        buffer << entry.entryFlags;
+    }
 }
 
 

--- a/src/game/Server/Packets/Petition.h
+++ b/src/game/Server/Packets/Petition.h
@@ -4,6 +4,7 @@
 #include "Packet.h"
 #include "ObjectGuid.h"
 #include <string>
+#include <vector>
 
 namespace WorldPackets { namespace Petition
 {
@@ -91,6 +92,76 @@ namespace WorldPackets { namespace Petition
         explicit PetitionBuy() : ClientPacket(CMSG_PETITION_BUY) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class PetitionSignResults final : public ServerPacket
+    {
+    public:
+        ObjectGuid itemGuid;
+        ObjectGuid playerGuid;
+        uint32 result = 0;
+
+        explicit PetitionSignResults() : ServerPacket(SMSG_PETITION_SIGN_RESULTS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class TurnInPetitionResults final : public ServerPacket
+    {
+    public:
+        uint32 result = 0;
+
+        explicit TurnInPetitionResults() : ServerPacket(SMSG_TURN_IN_PETITION_RESULTS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class PetitionQueryResponse final : public ServerPacket
+    {
+    public:
+        uint32 petitionGuid = 0;
+        ObjectGuid ownerGuid;
+        std::string name;
+        uint32 flags = 0;
+        uint32 minSignatures = 0;
+        uint32 maxSignatures = 0;
+
+        explicit PetitionQueryResponse() : ServerPacket(SMSG_PETITION_QUERY_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class PetitionRenameResult final : public ServerPacket
+    {
+    public:
+        ObjectGuid itemGuid;
+        std::string newName;
+
+        explicit PetitionRenameResult() : ServerPacket(MSG_PETITION_RENAME) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class PetitionDeclineResult final : public ServerPacket
+    {
+    public:
+        ObjectGuid playerGuid;
+
+        explicit PetitionDeclineResult() : ServerPacket(MSG_PETITION_DECLINE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class PetitionShowList final : public ServerPacket
+    {
+    public:
+        ObjectGuid npcGuid;
+        uint8 count = 0;
+        uint32 index = 0;
+        uint32 charterEntry = 0;
+        uint32 charterDisplayId = 0;
+        uint32 charterCost = 0;
+        uint32 unknown = 0;
+
+        explicit PetitionShowList() : ServerPacket(SMSG_PETITION_SHOWLIST) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Petition
 
 #endif // MANGOS_PACKETS_PETITION_H

--- a/src/game/Server/Packets/Petition.h
+++ b/src/game/Server/Packets/Petition.h
@@ -120,9 +120,22 @@ namespace WorldPackets { namespace Petition
         uint32 petitionGuid = 0;
         ObjectGuid ownerGuid;
         std::string name;
+        std::string bodyText;
         uint32 flags = 0;
+
+        // All those fields below don't really change anything in the UI
         uint32 minSignatures = 0;
         uint32 maxSignatures = 0;
+        uint32 deadlineTimestamp = 0;
+        uint32 creationTimestamp = 0;
+        uint32 allowedGuildID = 0;
+        uint32 allowedClasses = 0;
+        uint32 allowedRaces = 0;
+        uint16 allowedGender = 0;
+        uint32 allowedMinLevel = 0;
+        uint32 allowedMaxLevel = 0;
+        std::vector<std::string> choices;
+        uint32 defaultChoice = 0;
 
         explicit PetitionQueryResponse() : ServerPacket(SMSG_PETITION_QUERY_RESPONSE) {}
         void AppendBodyTo(ByteBuffer& buffer) const override;
@@ -147,16 +160,20 @@ namespace WorldPackets { namespace Petition
         void AppendBodyTo(ByteBuffer& buffer) const override;
     };
 
+    struct PetitionShowListEntry
+    {
+        uint32 index = 0;
+        uint32 charterEntry = 0;
+        uint32 charterDisplayId = 0;
+        int32 charterCost = 0;
+        int32 entryFlags = 0; // must be `&1` to show it in the UI
+    };
+
     class PetitionShowList final : public ServerPacket
     {
     public:
         ObjectGuid npcGuid;
-        uint8 count = 0;
-        uint32 index = 0;
-        uint32 charterEntry = 0;
-        uint32 charterDisplayId = 0;
-        uint32 charterCost = 0;
-        uint32 unknown = 0;
+        std::vector<PetitionShowListEntry> entries; // only 1 element is supported in the client
 
         explicit PetitionShowList() : ServerPacket(SMSG_PETITION_SHOWLIST) {}
         void AppendBodyTo(ByteBuffer& buffer) const override;

--- a/src/game/Server/Packets/Query.cpp
+++ b/src/game/Server/Packets/Query.cpp
@@ -36,3 +36,29 @@ void WorldPackets::Query::ItemNameQuery::ReadFromWorldPacket(WorldPacket& recv_d
     recv_data >> itemId;
     recv_data.read_skip<uint64>(); // guid, not used
 }
+
+void WorldPackets::Query::QueryTimeResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << time;
+}
+
+void WorldPackets::Query::NameQueryResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << playerGuid;
+    buffer << name;
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
+    buffer << realmName;
+#endif
+    buffer << race;
+    buffer << gender;
+    buffer << class_;
+}
+
+void WorldPackets::Query::PageTextQueryResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << pageId;
+    buffer << text;
+    buffer << nextPageId;
+}
+
+

--- a/src/game/Server/Packets/Query.h
+++ b/src/game/Server/Packets/Query.h
@@ -77,7 +77,7 @@ namespace WorldPackets { namespace Query
         ObjectGuid playerGuid;
         std::string name;
 #if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
-        std::string realmName;
+        std::string realmName; // realm name for cross-realm BG usage
 #endif
         uint32 race = 0;
         uint32 gender = 0;

--- a/src/game/Server/Packets/Query.h
+++ b/src/game/Server/Packets/Query.h
@@ -61,6 +61,43 @@ namespace WorldPackets { namespace Query
         explicit ItemNameQuery() : ClientPacket(CMSG_ITEM_NAME_QUERY) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+
+    class QueryTimeResponse final : public ServerPacket
+    {
+    public:
+        uint32 time = 0;
+
+        explicit QueryTimeResponse() : ServerPacket(SMSG_QUERY_TIME_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class NameQueryResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid playerGuid;
+        std::string name;
+#if SUPPORTED_CLIENT_BUILD >= CLIENT_BUILD_1_12_1
+        std::string realmName;
+#endif
+        uint32 race = 0;
+        uint32 gender = 0;
+        uint32 class_ = 0;
+
+        explicit NameQueryResponse() : ServerPacket(SMSG_NAME_QUERY_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class PageTextQueryResponse final : public ServerPacket
+    {
+    public:
+        uint32 pageId = 0;
+        std::string text;
+        uint32 nextPageId = 0;
+
+        explicit PageTextQueryResponse() : ServerPacket(SMSG_PAGE_TEXT_QUERY_RESPONSE) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Query
 
 #endif // MANGOS_PACKETS_QUERY_H

--- a/src/game/Server/Packets/Quest.cpp
+++ b/src/game/Server/Packets/Quest.cpp
@@ -72,3 +72,17 @@ void WorldPackets::Quest::QuestPushResult::ReadFromWorldPacket(WorldPacket& recv
     recv_data >> guid;
     recv_data >> msg;
 }
+
+// --- Server Packets ---
+
+void WorldPackets::Quest::QuestPushResultResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << senderGuid;
+    buffer << msg;
+}
+
+void WorldPackets::Quest::QuestLogFull::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+

--- a/src/game/Server/Packets/Quest.h
+++ b/src/game/Server/Packets/Quest.h
@@ -4,6 +4,7 @@
 #include "Packet.h"
 #include "ObjectGuid.h"
 #include "SharedDefines.h"
+#include <string>
 
 namespace WorldPackets { namespace Quest
 {
@@ -131,6 +132,25 @@ namespace WorldPackets { namespace Quest
         explicit QuestPushResult() : ClientPacket(MSG_QUEST_PUSH_RESULT) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class QuestPushResultResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid senderGuid;  // guid of the player who sent the quest share
+        uint8 msg = 0;          // enum QuestShareMessages
+
+        explicit QuestPushResultResponse() : ServerPacket(MSG_QUEST_PUSH_RESULT) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class QuestLogFull final : public ServerPacket
+    {
+    public:
+        explicit QuestLogFull() : ServerPacket(SMSG_QUESTLOG_FULL) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Quest
 
 #endif // MANGOS_PACKETS_QUEST_H

--- a/src/game/Server/Packets/Skill.cpp
+++ b/src/game/Server/Packets/Skill.cpp
@@ -13,5 +13,11 @@ void WorldPackets::Skill::UnlearnSkill::ReadFromWorldPacket(WorldPacket& recv_da
 
 void WorldPackets::Skill::TalentWipeConfirm::ReadFromWorldPacket(WorldPacket& recv_data)
 {
-    recv_data >> guid;
+    recv_data >> trainerGuid;
+}
+
+void WorldPackets::Skill::TalentWipeConfirmResponse::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << trainerGuid;
+    buffer << cost;
 }

--- a/src/game/Server/Packets/Skill.h
+++ b/src/game/Server/Packets/Skill.h
@@ -30,10 +30,21 @@ namespace WorldPackets { namespace Skill
     class TalentWipeConfirm final : public ClientPacket
     {
     public:
-        ObjectGuid guid;
+        ObjectGuid trainerGuid;
 
         explicit TalentWipeConfirm() : ClientPacket(MSG_TALENT_WIPE_CONFIRM) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
+    };
+    // --- Server Packets ---
+
+    class TalentWipeConfirmResponse final : public ServerPacket
+    {
+    public:
+        ObjectGuid trainerGuid = 0; // guid of talent master (0 if player has no talents to reset)
+        uint32 cost = 0; // cost in copper to reset talents
+
+        explicit TalentWipeConfirmResponse() : ServerPacket(MSG_TALENT_WIPE_CONFIRM) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
     };
 }} // namespace WorldPackets::Skill
 

--- a/src/game/Server/Packets/Spell.cpp
+++ b/src/game/Server/Packets/Spell.cpp
@@ -1,5 +1,5 @@
 #include "Spell.h"
-#include "SharedDefines.h"
+#include "Spells/Spell.h"
 #include "SpellDefines.h"
 
 void WorldPackets::Spell::CastSpell::ReadFromWorldPacket(WorldPacket& recv_data)
@@ -39,7 +39,7 @@ void WorldPackets::Spell::CancelChanneling::ReadFromWorldPacket(WorldPacket& rec
 
 void WorldPackets::Spell::CastResultSimpleFailure::AppendBodyTo(ByteBuffer& buffer) const
 {
-    buffer << spellId;
+    buffer << spellEntry->Id;
     buffer << static_cast<uint8>(SPELL_RESULT_STATUS_FAIL);
     buffer << reason;
 }

--- a/src/game/Server/Packets/Spell.cpp
+++ b/src/game/Server/Packets/Spell.cpp
@@ -1,4 +1,6 @@
 #include "Spell.h"
+#include "SharedDefines.h"
+#include "SpellDefines.h"
 
 void WorldPackets::Spell::CastSpell::ReadFromWorldPacket(WorldPacket& recv_data)
 {
@@ -38,6 +40,6 @@ void WorldPackets::Spell::CancelChanneling::ReadFromWorldPacket(WorldPacket& rec
 void WorldPackets::Spell::CastResultSimpleFailure::AppendBodyTo(ByteBuffer& buffer) const
 {
     buffer << spellId;
-    buffer << uint8(2); // status = fail
+    buffer << static_cast<uint8>(SPELL_RESULT_STATUS_FAIL);
     buffer << reason;
 }

--- a/src/game/Server/Packets/Spell.cpp
+++ b/src/game/Server/Packets/Spell.cpp
@@ -34,3 +34,10 @@ void WorldPackets::Spell::CancelChanneling::ReadFromWorldPacket(WorldPacket& rec
 {
     recv_data >> spellId;
 }
+
+void WorldPackets::Spell::CastResultSimpleFailure::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << spellId;
+    buffer << uint8(2); // status = fail
+    buffer << reason;
+}

--- a/src/game/Server/Packets/Spell.h
+++ b/src/game/Server/Packets/Spell.h
@@ -5,6 +5,8 @@
 #include "SpellCastTargetsInfo.h"
 #include "ObjectGuid.h"
 
+class SpellEntry;
+
 namespace WorldPackets { namespace Spell
 {
     class CastSpell final : public ClientPacket
@@ -73,11 +75,11 @@ namespace WorldPackets { namespace Spell
     class CastResultSimpleFailure final : public ServerPacket
     {
     public:
-        uint32 spellId;
+        ::SpellEntry const* spellEntry; // SpellEntry pointers are always valid even when `.reload`
         uint8 reason;
 
-        explicit CastResultSimpleFailure(uint32 spellId, uint8 reason)
-            : ServerPacket(SMSG_CAST_RESULT), spellId(spellId), reason(reason) {}
+        explicit CastResultSimpleFailure(::SpellEntry const* spellEntry, uint8 reason)
+            : ServerPacket(SMSG_CAST_RESULT), spellEntry(spellEntry), reason(reason) {}
         void AppendBodyTo(ByteBuffer& buffer) const override;
     };
 }} // namespace WorldPackets::Spell

--- a/src/game/Server/Packets/Spell.h
+++ b/src/game/Server/Packets/Spell.h
@@ -65,6 +65,21 @@ namespace WorldPackets { namespace Spell
         explicit CancelChanneling() : ClientPacket(CMSG_CANCEL_CHANNELLING) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    // Simplified SMSG_CAST_RESULT for a basic spell failure (status=2) with no extra data.
+    // For complex failures with additional payload (e.g. cooldown time, required area),
+    // use the full Spell::SendCastResult() path in Spell.cpp instead.
+    class CastResultSimpleFailure final : public ServerPacket
+    {
+    public:
+        uint32 spellId;
+        uint8 reason;
+
+        explicit CastResultSimpleFailure(uint32 spellId, uint8 reason)
+            : ServerPacket(SMSG_CAST_RESULT), spellId(spellId), reason(reason) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
 }} // namespace WorldPackets::Spell
 
 #endif // MANGOS_PACKETS_SPELL_H

--- a/src/game/Server/Packets/Taxi.cpp
+++ b/src/game/Server/Packets/Taxi.cpp
@@ -32,3 +32,15 @@ void WorldPackets::Taxi::ActivateTaxiExpress::ReadFromWorldPacket(WorldPacket& r
     }
 }
 #endif
+
+void WorldPackets::Taxi::TaxiNodeStatus::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << guid;
+    buffer << known;
+}
+
+void WorldPackets::Taxi::NewTaxiPath::AppendBodyTo(ByteBuffer& /*buffer*/) const
+{
+}
+
+

--- a/src/game/Server/Packets/Taxi.h
+++ b/src/game/Server/Packets/Taxi.h
@@ -54,7 +54,7 @@ namespace WorldPackets { namespace Taxi
     {
     public:
         ObjectGuid guid;
-        uint8 known = 0;
+        bool known = false;
 
         explicit TaxiNodeStatus() : ServerPacket(SMSG_TAXINODE_STATUS) {}
         void AppendBodyTo(ByteBuffer& buffer) const override;

--- a/src/game/Server/Packets/Taxi.h
+++ b/src/game/Server/Packets/Taxi.h
@@ -48,6 +48,25 @@ namespace WorldPackets { namespace Taxi
     };
 #endif
 
+    // --- Server Packets ---
+
+    class TaxiNodeStatus final : public ServerPacket
+    {
+    public:
+        ObjectGuid guid;
+        uint8 known = 0;
+
+        explicit TaxiNodeStatus() : ServerPacket(SMSG_TAXINODE_STATUS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
+    class NewTaxiPath final : public ServerPacket
+    {
+    public:
+        explicit NewTaxiPath() : ServerPacket(SMSG_NEW_TAXI_PATH) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Taxi
 
 #endif // MANGOS_PACKETS_TAXI_H

--- a/src/game/Server/Packets/Trade.cpp
+++ b/src/game/Server/Packets/Trade.cpp
@@ -1,5 +1,7 @@
 #include "Trade.h"
 
+#include "SharedDefines.h"
+
 void WorldPackets::Trade::InitiateTrade::ReadFromWorldPacket(WorldPacket& recv_data)
 {
     recv_data >> tradeTargetGuid;
@@ -27,3 +29,26 @@ void WorldPackets::Trade::AcceptTrade::ReadFromWorldPacket(WorldPacket& recv_dat
     // some unused variable with is set to 1 when the player got TRADE_STATUS_OPEN_WINDOW at least once in this session
     recv_data.read_skip<uint32>();
 }
+
+void WorldPackets::Trade::TradeStatus::AppendBodyTo(ByteBuffer& buffer) const
+{
+    buffer << status;
+    switch (status)
+    {
+        case TRADE_STATUS_BEGIN_TRADE:
+            buffer << playerGuid;
+            break;
+        case TRADE_STATUS_CLOSE_WINDOW:
+            buffer << closeResult;
+            buffer << closeUnk;
+            buffer << closeItemLimitCategory;
+            break;
+        case TRADE_STATUS_ONLY_CONJURED:
+            buffer << slot;
+            break;
+        default:
+            break;
+    }
+}
+
+

--- a/src/game/Server/Packets/Trade.h
+++ b/src/game/Server/Packets/Trade.h
@@ -3,6 +3,7 @@
 
 #include "Packet.h"
 #include "ObjectGuid.h"
+#include <vector>
 
 namespace WorldPackets { namespace Trade
 {
@@ -50,6 +51,25 @@ namespace WorldPackets { namespace Trade
         explicit AcceptTrade() : ClientPacket(CMSG_ACCEPT_TRADE) {}
         void ReadFromWorldPacket(WorldPacket& recv_data) override;
     };
+    // --- Server Packets ---
+
+    class TradeStatus final : public ServerPacket
+    {
+    public:
+        uint32 status = 0;
+        // BEGIN_TRADE: guid of the player initiating trade
+        ObjectGuid playerGuid;
+        // CLOSE_WINDOW extra fields
+        uint32 closeResult = 0;
+        uint8 closeUnk = 0;
+        uint32 closeItemLimitCategory = 0;
+        // ONLY_CONJURED extra field
+        uint8 slot = 0;
+
+        explicit TradeStatus() : ServerPacket(SMSG_TRADE_STATUS) {}
+        void AppendBodyTo(ByteBuffer& buffer) const override;
+    };
+
 }} // namespace WorldPackets::Trade
 
 #endif // MANGOS_PACKETS_TRADE_H

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -44,6 +44,8 @@
 #include "PlayerBroadcaster.h"
 #include "Crypto/Hash/MD5.h"
 
+#include <limits>
+
 // select opcodes appropriate for processing in Map::Update context for current session state
 static bool MapSessionFilterHelper(WorldSession* session, OpcodeHandler const& opHandle)
 {
@@ -74,7 +76,7 @@ WorldSession::WorldSession(uint32 id, std::shared_ptr<WorldSocket> sock, Account
     m_playerLoading(false), m_playerLogout(false), m_playerRecentlyLogout(false), m_playerSave(false), m_sessionDbcLocale(sWorld.GetAvailableDbcLocale(locale)),
     m_sessionDbLocaleIndex(sObjectMgr.GetIndexForLocale(locale)), m_latency(0), m_tutorialState(TUTORIALDATA_UNCHANGED), m_warden(nullptr), m_cheatData(nullptr),
     m_bot(nullptr), m_clientOS(CLIENT_OS_UNKNOWN), m_clientPlatform(CLIENT_PLATFORM_UNKNOWN), m_gameBuild(0), m_verifiedEmail(true),
-    m_charactersCount(10), m_characterMaxLevel(0), m_lastPubChannelMsgTime(0), m_moveRejectTime(0), m_masterPlayer(nullptr), m_receivedPacketType{},
+    m_charactersCount(std::numeric_limits<uint32>::max()), m_characterMaxLevel(0), m_lastPubChannelMsgTime(0), m_moveRejectTime(0), m_masterPlayer(nullptr), m_receivedPacketType{},
     m_floodPacketsCount{}, m_tutorials{}
 {
     m_remoteIpAddress = sock ? sock->GetRemoteIpString() : "<BOT>";
@@ -422,10 +424,10 @@ void WorldSession::CheckPlayedTimeLimit(time_t now)
 void WorldSession::SendPlayTimeWarning(PlayTimeFlag flag, int32 timeLeftInSeconds)
 {
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_7_1
-    WorldPacket data(SMSG_PLAY_TIME_WARNING, sizeof(uint32) + sizeof(int32));
-    data << uint32(flag);
-    data << int32(timeLeftInSeconds);
-    SendPacket(&data);
+    auto packet = std::make_unique<WorldPackets::Misc::PlayTimeWarning>();
+    packet->flag = static_cast<uint32>(flag);
+    packet->timeLeftInSeconds = timeLeftInSeconds;
+    SendPacket(std::move(packet));
 #endif
 }
 
@@ -840,8 +842,7 @@ void WorldSession::LogoutPlayer(bool Save)
         SetPlayer(nullptr);                                    // deleted in Remove/DeleteFromWorld call
 
         // Send the 'logout complete' packet to the client
-        WorldPacket data(SMSG_LOGOUT_COMPLETE, 0);
-        SendPacket(&data);
+        SendPacket(std::make_unique<WorldPackets::Misc::LogoutComplete>());
 
         sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "SESSION: Sent SMSG_LOGOUT_COMPLETE Message");
     }

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -110,6 +110,34 @@ char const* WorldSession::GetPlayerName() const
     return GetPlayer() ? GetPlayer()->GetName() : "<none>";
 }
 
+// Sends a packet to the client.
+void WorldSession::SendPacket(std::unique_ptr<ServerPacket> packet)
+{
+    WorldPacket buffer;
+    { // TODO: This part will be offloaded to an IO thread soon. Only the IO thread will allocate a buffer.
+        buffer.SetOpcode(packet->GetOpcode());
+        buffer.FillPacketTime(WorldTimer::getMSTime());
+        packet->AppendBodyTo(buffer);
+    }
+
+    // There is a maximum size packet.
+    if (buffer.size() > 0x8000)
+    {
+        // Packet will be rejected by client
+        sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "[NETWORK] Packet %s size %u is too large. Not sent [Account %u Player %s]", LookupOpcodeName(buffer.GetOpcode()), buffer.size(), GetAccountId(), GetPlayerName());
+        return;
+    }
+
+    if (!m_socket)
+    {
+        if (GetBot() && GetBot()->ai)
+            GetBot()->ai->OnPacketReceived(&buffer); // TODO Direct forward `ServerPacket` to bot in next PR
+        return;
+    }
+
+    SendPacketImpl(&buffer); // TODO Queue `ServerPacket` and serialize it in IO thread
+}
+
 // Send a packet to the client
 void WorldSession::SendPacket(WorldPacket const* packet)
 {

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -61,6 +61,8 @@
 #include "Packets/Taxi.h"
 #include "Packets/Trade.h"
 
+#include <memory>
+
 struct ItemPrototype;
 struct AuctionEntry;
 struct AuctionHouseEntry;
@@ -360,6 +362,9 @@ class WorldSession
         static void VerifyPacketWasCorrectlyRead(WorldPacket const& recvPacket, ClientPacket const& clientPacket);
 
     public:
+        /// Sends a packet to the client.
+        void SendPacket(std::unique_ptr<ServerPacket> packet);
+        /// @deprecated Use SendPacket with ServerPacket class
         void SendPacket(WorldPacket const* packet);
         void SendMovementPacket(WorldPacket const* packet);
         void SendNotification(char const* format, ...) ATTR_PRINTF(2, 3);
@@ -779,7 +784,6 @@ class WorldSession
         void HandleCompleteCinematic(NullClientPacket const& packet);
         void HandleNextCinematicCamera(NullClientPacket const& packet);
 
-        void HandlePageQuerySkippedOpcode(WorldPacket& recvPacket);
         void HandlePageTextQueryOpcode(WorldPackets::Query::QueryPageText const& packet);
 
         void HandleTutorialFlagOpcode(WorldPackets::Misc::TutorialFlag const& packet);

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -370,7 +370,7 @@ class WorldSession
         void SendNotification(char const* format, ...) ATTR_PRINTF(2, 3);
         void SendNotification(int32 string_id, ...);
         void SendPetNameInvalid(uint32 error, std::string const& name);
-        void SendPartyResult(PartyOperation operation, std::string const& member, PartyResult res);
+        void SendPartyResult(PartyOperation operation, std::string const& memberName, PartyResult res);
         void SendAreaTriggerMessage(char const* Text, ...) ATTR_PRINTF(2, 3);
         void SendQueryTimeResponse();
 
@@ -468,7 +468,6 @@ class WorldSession
         // Group
         void BuildPartyMemberStatsChangedPacket(Player* player, WorldPacket* data);
         void BuildPartyMemberStatsPacket(Player* player, WorldPacket* data, uint32 updateMask, bool sendAllAuras);
-
     public:                                                 // opcodes handlers
         template<typename TClientPacket>
         static std::unique_ptr<ClientPacket> Handle_GenericRead(WorldPacket& recvPacket)
@@ -892,7 +891,7 @@ class WorldSession
         bool m_playerRecentlyLogout;
         bool m_playerSave;
         uint32 m_exhaustionState;
-        uint32 m_charactersCount;
+        uint32 m_charactersCount;                           // init with max, to prevent character creation before amount is recalculated in CharEnum handler
         uint32 m_characterMaxLevel;
         BigNumber m_sessionKey;
         AccountData m_accountData[NewAccountData::NUM_ACCOUNT_DATA_TYPES];

--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -1792,6 +1792,8 @@ enum TicketType
 // Used for some dynamic scaling systems, depending on total population
 #define BLIZZLIKE_REALM_POPULATION 2500
 
+struct WorldLocation;
+
 struct Position
 {
     Position() = default;
@@ -1805,24 +1807,27 @@ struct Position
     {
         return !x && !y && !z && !o;
     }
+
+    WorldLocation WithMapId(uint32 mapId) const;
 };
 
-struct WorldLocation
+struct WorldLocation : public Position
 {
     uint32 mapId = 0;
-    float x = 0.0f;
-    float y = 0.0f;
-    float z = 0.0f;
-    float o = 0.0f;
     explicit WorldLocation(uint32 _mapid = 0, float _x = 0, float _y = 0, float _z = 0, float _o = 0)
-        : mapId(_mapid), x(_x), y(_y), z(_z), o(_o) {}
+        : Position(_x, _y, _z, _o), mapId(_mapid) {}
     WorldLocation(WorldLocation const& loc)
-        : mapId(loc.mapId), x(loc.x), y(loc.y), z(loc.z), o(loc.o) {}
+        : Position(loc.x, loc.y, loc.z, loc.o), mapId(loc.mapId) {}
 
     bool IsEmpty() const
     {
-        return !mapId && !x && !y && !z && !o;
+        return !mapId && Position::IsEmpty();
     }
 };
+
+inline WorldLocation Position::WithMapId(uint32 mapId) const
+{
+    return WorldLocation(mapId, x, y, z, o);
+}
 
 #endif

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4401,7 +4401,7 @@ void Spell::SendCastResult(Player* caster, SpellEntry const* spellInfo, SpellCas
 
     if (result != SPELL_CAST_OK && !spellInfo->HasAttribute(SPELL_ATTR_EX2_DO_NOT_REPORT_SPELL_FAILURE))
     {
-        data << uint8(2); // status = fail
+        data << static_cast<uint8>(SPELL_RESULT_STATUS_FAIL);
         data << uint8(spellInfo->IsPassiveSpell() ? SPELL_FAILED_DONT_REPORT : result);                                  // problem
         switch (result)
         {
@@ -4431,7 +4431,9 @@ void Spell::SendCastResult(Player* caster, SpellEntry const* spellInfo, SpellCas
         }
     }
     else
-        data << uint8(0);
+    {
+        data << static_cast<uint8>(SPELL_RESULT_STATUS_OKAY);
+    }
 
     caster->GetSession()->SendPacket(&data);
 }

--- a/src/game/Spells/SpellDefines.h
+++ b/src/game/Spells/SpellDefines.h
@@ -542,7 +542,7 @@ enum SpellAuraInterruptFlags
     AURA_INTERRUPT_MOVING_CANCELS                   = 0x00000008,   // 3
     AURA_INTERRUPT_TURNING_CANCELS                  = 0x00000010,   // 4
     AURA_INTERRUPT_ANIM_CANCELS                     = 0x00000020,   // 5    used by Feign Death
-    AURA_INTERRUPT_DISMOUNT_CANCELS                 = 0x00000040,   // 6 
+    AURA_INTERRUPT_DISMOUNT_CANCELS                 = 0x00000040,   // 6
     AURA_INTERRUPT_UNDER_WATER_CANCELS              = 0x00000080,   // 7    removed by entering water
     AURA_INTERRUPT_ABOVE_WATER_CANCELS              = 0x00000100,   // 8    removed by leaving water
     AURA_INTERRUPT_SHEATHING_CANCELS                = 0x00000200,   // 9
@@ -1204,7 +1204,7 @@ enum SpellCategories
     SPELLCATEGORY_HOLY_FIRE = 451,
     SPELLCATEGORY_ICE_BARRIER = 471,
     SPELLCATEGORY_ASTRAL_RECALL = 511,
-    SPELLCATEGORY_NATURES_GRASP = 531, 
+    SPELLCATEGORY_NATURES_GRASP = 531,
     SPELLCATEGORY_AURA_OF_THE_PIOUS = 551,
     SPELLCATEGORY_HURRICANE = 571,
     SPELLCATEGORY_TOTEM_MANA_TIDE = 591,
@@ -1298,6 +1298,12 @@ enum SpellSpecific
     SPELL_FOOD_AND_DRINK    = 22,
     SPELL_NEGATIVE_HASTE    = 23,
     SPELL_SNARE             = 24,
+};
+
+enum SpellCastResultStatus : uint8
+{
+    SPELL_RESULT_STATUS_OKAY = 0,
+    SPELL_RESULT_STATUS_FAIL = 2
 };
 
 #endif

--- a/src/game/Weather.cpp
+++ b/src/game/Weather.cpp
@@ -214,16 +214,16 @@ void Weather::SendWeatherUpdateToPlayer(Player* player)
     NormalizeGrade();
 
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_7_1
-    WorldPacket data(SMSG_WEATHER, 4 + 4 + 4 + 1);
-    data << uint32(m_type);
-    data << float(m_grade);
+    auto packet = std::make_unique<WorldPackets::Misc::WeatherUpdate>();
+    packet->weatherType = m_type;
+    packet->grade = m_grade;
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_8_4
-    data << uint32(GetSound()); // 1.12 soundid
+    packet->soundId = GetSound();
 #endif
 #if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_9_4
-    data << uint8(0);           // 1 = instant change, 0 = smooth change
+    packet->instantChange = false;
 #endif
-    player->GetSession()->SendPacket(&data);
+    player->GetSession()->SendPacket(std::move(packet));
 #endif
 }
 

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -3229,11 +3229,3 @@ uint32 World::GetDelayUntilNextSpellBatchingInterval()
 
     return (getConfig(CONFIG_UINT32_SPELL_EFFECT_DELAY) - (WorldTimer::getMSTime() % getConfig(CONFIG_UINT32_SPELL_EFFECT_DELAY)));
 }
-
-void SessionPacketSendTask::operator()()
-{
-    if (WorldSession* session = sWorld.FindSession(m_accountId))
-    {
-        session->SendPacket(&m_data);
-    }
-}

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2758,14 +2758,22 @@ void World::ShutdownCancel()
 // Send a server message to the user(s)
 void World::SendServerMessage(ServerMessageType type, char const* text, Player* player)
 {
-    WorldPacket data(SMSG_SERVER_MESSAGE, 50);              // guess size
-    data << uint32(type);
-    data << text;
+    auto packet = std::make_unique<WorldPackets::Misc::ServerMessage>();
+    packet->messageType = static_cast<uint32>(type);
+    packet->text = text;
 
     if (player)
-        player->GetSession()->SendPacket(&data);
+    {
+        player->GetSession()->SendPacket(std::move(packet));
+    }
     else
+    {
+        // TODO Use broadcaster which does the binary conversion automatically
+        WorldPacket data;
+        data.SetOpcode(packet->GetOpcode());
+        packet->AppendBodyTo(data);
         SendGlobalMessage(&data);
+    }
 }
 
 void World::UpdateSessions(uint32 diff)

--- a/src/game/World.h
+++ b/src/game/World.h
@@ -633,17 +633,6 @@ enum RealmType
                                                             // replaced by REALM_PVP in realm list
 };
 
-class SessionPacketSendTask
-{
-public:
-    SessionPacketSendTask(SessionPacketSendTask const&) = delete;
-    SessionPacketSendTask(uint32 accountId, WorldPacket& data) : m_accountId(accountId), m_data(data) {}
-    void operator ()();
-private:
-    uint32 m_accountId;
-    WorldPacket m_data;
-};
-
 // Storage class for commands issued for delayed execution
 struct CliCommandHolder
 {
@@ -653,7 +642,7 @@ struct CliCommandHolder
     uint32 m_cliAccountId;                                  // 0 for console and real account id for RA/soap
     AccountTypes m_cliAccessLevel;
     void* m_callbackArg;
-    char *m_command;
+    char* m_command;
     Print* m_print;
     CommandFinished* m_commandFinished;
 

--- a/src/shared/IO/Networking/NetworkError.cpp
+++ b/src/shared/IO/Networking/NetworkError.cpp
@@ -1,7 +1,7 @@
 #include "./NetworkError.h"
 #include "../SystemErrorToString.h"
 
-std::string const& GetErrorBaseString(IO::NetworkError::ErrorType errorType)
+static std::string const& GetErrorBaseString(IO::NetworkError::ErrorType errorType)
 {
     switch (errorType)
     {

--- a/src/shared/IO/SystemErrorToString.cpp
+++ b/src/shared/IO/SystemErrorToString.cpp
@@ -10,7 +10,7 @@ constexpr int MAX_ERROR_TEXT_LENGTH = 255;
 thread_local char g_threadLocalStorage[MAX_ERROR_TEXT_LENGTH];
 
 // The buffer is thread_local, don't free it
-char const* SystemErrorToCString(int nativeSystemErrorCode) {
+static char const* SystemErrorToCString(int nativeSystemErrorCode) {
 #if defined(WIN32)
     if (!FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_MAX_WIDTH_MASK, nullptr, nativeSystemErrorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL), g_threadLocalStorage, MAX_ERROR_TEXT_LENGTH, nullptr))
         return "<Unable to generate error text>";

--- a/src/shared/nonstd/optional.hpp
+++ b/src/shared/nonstd/optional.hpp
@@ -366,7 +366,7 @@ struct optional_storage_base {
   TL_OPTIONAL_11_CONSTEXPR optional_storage_base(in_place_t, U &&... u)
       : m_value(std::forward<U>(u)...), m_has_value(true) {}
 
-  ~optional_storage_base() {
+  ~optional_storage_base() noexcept(::std::is_nothrow_destructible<T>::value) {
     if (m_has_value) {
       m_value.~T();
       m_has_value = false;


### PR DESCRIPTION
Converts some of the manually built `WorldPacket` (which were sent by the server) to nicely structured `ServerPackets`.

Due to the large amount of changes required this will be split into multiple PRs.
