### PR TITLE
Add Linux development release.

### DIFF
--- a/.github/scripts/package-linux-release.sh
+++ b/.github/scripts/package-linux-release.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026-present  VMaNGOS  https://github.com/vmangos
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <install-dir> <archive-filename>" >&2
+  exit 1
+fi
+
+install_dir="$1"
+archive_filename="$2"
+package_name="vmangos-linux-amd64"
+stage_parent="$PWD/bin/linux-release"
+package_dir="$stage_parent/$package_name"
+lib_dir="$package_dir/lib"
+archive_path="$PWD/bin/$archive_filename"
+elf_files=()
+
+if [ ! -d "$install_dir" ]; then
+  echo "Could not find install directory at $install_dir." >&2
+  exit 1
+fi
+
+case "$archive_filename" in
+*/*)
+  echo "Archive filename must not contain a path." >&2
+  exit 1
+  ;;
+*.tar.gz)
+  ;;
+*)
+  echo "Archive filename must end in .tar.gz." >&2
+  exit 1
+  ;;
+esac
+
+is_elf() {
+  local file="$1"
+  local magic
+
+  if [ ! -f "$file" ]; then
+    return 1
+  fi
+
+  magic="$(head -c 4 "$file" 2>/dev/null || true)"
+  [ "$magic" = $'\177ELF' ]
+}
+
+is_glibc_library() {
+  local library_name
+
+  library_name="$(basename "$1")"
+
+  case "$library_name" in
+  ld-linux*.so* | libc.so* | libm.so* | libpthread.so* | librt.so* | libdl.so* | libresolv.so* | libnss_*.so* | libnsl.so* | libutil.so* | libanl.so*)
+    return 0
+    ;;
+  esac
+
+  return 1
+}
+
+collect_elf_files() {
+  local file
+
+  elf_files=()
+
+  while IFS= read -r -d '' file; do
+    if is_elf "$file"; then
+      elf_files+=("$file")
+    fi
+  done < <(find "$package_dir" -type f -print0)
+}
+
+extract_dependency_paths() {
+  local elf_file="$1"
+  local line
+  local dependency_path
+  local linked_dependency_regex='=>[[:space:]]+(/[^[:space:]]+)'
+  local absolute_dependency_regex='^[[:space:]]*(/[^[:space:]]+)'
+
+  while IFS= read -r line; do
+    if [[ "$line" == *"not found"* ]]; then
+      echo "Missing dependency while scanning $elf_file: $line" >&2
+      return 1
+    fi
+
+    dependency_path=""
+
+    if [[ "$line" =~ $linked_dependency_regex ]]; then
+      dependency_path="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ $absolute_dependency_regex ]]; then
+      dependency_path="${BASH_REMATCH[1]}"
+    fi
+
+    if [ -n "$dependency_path" ] && [ -f "$dependency_path" ] && ! is_glibc_library "$dependency_path"; then
+      printf '%s\n' "$dependency_path"
+    fi
+  done < <(ldd "$elf_file")
+}
+
+copy_runtime_dependencies() {
+  local index
+  local elf_file
+  local dependency_path
+  local dependency_name
+  local bundled_dependency_path
+
+  collect_elf_files
+
+  index=0
+  while [ "$index" -lt "${#elf_files[@]}" ]; do
+    elf_file="${elf_files[$index]}"
+    index=$((index + 1))
+
+    while IFS= read -r dependency_path; do
+      dependency_name="$(basename "$dependency_path")"
+      bundled_dependency_path="$lib_dir/$dependency_name"
+
+      if [ -e "$bundled_dependency_path" ]; then
+        continue
+      fi
+
+      cp -L "$dependency_path" "$bundled_dependency_path"
+      chmod u+w "$bundled_dependency_path"
+
+      if is_elf "$bundled_dependency_path"; then
+        elf_files+=("$bundled_dependency_path")
+      fi
+    done < <(extract_dependency_paths "$elf_file")
+  done
+}
+
+patch_rpaths() {
+  local elf_file
+  local elf_dir
+  local relative_dir
+  local rpath
+  local path_parts
+  local path_part
+
+  collect_elf_files
+
+  for elf_file in "${elf_files[@]}"; do
+    elf_dir="$(dirname "$elf_file")"
+    relative_dir="${elf_dir#"$package_dir"}"
+    relative_dir="${relative_dir#/}"
+    rpath="\$ORIGIN"
+
+    if [ "$relative_dir" != "lib" ]; then
+      IFS='/' read -r -a path_parts <<<"$relative_dir"
+
+      for path_part in "${path_parts[@]}"; do
+        if [ -n "$path_part" ]; then
+          rpath="$rpath/.."
+        fi
+      done
+
+      rpath="$rpath/lib"
+    fi
+
+    patchelf --set-rpath "$rpath" "$elf_file"
+  done
+}
+
+verify_dependencies() {
+  local elf_file
+  local missing_dependencies
+
+  collect_elf_files
+
+  missing_dependencies=0
+
+  for elf_file in "${elf_files[@]}"; do
+    if ldd "$elf_file" | grep -q "not found"; then
+      echo "Missing runtime dependency in $elf_file." >&2
+      ldd "$elf_file" >&2
+      missing_dependencies=1
+    fi
+  done
+
+  if [ "$missing_dependencies" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+rm -rf "$stage_parent"
+mkdir -p "$package_dir" "$lib_dir" "$(dirname "$archive_path")"
+
+cp -a "$install_dir/." "$package_dir/"
+
+copy_runtime_dependencies
+patch_rpaths
+verify_dependencies
+
+rm -f "$archive_path"
+tar -czf "$archive_path" -C "$stage_parent" "$package_name"

--- a/.github/scripts/publish-moving-release.sh
+++ b/.github/scripts/publish-moving-release.sh
@@ -18,24 +18,35 @@
 
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <release-tag> <release-title-prefix> <asset-dir>" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "Usage: $0 <release-tag> <release-title-prefix> <asset-dir> [notes-preamble-file]" >&2
   exit 1
 fi
 
 release_tag="$1"
 release_title_prefix="$2"
 asset_dir="$3"
+notes_preamble_file="${4:-}"
 repo_url="https://github.com/$GITHUB_REPOSITORY"
 release_title="$release_title_prefix ($(date -u +%F))"
 notes_file="$(mktemp)"
 
 trap 'rm -f "$notes_file"' EXIT
 
+if [ -n "$notes_preamble_file" ] && [ ! -f "$notes_preamble_file" ]; then
+  echo "Could not find notes preamble file at $notes_preamble_file." >&2
+  exit 1
+fi
+
 git fetch --force --tags origin
 previous_sha="$(git rev-parse -q --verify "refs/tags/$release_tag^{commit}" 2>/dev/null || true)"
 
-echo "## Commits" >"$notes_file"
+if [ -n "$notes_preamble_file" ]; then
+  cat "$notes_preamble_file" >"$notes_file"
+  printf '\n' >>"$notes_file"
+fi
+
+echo "## Commits" >>"$notes_file"
 
 if [ -n "$previous_sha" ] && [ "$previous_sha" != "$GITHUB_SHA" ]; then
   git_log_args=(--reverse --format='%H%x09%s' "$previous_sha..$GITHUB_SHA")

--- a/.github/workflows/linux-development-release.yaml
+++ b/.github/workflows/linux-development-release.yaml
@@ -1,0 +1,142 @@
+# Build and publish the Linux development release on pushes to development.
+name: Linux Development Release
+
+on:
+  push:
+    branches:
+      - development
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/workflows/development-db-dump.yaml'
+      - '.github/workflows/pr-sql-check.yaml'
+      - '.gitignore'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'sql/**'
+
+concurrency:
+  group: linux-development-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Linux development release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install Ubuntu build dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            libmysqlclient-dev \
+            libssl-dev \
+            patchelf \
+            zlib1g-dev
+
+      - name: Build release binaries
+        run: |
+          set -euo pipefail
+          mkdir -p build _install
+          cd build
+          cmake ../ \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install" \
+            -DBUILD_EXTRACTORS=1 \
+            -DBUILD_FOR_HOST_CPU=0 \
+            -DCONF_DIR:STRING=./etc \
+            -DDEBUG_SYMBOLS=0
+          make -j"$(nproc)"
+          make install
+
+      - name: Set release archive filename
+        run: |
+          echo "ARCHIVE_FILENAME=dev-linux-amd64-$(git rev-parse --short HEAD).tar.gz" >>"$GITHUB_ENV"
+
+      - name: Create release archive
+        run: |
+          set -euo pipefail
+          ./.github/scripts/package-linux-release.sh _install "$ARCHIVE_FILENAME"
+
+      - name: Smoke test release
+        run: |
+          set -euo pipefail
+          cat >smoke-test-linux-release.sh <<'SMOKE_TEST'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          mkdir -p /tmp/vmangos-release
+          tar -xzf /tmp/release.tar.gz -C /tmp/vmangos-release
+
+          /tmp/vmangos-release/vmangos-linux-amd64/bin/realmd --version
+          /tmp/vmangos-release/vmangos-linux-amd64/bin/mangosd --version
+
+          while IFS= read -r -d '' file; do
+            magic="$(head -c 4 "$file" 2>/dev/null || true)"
+            if [ "$magic" = $'\177ELF' ]; then
+              ldd "$file"
+            fi
+          done < <(find /tmp/vmangos-release/vmangos-linux-amd64 -type f -print0) >/tmp/ldd-output.txt
+
+          if grep -q "not found" /tmp/ldd-output.txt; then
+            cat /tmp/ldd-output.txt
+            exit 1
+          fi
+          SMOKE_TEST
+
+          docker run --rm --platform linux/amd64 \
+            -v "$GITHUB_WORKSPACE/bin/$ARCHIVE_FILENAME:/tmp/release.tar.gz:ro" \
+            -v "$PWD/smoke-test-linux-release.sh:/tmp/smoke-test-linux-release.sh:ro" \
+            ubuntu:24.04 \
+            bash /tmp/smoke-test-linux-release.sh
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-development-build
+          path: "${{ github.workspace }}/bin/${{ env.ARCHIVE_FILENAME }}"
+
+  publish:
+    name: Publish Linux development release
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v8
+        with:
+          pattern: linux-development-build
+          merge-multiple: true
+          path: release-assets
+
+      - name: Write release notes preamble
+        run: |
+          cat >linux-release-notes.md <<'RELEASE_NOTES'
+          ## Compatibility
+
+          This Linux development build is for `amd64` systems using `glibc` 2.39 or newer.
+          It is built on Ubuntu 24.04 and bundles non-`glibc` runtime libraries.
+          It is not expected to run on Alpine/`musl` or older `glibc` systems.
+
+          RELEASE_NOTES
+
+      - name: Publish release snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/scripts/publish-moving-release.sh linux_latest "Linux Development Build" release-assets linux-release-notes.md

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This project is an independent continuation of the Elysium / LightsHope codebase
 
 ### Downloads
 - [![Windows Development Release](https://github.com/vmangos/core/actions/workflows/windows-development-release.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/latest) Latest Windows development build
+- [![Linux Development Release](https://github.com/vmangos/core/actions/workflows/linux-development-release.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/linux_latest) Latest Linux development build
 - [![Development Database Dump](https://github.com/vmangos/core/actions/workflows/development-db-dump.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/db_latest) Latest MySQL 5.6 development database snapshot; no updates required
 
 ### Useful Links


### PR DESCRIPTION
## 🍰 Pullrequest
This adds a Linux development release (`amd64`-only) similar to the existing Windows release, [as requested](https://github.com/vmangos/core/pull/3316#issuecomment-4276136278) by @NickTyrer.

The release is built on Ubuntu 24.04 and published as `dev-linux-amd64-<sha>.tar.gz` under a new `linux_latest` moving release tag.

I decided to make the release somewhat portable instead of relying on system dependencies, but it is not fully statically linked. Instead, the package bundles non-`glibc` runtime libraries in `lib/` and uses [PatchELF](https://github.com/NixOS/patchelf) to set relative `RPATH`s, so binaries under `bin/` can find the bundled libraries after extraction.

`glibc` and the dynamic loader are not bundled, so the archive is expected to work on `amd64` systems with `glibc` 2.39 or newer. Alpine/`musl` and older `glibc` systems are not supported.

The workflow includes a small smoke test (which I can also remove if unwanted) that extracts the archive in a fresh Ubuntu 24.04 Docker container, runs `realmd --version` and `mangosd --version`, and checks the packaged ELF files with `ldd`. ~~I have not done a full runtime test with a configured database and extracted client data, so I marked this as draft for now. (@NickTyrer: if you could try this, it would be great.)~~

__Edit:__ I did some testing and for me everything worked, Nick tested too, so this should be fine functionality-wise, removed the draft status.

### Proof
- None

### Issues
- Closes #2979

### How2Test
1. Download the test release from [my fork](https://github.com/mserajnik/vmangos-core/releases/tag/linux_latest).
2. Extract it and run from the archive root:
  ```sh
  cd vmangos-linux-amd64
  ```
3. Copy and edit the config files:
  ```sh
  cp etc/realmd.conf.dist etc/realmd.conf
  cp etc/mangosd.conf.dist etc/mangosd.conf
  ```
4. Adjust DB credentials and other settings as required for your setup.
5. Put extracted client data under the archive root, matching the default `DataDir = "."` (or put it elsewhere and adjust `DataDir` accordingly):
  ```
  vmangos-linux-amd64/
    maps/
    mmaps/
    vmaps/
    5875/
      dbc/
  ```
6. Start `realmd` and `mangosd` from the archive root:
  ```sh
  ./bin/realmd
  ./bin/mangosd
  ```

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] Test if it actually works