### PR TITLE
CI: Add MinGW64 build job.

### DIFF
--- a/.github/scripts/package-windows-release.sh
+++ b/.github/scripts/package-windows-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026-present  VMaNGOS  https://github.com/vmangos
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <dependency-dir-name> <archive-filename>" >&2
+  exit 1
+fi
+
+dep_dir_name="$1"
+archive_filename="$2"
+release_dir="$PWD/bin/Release"
+dep_dir="$PWD/dep/windows/lib/${dep_dir_name}_release"
+archive_path="$PWD/bin/$archive_filename"
+
+if [ ! -d "$release_dir" ]; then
+  echo "Could not find release directory at $release_dir." >&2
+  exit 1
+fi
+
+if [ ! -d "$dep_dir" ]; then
+  echo "Could not find dependency directory at $dep_dir." >&2
+  exit 1
+fi
+
+cp -f "$dep_dir/libmySQL.dll" "$release_dir/libmySQL.dll"
+cp -f "$dep_dir/libeay32.dll" "$release_dir/libeay32.dll"
+
+rm -f "$archive_path"
+
+(
+  cd "$PWD/bin"
+  7z a -tzip "$archive_filename" Release >/dev/null
+)

--- a/.github/scripts/publish-moving-release.sh
+++ b/.github/scripts/publish-moving-release.sh
@@ -27,7 +27,7 @@ release_tag="$1"
 release_title_prefix="$2"
 asset_dir="$3"
 repo_url="https://github.com/$GITHUB_REPOSITORY"
-release_title="$release_title_prefix($(date -u +%F))"
+release_title="$release_title_prefix ($(date -u +%F))"
 notes_file="$(mktemp)"
 
 trap 'rm -f "$notes_file"' EXIT

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,4 +1,5 @@
-# Build on Ubuntu with GCC and Clang, plus a Windows Visual Studio build.
+# Build on Ubuntu with GCC and Clang, plus Windows Visual Studio and MinGW64
+# builds.
 name: CI Build
 
 on:
@@ -30,8 +31,8 @@ on:
 
 jobs:
   build:
-    name: Build on ${{ matrix.job_name }} (client build ${{ matrix.client_build }})
-    runs-on: ${{ matrix.os }}
+    name: Build on ${{ matrix.config.job_name }} (client build ${{ matrix.client_build }})
+    runs-on: ${{ matrix.config.os }}
     permissions:
       contents: read
     strategy:
@@ -45,10 +46,7 @@ jobs:
           - 4695
           - 4544
           - 4449
-        os:
-          - ubuntu-24.04
-          - windows-2022
-        include:
+        config:
           - os: ubuntu-24.04
             c_compiler: gcc
             cxx_compiler: g++
@@ -60,13 +58,16 @@ jobs:
             job_name: Ubuntu Clang
           - os: windows-2022
             job_name: Windows Visual Studio
+          - os: windows-2022
+            job_name: Windows MinGW
+            use_mingw: true
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
       - name: Install Ubuntu build dependencies
-        if: matrix.os == 'ubuntu-24.04'
+        if: matrix.config.os == 'ubuntu-24.04'
         run: |
           sudo apt update
           sudo apt install -y --no-install-recommends \
@@ -78,18 +79,32 @@ jobs:
             zlib1g-dev
 
       - name: Install Clang compiler
-        if: matrix.install_clang
+        if: matrix.config.install_clang
         run: sudo apt install -y --no-install-recommends clang
 
+      - name: Set up MSYS2 (MINGW64)
+        if: matrix.config.use_mingw
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            git
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-curl
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-ninja
+
       - name: Build and install on Ubuntu
-        if: matrix.os == 'ubuntu-24.04'
+        if: matrix.config.os == 'ubuntu-24.04'
         run: |
           set -euo pipefail
           mkdir -p build _install
           cd build
           cmake ../ \
-            -DCMAKE_C_COMPILER="${{ matrix.c_compiler }}" \
-            -DCMAKE_CXX_COMPILER="${{ matrix.cxx_compiler }}" \
+            -DCMAKE_C_COMPILER="${{ matrix.config.c_compiler }}" \
+            -DCMAKE_CXX_COMPILER="${{ matrix.config.cxx_compiler }}" \
             -DCMAKE_INSTALL_PREFIX="../_install" \
             -DBUILD_EXTRACTORS=1 \
             -DENABLE_MAILSENDER=1 \
@@ -97,8 +112,8 @@ jobs:
           make -j"$(nproc)"
           make install
 
-      - name: Build and install on Windows
-        if: matrix.os == 'windows-2022'
+      - name: Build and install on Windows (Visual Studio)
+        if: matrix.config.os == 'windows-2022' && !matrix.config.use_mingw
         shell: bash # Windows runners default to PowerShell.
         run: |
           set -euo pipefail
@@ -111,3 +126,13 @@ jobs:
           cd build
           cmake -DBUILD_EXTRACTORS=1 -DENABLE_MAILSENDER=1 -DSUPPORTED_CLIENT_BUILD="${{ matrix.client_build }}" -G "Visual Studio 17 2022" -A x64 ..
           "/c/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" "MaNGOS.sln" //p:Platform=x64 //p:Configuration=Release //m
+
+      - name: Build and install on Windows (MinGW)
+        if: matrix.config.use_mingw
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          cd build
+          cmake -DBUILD_EXTRACTORS=1 -DENABLE_MAILSENDER=1 -DSUPPORTED_CLIENT_BUILD="${{ matrix.client_build }}" -DCMAKE_BUILD_TYPE=Release -G Ninja ..
+          cmake --build . --parallel

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -37,6 +37,9 @@ jobs:
       contents: read
     strategy:
       matrix:
+        # Every supported client build is verified against Ubuntu GCC; the
+        # latest (1.12.1.5875) additionally runs against Ubuntu Clang, Windows
+        # Visual Studio, and Windows MinGW (added via include below).
         client_build:
           - 5875
           - 5464
@@ -46,21 +49,29 @@ jobs:
           - 4695
           - 4544
           - 4449
+          - 4375
         config:
           - os: ubuntu-24.04
             c_compiler: gcc
             cxx_compiler: g++
             job_name: Ubuntu GCC
-          - os: ubuntu-24.04
-            c_compiler: clang
-            cxx_compiler: clang++
-            install_clang: true
-            job_name: Ubuntu Clang
-          - os: windows-2022
-            job_name: Windows Visual Studio
-          - os: windows-2022
-            job_name: Windows MinGW
-            use_mingw: true
+        include:
+          - client_build: 5875
+            config:
+              os: ubuntu-24.04
+              c_compiler: clang
+              cxx_compiler: clang++
+              install_clang: true
+              job_name: Ubuntu Clang
+          - client_build: 5875
+            config:
+              os: windows-2022
+              job_name: Windows Visual Studio
+          - client_build: 5875
+            config:
+              os: windows-2022
+              job_name: Windows MinGW
+              use_mingw: true
 
     steps:
       - name: Check out repository

--- a/.github/workflows/development-db-dump.yaml
+++ b/.github/workflows/development-db-dump.yaml
@@ -126,4 +126,4 @@ jobs:
       - name: Publish release snapshot
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./.github/scripts/publish-moving-release.sh db_latest "Development DB Dump" release-assets
+        run: ./.github/scripts/publish-moving-release.sh db_latest "Development Database Snapshot" release-assets

--- a/.github/workflows/windows-development-release.yaml
+++ b/.github/workflows/windows-development-release.yaml
@@ -46,13 +46,10 @@ jobs:
           echo "ARCHIVE_FILENAME=dev-$(git rev-parse --short HEAD).zip" >> $env:GITHUB_ENV
 
       - name: Create release archive
+        shell: bash # Windows runners default to PowerShell.
         run: |
-          Set-StrictMode -Version Latest
-          Set-Location "${{ github.workspace }}/bin"
-          Copy-Item -Force "${{ github.workspace }}/dep/windows/lib/x64_release/libmySQL.dll" "${{ github.workspace }}/bin/Release/libmySQL.dll"
-          Copy-Item -Force "${{ github.workspace }}/dep/windows/lib/x64_release/libeay32.dll" "${{ github.workspace }}/bin/Release/libeay32.dll"
-
-          7z a -tzip "${{ env.ARCHIVE_FILENAME }}" Release
+          set -euo pipefail
+          ./.github/scripts/package-windows-release.sh x64 "$ARCHIVE_FILENAME"
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v7
@@ -83,4 +80,4 @@ jobs:
       - name: Publish release snapshot
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./.github/scripts/publish-moving-release.sh latest "Development Build" release-assets
+        run: ./.github/scripts/publish-moving-release.sh latest "Windows Development Build" release-assets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,9 @@ if(WIN32)
   set(OPENSSL_LIBRARIES ${CMAKE_SOURCE_DIR}/dep/windows/lib/${DEP_ARCH}_release/libeay32.lib)
   set(OPENSSL_DEBUG_LIBRARIES ${CMAKE_SOURCE_DIR}/dep/windows/lib/${DEP_ARCH}_debug/libeay32.lib)
   set(ZLIB_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/dep/windows/include/zlib)
-  if (REQUIRES_LIBCURL)
+  if (REQUIRES_LIBCURL AND MSVC)
+    # MinGW falls through to find_package(CURL) below, which picks up
+    # libcurl from the toolchain environment (e.g., MSYS2).
     set(CURL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/dep/windows/optional_dependencies/curl/include)
     set(CURL_LIBRARY     ${CMAKE_SOURCE_DIR}/dep/windows/optional_dependencies/curl/lib/libcurl.lib)
   endif()

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This project is an independent continuation of the Elysium / LightsHope codebase
 - Tools are great: Content creation should not require programming knowledge. We hope to eventually provide tools that allow for user-friendly editing of database scripts and content, with all data presented in human-readable form.
 
 ### Downloads
-- [![Windows Development Release](https://github.com/vmangos/core/actions/workflows/windows-development-release.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/latest)  Latest development binary
-- [![Development Database Dump](https://github.com/vmangos/core/actions/workflows/development-db-dump.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/db_latest)  mysql5.6 full dump, no update needed.
+- [![Windows Development Release](https://github.com/vmangos/core/actions/workflows/windows-development-release.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/latest) Latest Windows development build
+- [![Development Database Dump](https://github.com/vmangos/core/actions/workflows/development-db-dump.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/db_latest) Latest MySQL 5.6 development database snapshot; no updates required
 
 ### Useful Links
 - [Wiki](https://github.com/vmangos/wiki)

--- a/dep/src/g3dlite/GThread.cpp
+++ b/dep/src/g3dlite/GThread.cpp
@@ -12,6 +12,12 @@
 #include "G3D/debugAssert.h"
 #include "G3D/GMutex.h"
 
+#ifdef __MINGW32__
+// MinGW needs libseh's SEH macros for this debugger thread-name exception.
+// The include needs to be outside of the G3D namespace.
+#include <seh.h>
+#endif
+
 namespace G3D {
 
 namespace _internal {
@@ -90,10 +96,6 @@ typedef struct tagTHREADNAME_INFO {
    DWORD dwFlags; // Reserved for future use, must be zero.
 } THREADNAME_INFO;
 #pragma pack(pop)
-
-#ifdef __MINGW32__
-#include <seh.h>
-#endif
 
 static void SetThreadName(DWORD dwThreadID, const char* threadName) {
     THREADNAME_INFO info;

--- a/src/shared/ByteBuffer.h
+++ b/src/shared/ByteBuffer.h
@@ -131,7 +131,7 @@ class ByteBuffer
             return *this;
         }
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(__MINGW64__)
         ByteBuffer& operator<<(time_t value)
         {
             append<time_t>(value);
@@ -227,7 +227,7 @@ class ByteBuffer
             return *this;
         }
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(__MINGW64__)
         ByteBuffer& operator >> (time_t& value)
         {
             value = read<time_t>();

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -262,6 +262,12 @@ if(WIN32)
   target_include_directories(shared PUBLIC
     ${CMAKE_SOURCE_DIR}/dep/windows/include
   )
+
+  if(MINGW)
+    target_include_directories(shared PRIVATE
+      ${CMAKE_SOURCE_DIR}/dep/src/libseh
+    )
+  endif()
 endif()
 
 if (REQUIRES_LIBCURL)
@@ -284,6 +290,14 @@ endif(UNIX)
 
 if(WIN32)
   target_link_libraries(shared PUBLIC ws2_32 mswsock)
+
+  if(MINGW)
+    # MinGW needs libseh for the debugger thread-name SEH handler in
+    # CreateThread.cpp.
+    # MinGW also needs an explicit winmm link because it does not honor
+    # TimePeriod.cpp's Winmm.lib pragma.
+    target_link_libraries(shared PRIVATE libseh winmm)
+  endif()
 endif()
 
 if (ENABLE_CPPTRACE)

--- a/src/shared/IO/Context/IoContext_windows.cpp
+++ b/src/shared/IO/Context/IoContext_windows.cpp
@@ -1,5 +1,6 @@
 #include "IoContext.h"
 #include "Log.h"
+#include <thread>
 #include <Windows.h>
 
 std::unique_ptr<IO::IoContext> IO::IoContext::CreateIoContext()

--- a/src/shared/IO/Multithreading/CreateThread.cpp
+++ b/src/shared/IO/Multithreading/CreateThread.cpp
@@ -4,6 +4,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #undef WIN32_LEAN_AND_MEAN
+#if defined(__MINGW32__)
+#include <seh.h>
+#endif
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <pthread.h>
 #endif
@@ -49,6 +52,17 @@ void IO::Multithreading::RenameCurrentThread(std::string const& name)
     info.dwThreadID = GetCurrentThreadId();
     info.dwFlags = 0;
 
+#if defined(__MINGW32__)
+    // MinGW lacks SEH __try/__except syntax, so the libseh macros are used.
+    __seh_try
+    {
+        RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+    }
+    __seh_except(EXCEPTION_EXECUTE_HANDLER)
+    {
+    }
+    __seh_end_except
+#else
     __try
     {
         RaiseException( MS_VC_EXCEPTION, 0, sizeof(info)/sizeof(ULONG_PTR), (ULONG_PTR*)&info );
@@ -56,6 +70,7 @@ void IO::Multithreading::RenameCurrentThread(std::string const& name)
     __except(EXCEPTION_EXECUTE_HANDLER)
     {
     }
+#endif
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
     ::pthread_setname_np(pthread_self(), name.c_str());
 #elif defined(__APPLE__)

--- a/src/shared/IO/Networking/AsyncSocketAcceptor_windows.cpp
+++ b/src/shared/IO/Networking/AsyncSocketAcceptor_windows.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 #include <chrono>
+#include <thread>
 
 #include <WinSock2.h>
 #include <MSWSock.h> // TODO: Currently just needed for ::AcceptEx, maybe its better if we get this func-ptr at runtime, just like Microsoft recommends it


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
__Edit:__ As discussed below, I changed the PR to add a new (modern) MinGW CI build (instead of the previously proposed Windows XP release).

I left the slight Windows packaging refactor since it's imo cleaner, and also the slight naming adjustments in the README and the releases themselves.

Also, more importantly, this also fixes a bug with the build matrix; when I fixed the Clang builds previously, I made a mistake there I only noticed today which caused all Ubuntu builds to use Clang instead of GCC since then; oops.
With this PR, that is also corrected.