### PR TITLE
License: Re-add OpenSSL exception

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -337,3 +337,14 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+                            OpenSSL exception
+In addition, as a special exception, the vMaNGOS project
+gives permission to link the code of its release of vMaNGOS with
+the OpenSSL project's "OpenSSL" library (or with modified versions of
+it that use the same license as the "OpenSSL" library), and distribute
+the linked executables.  You must obey the GNU General Public License
+in all respects for all of the code used other than "OpenSSL".  If you
+modify this file, you may extend this exception to your version of the
+file, but you are not obligated to do so.  If you do not wish to do
+so, delete this exception statement from your version.


### PR DESCRIPTION
## 🍰 Pullrequest

This PR restores the OpenSSL exception that was already present in the initial MaNGOS commit.
It appears to have been omitted when the vMaNGOS repository was published.
_(TrinityCore had a similar issue for a while which was later corrected.)_

_MaNGOS Zero_ first commit:
https://github.com/mangoszero/server/blob/386f5374ab11bf650ed6ef29202ce7a482f1e968/README.md?plain=1#L133-L137

_CMaNGOS_ first commit:
https://github.com/cmangos/mangos-classic/blob/ea63fbe103d9242bae4c4e3933bf0e7a1bada8d6/README#L19-L27

_MaNGOS_ first commit:
https://github.com/mangos/MaNGOS/blob/ea63fbe103d9242bae4c4e3933bf0e7a1bada8d6/README#L19-L27
