### PR TITLE
Remove SetWalk from players on confused movement end

### DIFF
--- a/src/game/Movement/ConfusedMovementGenerator.cpp
+++ b/src/game/Movement/ConfusedMovementGenerator.cpp
@@ -93,6 +93,7 @@ void ConfusedMovementGenerator<Player>::Finalize(Player &unit)
     unit.ClearUnitState(UNIT_STATE_CONFUSED);
     unit.StopMoving();
     unit.UpdateControl();
+    unit.SetWalk(false);
 }
 
 template<>

--- a/src/game/Movement/ConfusedMovementGenerator.cpp
+++ b/src/game/Movement/ConfusedMovementGenerator.cpp
@@ -91,15 +91,16 @@ template<>
 void ConfusedMovementGenerator<Player>::Finalize(Player &unit)
 {
     unit.ClearUnitState(UNIT_STATE_CONFUSED);
+    unit.SetWalk(false, false);
     unit.StopMoving();
     unit.UpdateControl();
-    unit.SetWalk(false);
 }
 
 template<>
 void ConfusedMovementGenerator<Creature>::Finalize(Creature &unit)
 {
     unit.ClearUnitState(UNIT_STATE_CONFUSED);
+    unit.SetWalk(!unit.HasUnitState(UNIT_STATE_RUNNING), false);
     unit.UpdateControl();
 }
 


### PR DESCRIPTION
fixes bug with confused movegen retaining walk mode after ending on players
test: .aura 23601 (scatter shot)