### PR TITLE
CI: Add macOS CI build.

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -65,6 +65,10 @@ jobs:
               job_name: Ubuntu Clang
           - client_build: 5875
             config:
+              os: macos-26
+              job_name: macOS Clang
+          - client_build: 5875
+            config:
               os: windows-2022
               job_name: Windows Visual Studio
           - client_build: 5875
@@ -92,6 +96,10 @@ jobs:
       - name: Install Clang compiler
         if: matrix.config.install_clang
         run: sudo apt install -y --no-install-recommends clang
+
+      - name: Install macOS build dependencies
+        if: matrix.config.os == 'macos-26'
+        run: brew install mysql-client
 
       - name: Set up MSYS2 (MINGW64)
         if: matrix.config.use_mingw
@@ -122,6 +130,21 @@ jobs:
             -DBUILD_WARNINGS_AS_ERROR=1 \
             -DSUPPORTED_CLIENT_BUILD="${{ matrix.client_build }}"
           make -j"$(nproc)"
+          make install
+
+      - name: Build and install on macOS
+        if: matrix.config.os == 'macos-26'
+        run: |
+          set -euo pipefail
+          mkdir -p build _install
+          cd build
+          cmake ../ \
+            -DCMAKE_INSTALL_PREFIX="../_install" \
+            -DBUILD_EXTRACTORS=1 \
+            -DENABLE_MAILSENDER=1 \
+            -DBUILD_WARNINGS_AS_ERROR=1 \
+            -DSUPPORTED_CLIENT_BUILD="${{ matrix.client_build }}"
+          make -j"$(sysctl -n hw.ncpu)"
           make install
 
       - name: Build and install on Windows (Visual Studio)

--- a/cmake/find/FindMySQL.cmake
+++ b/cmake/find/FindMySQL.cmake
@@ -17,11 +17,20 @@ if( UNIX )
     "preferred path to MySQL (mysql_config)"
   )
 
-  find_program(MYSQL_CONFIG NAMES mysql_config mariadb_config
-    ${MYSQL_CONFIG_PREFER_PATH}
-    /usr/local/mysql/bin/
-    /usr/local/bin/
-    /usr/bin/
+  find_program(MYSQL_CONFIG
+    NAMES
+      mysql_config
+      mariadb_config
+    HINTS
+      ${MYSQL_CONFIG_PREFER_PATH}
+    PATHS
+      /usr/local/mysql/bin/
+      /usr/local/bin/
+      /usr/bin/
+      /opt/homebrew/opt/mysql-client/bin/
+      /opt/homebrew/opt/mysql/bin/
+      /usr/local/opt/mysql-client/bin/
+      /usr/local/opt/mysql/bin/
   )
 
   if( MYSQL_CONFIG )
@@ -72,6 +81,14 @@ find_path(MYSQL_INCLUDE_DIR
     /usr/local/include
     /usr/local/include/mysql
     /usr/local/mysql/include
+    /opt/homebrew/opt/mysql-client/include
+    /opt/homebrew/opt/mysql-client/include/mysql
+    /opt/homebrew/opt/mysql/include
+    /opt/homebrew/opt/mysql/include/mysql
+    /usr/local/opt/mysql-client/include
+    /usr/local/opt/mysql-client/include/mysql
+    /usr/local/opt/mysql/include
+    /usr/local/opt/mysql/include/mysql
     "C:/Program Files/MySQL/include"
     "C:/Program Files/MySQL/MySQL Server 5.0/include"
     "C:/Program Files/MySQL/MySQL Server 5.1/include"
@@ -97,6 +114,14 @@ foreach(LIB ${MYSQL_ADD_LIBRARIES})
       /usr/local/lib
       /usr/local/lib/mysql
       /usr/local/mysql/lib
+      /opt/homebrew/opt/mysql-client/lib
+      /opt/homebrew/opt/mysql-client/lib/mysql
+      /opt/homebrew/opt/mysql/lib
+      /opt/homebrew/opt/mysql/lib/mysql
+      /usr/local/opt/mysql-client/lib
+      /usr/local/opt/mysql-client/lib/mysql
+      /usr/local/opt/mysql/lib
+      /usr/local/opt/mysql/lib/mysql
     DOC "Specify the location of the mysql library here."
   )
 endforeach(LIB ${MYSQL_ADD_LIBRARY})

--- a/cmake/platform/unix/settings.cmake
+++ b/cmake/platform/unix/settings.cmake
@@ -22,7 +22,7 @@ set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -Wno-reorder") # ... will 
 set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -Wno-unused-variable") # unused variable
 set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -Wno-unused-but-set-variable") # set but not used
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -Wno-unused-private-field") # private field is not used
   set(BUILD_ADDITIONAL_FLAGS "${BUILD_ADDITIONAL_FLAGS} -Wno-instantiation-after-specialization") # explicit instantiation of that occurs after an explicit specialization has no effect
 

--- a/contrib/extractor/System.cpp
+++ b/contrib/extractor/System.cpp
@@ -155,13 +155,13 @@ void HandleArgs(int argc, char* arg[])
         {
             case 'i':
                 if (c + 1 < argc)                           // all ok
-                    strcpy(input_path, arg[(c++) + 1]);
+                    snprintf(input_path, sizeof(input_path), "%s", arg[(c++) + 1]);
                 else
                     Usage(arg[0]);
                 break;
             case 'o':
                 if (c + 1 < argc)                           // all ok
-                    strcpy(output_path, arg[(c++) + 1]);
+                    snprintf(output_path, sizeof(output_path), "%s", arg[(c++) + 1]);
                 else
                     Usage(arg[0]);
                 break;
@@ -201,7 +201,7 @@ uint32 ReadMapDBC()
     for (uint32 x = 0; x < map_count; ++x)
     {
         map_ids[x].id = dbc.getRecord(x).getUInt(0);
-        strcpy(map_ids[x].name, dbc.getRecord(x).getString(1));
+        snprintf(map_ids[x].name, sizeof(map_ids[x].name), "%s", dbc.getRecord(x).getString(1));
     }
     printf("Done! (%u maps loaded)\n", uint32(map_count));
     return map_count;
@@ -767,7 +767,7 @@ void ExtractMapsFromMpq()
     {
         printf("Extract %s (%d/%d)                  \n", map_ids[z].name, z + 1, map_count);
         // Loadup map grid data
-        sprintf(mpq_map_name, "World\\Maps\\%s\\%s.wdt", map_ids[z].name, map_ids[z].name);
+        snprintf(mpq_map_name, sizeof(mpq_map_name), "World\\Maps\\%s\\%s.wdt", map_ids[z].name, map_ids[z].name);
         WDT_file wdt;
         if (!wdt.loadFile(mpq_map_name, false))
         {
@@ -781,8 +781,8 @@ void ExtractMapsFromMpq()
             {
                 if (!wdt.main->adt_list[y][x].exist)
                     continue;
-                sprintf(mpq_filename, "World\\Maps\\%s\\%s_%u_%u.adt", map_ids[z].name, map_ids[z].name, x, y);
-                sprintf(output_filename, "%s/maps/%03u%02u%02u.map", output_path, map_ids[z].id, y, x);
+                snprintf(mpq_filename, sizeof(mpq_filename), "World\\Maps\\%s\\%s_%u_%u.adt", map_ids[z].name, map_ids[z].name, x, y);
+                snprintf(output_filename, sizeof(output_filename), "%s/maps/%03u%02u%02u.map", output_path, map_ids[z].id, y, x);
                 ConvertADT(mpq_filename, output_filename, y, x);
             }
             // draw progress bar
@@ -892,7 +892,7 @@ void LoadCommonMPQFiles()
     int count = sizeof(CONF_mpq_list) / sizeof(char*);
     for (int i = 0; i < count; ++i)
     {
-        sprintf(filename, "%s/Data/%s", input_path, CONF_mpq_list[i]);
+        snprintf(filename, sizeof(filename), "%s/Data/%s", input_path, CONF_mpq_list[i]);
         if (FileExists(filename))
             new MPQArchive(filename);
     }

--- a/contrib/git_id/git_id.cpp
+++ b/contrib/git_id/git_id.cpp
@@ -259,7 +259,7 @@ bool find_rev()
         if(!local && !origins[i][0]) continue;
 
         if(local) snprintf(cmd, MAX_CMD, "git log HEAD --pretty=\"format:%%s\"");
-        else sprintf(cmd, "git log %s/%s --pretty=\"format:%%s\"", origins[i], remote_branch);
+        else snprintf(cmd, MAX_CMD, "git log %s/%s --pretty=\"format:%%s\"", origins[i], remote_branch);
         if( (cmd_pipe = popen( cmd, "r" )) == NULL )
             continue;
 
@@ -318,7 +318,7 @@ bool write_rev_nr()
 {
     printf("+ writing revision_nr.h\n");
     char rev_str[256];
-    sprintf(rev_str, "%04d", rev);
+    snprintf(rev_str, sizeof(rev_str), "%04d", rev);
     std::string header = generateNrHeader(rev_str);
 
     char prefixed_file[MAX_PATH];

--- a/contrib/mmap/src/IntermediateValues.cpp
+++ b/contrib/mmap/src/IntermediateValues.cpp
@@ -33,7 +33,7 @@ namespace MMAP
     {
         char fileName[255];
         char tileString[25];
-        sprintf(tileString, "[%02u,%02u]: ", tileX, tileY);
+        snprintf(tileString, sizeof(tileString), "[%02u,%02u]: ", tileX, tileY);
 
         printf("%sWriting debug output...                       \r", tileString);
 
@@ -41,12 +41,12 @@ namespace MMAP
 
 #define DEBUG_WRITE(fileExtension,data) \
         do { \
-            sprintf(fileName, (name + fileExtension).c_str(), mapID, tileY, tileX); \
+            snprintf(fileName, sizeof(fileName), (name + fileExtension).c_str(), mapID, tileY, tileX); \
             FILE* file = fopen(fileName, "wb"); \
             if (!file) \
             { \
                 char message[1024]; \
-                sprintf(message, "%sFailed to open %s for writing!\n",  tileString, fileName); \
+                snprintf(message, sizeof(message), "%sFailed to open %s for writing!\n",  tileString, fileName); \
                 perror(message); \
             } \
             else \
@@ -202,7 +202,7 @@ namespace MMAP
     void IntermediateValues::generateObjFile(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData)
     {
         char objFileName[255];
-        sprintf(objFileName, "map%03u%02u%02u", mapID, tileY, tileX);
+        snprintf(objFileName, sizeof(objFileName), "map%03u%02u%02u", mapID, tileY, tileX);
         generateObjFile(objFileName, meshData);
     }
     void IntermediateValues::generateObjFile(std::string filename, MeshData& meshData)
@@ -212,7 +212,7 @@ namespace MMAP
         if (!objFile)
         {
             char message[1024];
-            sprintf(message, "Failed to open %s for writing!\n", realFileName.c_str());
+            snprintf(message, sizeof(message), "Failed to open %s for writing!\n", realFileName.c_str());
             perror(message);
             return;
         }
@@ -245,7 +245,7 @@ namespace MMAP
         if (!objFile)
         {
             char message[1024];
-            sprintf(message, "Failed to open %s for writing!\n", realFileName.c_str());
+            snprintf(message, sizeof(message), "Failed to open %s for writing!\n", realFileName.c_str());
             perror(message);
             return;
         }
@@ -259,7 +259,7 @@ namespace MMAP
         if (!objFile)
         {
             char message[1024];
-            sprintf(message, "Failed to open %s for writing!\n", realFileName.c_str());
+            snprintf(message, sizeof(message), "Failed to open %s for writing!\n", realFileName.c_str());
             perror(message);
             return;
         }

--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -104,7 +104,7 @@ namespace MMAP
             std::set<uint32>& tiles = (*itr).second;
             mapID = (*itr).first;
 
-            sprintf(filter, "%03u*.vmtile", mapID);
+            snprintf(filter, sizeof(filter), "%03u*.vmtile", mapID);
             files.clear();
             getDirContents(files, "vmaps", filter);
             for (uint32 i = 0; i < files.size(); ++i)
@@ -117,7 +117,7 @@ namespace MMAP
                 count++;
             }
 
-            sprintf(filter, "%03u*", mapID);
+            snprintf(filter, sizeof(filter), "%03u*", mapID);
             files.clear();
             getDirContents(files, "maps", filter);
             for (uint32 i = 0; i < files.size(); ++i)
@@ -386,14 +386,14 @@ namespace MMAP
         }
 
         char fileName[25];
-        sprintf(fileName, "mmaps/%03u.mmap", mapID);
+        snprintf(fileName, sizeof(fileName), "mmaps/%03u.mmap", mapID);
 
         FILE* file = fopen(fileName, "wb");
         if (!file)
         {
             dtFreeNavMesh(navMesh);
             char message[1024];
-            sprintf(message, "[Map %03i] Failed to open %s for writing!             \n", mapID, fileName);
+            snprintf(message, sizeof(message), "[Map %03i] Failed to open %s for writing!             \n", mapID, fileName);
             perror(message);
             return;
         }
@@ -703,12 +703,12 @@ namespace MMAP
             return;
         }
         char fileName[255];
-        sprintf(fileName, "mmaps/go%04u.mmtile", displayId);
+        snprintf(fileName, sizeof(fileName), "mmaps/go%04u.mmtile", displayId);
         FILE* file = fopen(fileName, "wb");
         if (!file)
         {
             char message[1024];
-            sprintf(message, "Failed to open %s for writing!\n", fileName);
+            snprintf(message, sizeof(message), "Failed to open %s for writing!\n", fileName);
             perror(message);
             dtFree(navData);
             return;

--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -95,7 +95,7 @@ namespace MMAP
     bool TerrainBuilder::loadMap(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData, Spot portion)
     {
         char mapFileName[255];
-        sprintf(mapFileName, "maps/%03u%02u%02u.map", mapID, tileY, tileX);
+        snprintf(mapFileName, sizeof(mapFileName), "maps/%03u%02u%02u.map", mapID, tileY, tileX);
 
         FILE* mapFile = fopen(mapFileName, "rb");
         if (!mapFile)

--- a/contrib/mmap/src/TileWorker.cpp
+++ b/contrib/mmap/src/TileWorker.cpp
@@ -252,7 +252,7 @@ namespace MMAP
     bool TileWorker::duDumpPolyMeshToObj(rcPolyMesh& pmesh, uint32 mapID, uint32 tileY, uint32 tileX)
     {
         char fname[256];
-        sprintf(fname, "meshes/map%03u%02u%02unavmesh.obj", mapID, tileY, tileX);
+        snprintf(fname, sizeof(fname), "meshes/map%03u%02u%02unavmesh.obj", mapID, tileY, tileX);
         FILE* objFile = fopen(fname, "wb");
         if (!objFile)
         {
@@ -301,7 +301,7 @@ namespace MMAP
     {
 
         char fname[256];
-        sprintf(fname, "meshes/map%03u%02u%02unavmeshdetail.obj", mapID, tileY, tileX);
+        snprintf(fname, sizeof(fname), "meshes/map%03u%02u%02unavmeshdetail.obj", mapID, tileY, tileX);
         FILE* objFile = fopen(fname, "wb");
 
         if (!objFile)
@@ -346,7 +346,7 @@ namespace MMAP
     bool TileWorker::shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY)
     {
         char fileName[255];
-        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+        snprintf(fileName, sizeof(fileName), "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
         FILE* file = fopen(fileName, "rb");
         if (!file)
         {
@@ -422,7 +422,7 @@ namespace MMAP
     {
         // console output
         char tileString[20];
-        sprintf(tileString, "[Map %03i] [%02i,%02i]: ", mapID, tileX, tileY);
+        snprintf(tileString, sizeof(tileString), "[Map %03i] [%02i,%02i]: ", mapID, tileX, tileY);
         printf("%s Building movemap tiles...                          \r", tileString);
 
         IntermediateValues iv;
@@ -868,12 +868,12 @@ namespace MMAP
 
             // file output
             char fileName[255];
-            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+            snprintf(fileName, sizeof(fileName), "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
             FILE* file = fopen(fileName, "wb");
             if (!file)
             {
                 char message[1024];
-                sprintf(message, "[Map %03i] Failed to open %s for writing!             \n", mapID, fileName);
+                snprintf(message, sizeof(message), "[Map %03i] Failed to open %s for writing!             \n", mapID, fileName);
                 perror(message);
                 navMesh->removeTile(tileRef, nullptr, nullptr);
                 continue;
@@ -904,7 +904,7 @@ namespace MMAP
                 //iv.writeIV(mapID, tileX, tileY);
                 // Write navmesh data
                 char fname[256];
-                sprintf(fname, "meshes/map%03u%02u%02u.nav", mapID, tileY, tileX);
+                snprintf(fname, sizeof(fname), "meshes/map%03u%02u%02u.nav", mapID, tileY, tileX);
                 FILE* file = fopen(fname, "wb");
                 if (file)
                 {

--- a/contrib/vmap_extractor/vmapextract/model.cpp
+++ b/contrib/vmap_extractor/vmapextract/model.cpp
@@ -166,7 +166,7 @@ ModelInstance::ModelInstance(MPQFile& f, const char* ModelInstName, uint32 mapID
     sc = scale / 1024.0f;
 
     char tempname[512];
-    sprintf(tempname, "%s/%s", szWorkDirWmo, ModelInstName);
+    snprintf(tempname, sizeof(tempname), "%s/%s", szWorkDirWmo, ModelInstName);
 
     FILE* input = fopen(tempname, "r+b");
     if (!input)
@@ -239,7 +239,7 @@ void Doodad::ExtractSet(WMODoodadData const& doodadData, ADT::MODF const& wmo, u
         WMO::MODD const& doodad = doodadData.Spawns[doodadIndex];
 
         char ModelInstName[1024];
-        sprintf(ModelInstName, "%s", GetPlainName(&doodadData.Paths[doodad.NameIndex]));
+        snprintf(ModelInstName, sizeof(ModelInstName), "%s", GetPlainName(&doodadData.Paths[doodad.NameIndex]));
         uint32 nlen = strlen(ModelInstName);
         FixNameCase(ModelInstName, nlen);
         FixNameSpaces(ModelInstName, nlen);

--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -143,7 +143,7 @@ bool ExtractSingleWmo(std::string& fname)
     char* plain_name = GetPlainName(&fname[0]);
     FixNameCase(plain_name, strlen(plain_name));
     FixNameSpaces(plain_name, strlen(plain_name));
-    sprintf(szLocalFile, "%s/%s", szWorkDirWmo, plain_name);
+    snprintf(szLocalFile, sizeof(szLocalFile), "%s/%s", szWorkDirWmo, plain_name);
 
     if (FileExists(szLocalFile))
         return true;
@@ -191,10 +191,10 @@ bool ExtractSingleWmo(std::string& fname)
         for (uint32 i = 0; i < froot.nGroups; ++i)
         {
             char temp[1024];
-            strcpy(temp, fname.c_str());
+            snprintf(temp, sizeof(temp), "%s", fname.c_str());
             temp[fname.length() - 4] = 0;
             char groupFileName[1024];
-            sprintf(groupFileName, "%s_%03d.wmo", temp, i);
+            snprintf(groupFileName, sizeof(groupFileName), "%s_%03d.wmo", temp, i);
             //printf("Trying to open groupfile %s\n",groupFileName);
 
             string s = groupFileName;
@@ -247,8 +247,8 @@ bool ParsMapFiles()
     StringSet failedPaths;
     for (unsigned int i = 0; i < map_count; ++i)
     {
-        sprintf(id, "%03u", map_ids[i].id);
-        sprintf(fn, "World\\Maps\\%s\\%s.wdt", map_ids[i].name, map_ids[i].name);
+        snprintf(id, sizeof(id), "%03u", map_ids[i].id);
+        snprintf(fn, sizeof(fn), "World\\Maps\\%s\\%s.wdt", map_ids[i].name, map_ids[i].name);
         WDTFile WDT(fn, map_ids[i].name);
         if (WDT.init(id, map_ids[i].id))
         {
@@ -283,9 +283,9 @@ bool ParsMapFiles()
 void getGamePath()
 {
 #ifdef _WIN32
-    strcpy(input_path, "Data\\");
+    snprintf(input_path, sizeof(input_path), "Data\\");
 #else
-    strcpy(input_path, "Data/");
+    snprintf(input_path, sizeof(input_path), "Data/");
 #endif
 }
 
@@ -298,11 +298,11 @@ bool scan_patches(char* scanmatch, std::vector<std::string>& pArchiveNames)
     {
         if (i != 1)
         {
-            sprintf(path, "%s-%d.MPQ", scanmatch, i);
+            snprintf(path, sizeof(path), "%s-%d.MPQ", scanmatch, i);
         }
         else
         {
-            sprintf(path, "%s.MPQ", scanmatch);
+            snprintf(path, sizeof(path), "%s.MPQ", scanmatch);
         }
         if (FILE* h = fopen(path, "rb"))
         {
@@ -326,21 +326,21 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
 
     // open expansion and common files
     printf("Opening data files from data directory.\n");
-    sprintf(path, "%sterrain.MPQ", input_path);
+    snprintf(path, sizeof(path), "%sterrain.MPQ", input_path);
     pArchiveNames.push_back(path);
-    sprintf(path, "%smodel.MPQ", input_path);
+    snprintf(path, sizeof(path), "%smodel.MPQ", input_path);
     pArchiveNames.push_back(path);
-    sprintf(path, "%stexture.MPQ", input_path);
+    snprintf(path, sizeof(path), "%stexture.MPQ", input_path);
     pArchiveNames.push_back(path);
-    sprintf(path, "%swmo.MPQ", input_path);
+    snprintf(path, sizeof(path), "%swmo.MPQ", input_path);
     pArchiveNames.push_back(path);
-    sprintf(path, "%sbase.MPQ", input_path);
+    snprintf(path, sizeof(path), "%sbase.MPQ", input_path);
     pArchiveNames.push_back(path);
-    sprintf(path, "%smisc.MPQ", input_path);
+    snprintf(path, sizeof(path), "%smisc.MPQ", input_path);
 
     // now, scan for the patch levels in the core dir
     printf("Scanning patch levels from data directory.\n");
-    sprintf(path, "%spatch", input_path);
+    snprintf(path, sizeof(path), "%spatch", input_path);
     if (!scan_patches(path, pArchiveNames))
         return (false);
 
@@ -366,9 +366,12 @@ bool processArgv(int argc, char** argv)
             if ((i + 1) < argc)
             {
                 hasInputPathParam = true;
-                strcpy(input_path, argv[i + 1]);
+                snprintf(input_path, sizeof(input_path), "%s", argv[i + 1]);
                 if (input_path[strlen(input_path) - 1] != '\\' && input_path[strlen(input_path) - 1] != '/')
-                    strcat(input_path, "/");
+                {
+                    size_t inputPathLen = strlen(input_path);
+                    snprintf(input_path + inputPathLen, sizeof(input_path) - inputPathLen, "/");
+                }
                 ++i;
             }
             else
@@ -482,7 +485,7 @@ int main(int argc, char** argv)
         for (unsigned int x = 0; x < map_count; ++x)
         {
             map_ids[x].id = dbc->getRecord(x).getUInt(0);
-            strcpy(map_ids[x].name, dbc->getRecord(x).getString(1));
+            snprintf(map_ids[x].name, sizeof(map_ids[x].name), "%s", dbc->getRecord(x).getString(1));
             printf("Map - %s\n", map_ids[x].name);
         }
 

--- a/contrib/vmap_extractor/vmapextract/wdtfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/wdtfile.cpp
@@ -129,6 +129,6 @@ ADTFile* WDTFile::GetMap(int x, int z)
 
     char name[512];
 
-    sprintf(name, "World\\Maps\\%s\\%s_%d_%d.adt", filename.c_str(), filename.c_str(), x, z);
+    snprintf(name, sizeof(name), "World\\Maps\\%s\\%s_%d_%d.adt", filename.c_str(), filename.c_str(), x, z);
     return new ADTFile(name);
 }

--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -565,7 +565,7 @@ WMOInstance::WMOInstance(MPQFile& f, const char* WmoInstName, uint32 mapID, uint
     //-----------add_in _dir_file----------------
 
     char tempname[512];
-    sprintf(tempname, "%s/%s", szWorkDirWmo, WmoInstName);
+    snprintf(tempname, sizeof(tempname), "%s/%s", szWorkDirWmo, WmoInstName);
     FILE* input;
     input = fopen(tempname, "r+b");
 

--- a/dep/include/nlohmann/json.hpp
+++ b/dep/include/nlohmann/json.hpp
@@ -22695,7 +22695,7 @@ if no parse error occurred.
 @since version 1.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+inline nlohmann::json operator""_json(const char* s, std::size_t n)
 {
     return nlohmann::json::parse(s, s + n);
 }
@@ -22714,7 +22714,7 @@ object if no parse error occurred.
 @since version 2.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+inline nlohmann::json::json_pointer operator""_json_pointer(const char* s, std::size_t n)
 {
     return nlohmann::json::json_pointer(std::string(s, n));
 }

--- a/src/game/Battlegrounds/BattleGroundAV.cpp
+++ b/src/game/Battlegrounds/BattleGroundAV.cpp
@@ -454,7 +454,7 @@ void BattleGroundAV::UpgradeArmor(Object* questGiver, Player* player)
 
     if (resources%500 == 0 && m_teamQuestStatus[teamIdx][0] != 0 && questGiver->GetTypeId() == TYPEID_UNIT)
     {
-        sprintf(sMessageRemaining,"Thanks for the supplies, %s",player->GetName());
+        snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Thanks for the supplies, %s",player->GetName());
         ((Creature*)questGiver)->MonsterSay(sMessageRemaining, 0, 0);
 
         if (resources == 500)
@@ -464,7 +464,7 @@ void BattleGroundAV::UpgradeArmor(Object* questGiver, Player* player)
             else
                 CastSpellOnTeam(28418, HORDE);
 
-            sprintf(sMessageRemaining,"Seasoned units are entering the battle!");
+            snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Seasoned units are entering the battle!");
             ((Creature*)questGiver)->MonsterYell(sMessageRemaining, 0, 0);
         }
         else if (resources == 1000)
@@ -474,7 +474,7 @@ void BattleGroundAV::UpgradeArmor(Object* questGiver, Player* player)
             else
                 CastSpellOnTeam(28419, HORDE);
 
-            sprintf(sMessageRemaining,"Veteran units are entering the battle!");
+            snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Veteran units are entering the battle!");
             ((Creature*)questGiver)->MonsterYell(sMessageRemaining, 0, 0);
         }
         else if (resources == 1500)
@@ -484,7 +484,7 @@ void BattleGroundAV::UpgradeArmor(Object* questGiver, Player* player)
             else
                 CastSpellOnTeam(28420, HORDE);
 
-            sprintf(sMessageRemaining,"Champion units are entering the battle!");
+            snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Champion units are entering the battle!");
             ((Creature*)questGiver)->MonsterYell(sMessageRemaining, 0, 0);
         }
     }
@@ -525,7 +525,7 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
 
 /*            if (m_teamQuestStatus[teamIdx][0]%500 == 0 && m_teamQuestStatus[teamIdx][0] != 0 && questGiver->GetTypeId() == TYPEID_UNIT)
             {
-                sprintf(sMessageRemaining,"Thanks for the supplies, %s",player->GetName());
+                snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Thanks for the supplies, %s",player->GetName());
                 ((Creature*)questGiver)->MonsterSay(sMessageRemaining, 0, 0);
 
                 if (m_teamQuestStatus[teamIdx][0] == 500)
@@ -535,7 +535,7 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
                     else
                         CastSpellOnTeam(28418, HORDE);
 
-                   sprintf(sMessageRemaining,"Seasoned units are entering the battle!");
+                   snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Seasoned units are entering the battle!");
                    ((Creature*)questGiver)->MonsterYell(sMessageRemaining, 0, 0);
                 }
                 else if (m_teamQuestStatus[teamIdx][0] == 1000)
@@ -545,7 +545,7 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
                     else
                         CastSpellOnTeam(28419, HORDE);
 
-                    sprintf(sMessageRemaining,"Veteran units are entering the battle!");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Veteran units are entering the battle!");
                     ((Creature*)questGiver)->MonsterYell(sMessageRemaining, 0, 0);
                 }
                 else if (m_teamQuestStatus[teamIdx][0] == 1500)
@@ -555,7 +555,7 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
                     else
                         CastSpellOnTeam(28420, HORDE);
 
-                    sprintf(sMessageRemaining,"Champion units are entering the battle!");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Champion units are entering the battle!");
                     ((Creature*)questGiver)->MonsterYell(sMessageRemaining, 0, 0);
                 }
 
@@ -610,9 +610,9 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
             if (m_teamQuestStatus[teamIdx][1] == 90)
             {
                 if (teamIdx == 0)
-                    sprintf(sMessageRemaining,"Soldiers of Stormpike, come to my aid! The beacon must be planted.");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of Stormpike, come to my aid! The beacon must be planted.");
                 else
-                    sprintf(sMessageRemaining,"Soldiers of the Horde, come to my aid! The beacon must be planted.");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of the Horde, come to my aid! The beacon must be planted.");
 
                 questGiver->MonsterYell(sMessageRemaining, 0, 0);
             }
@@ -624,9 +624,9 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
             if (m_teamQuestStatus[teamIdx][2] == 60)
             {
                 if (teamIdx == 0)
-                    sprintf(sMessageRemaining,"Soldiers of Stormpike, come to my aid! The beacon must be planted.");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of Stormpike, come to my aid! The beacon must be planted.");
                 else
-                    sprintf(sMessageRemaining,"Soldiers of the Horde, come to my aid! The beacon must be planted.");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of the Horde, come to my aid! The beacon must be planted.");
 
                 questGiver->MonsterYell(sMessageRemaining, 0, 0);
             }
@@ -638,9 +638,9 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
             if (m_teamQuestStatus[teamIdx][3] == 30)
             {
                 if (teamIdx == 0)
-                    sprintf(sMessageRemaining,"Soldiers of Stormpike, come to my aid! The beacon must be planted.");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of Stormpike, come to my aid! The beacon must be planted.");
                 else
-                    sprintf(sMessageRemaining,"Soldiers of the Horde, come to my aid! The beacon must be planted.");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of the Horde, come to my aid! The beacon must be planted.");
 
                 questGiver->MonsterYell(sMessageRemaining, 0, 0);
             }
@@ -657,9 +657,9 @@ void BattleGroundAV::HandleQuestComplete(Unit* questGiver, uint32 questid, Playe
             if (m_teamQuestStatus[teamIdx][4] == 200)
             {
                 if (teamIdx == 0)
-                    sprintf(sMessageRemaining,"Soldiers of Stormpike, aid and protect us! The Forest Lord has granted us his protection. The portal must now be opened!");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of Stormpike, aid and protect us! The Forest Lord has granted us his protection. The portal must now be opened!");
                 else
-                    sprintf(sMessageRemaining,"Soldiers of Frostwolf, come to my aid! The Ice Lord has granted us his protection. He's accepted the offering! The time has come to unleash him upon the Stormpike Army!");
+                    snprintf(sMessageRemaining, sizeof(sMessageRemaining),"Soldiers of Frostwolf, come to my aid! The Ice Lord has granted us his protection. He's accepted the offering! The time has come to unleash him upon the Stormpike Army!");
 
                 questGiver->MonsterYell(sMessageRemaining, 0, 0);
             }

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -4038,14 +4038,14 @@ std::string ChatHandler::PrepareStringNpcOrGoSpawnInformation(uint32 guid)
         {
             char buffer[100];
             char const* format = GetMangosString(LANG_NPC_GO_INFO_POOL_EVENT_STRING);
-            sprintf(buffer, format, pool_id, event_id);
+            snprintf(buffer, sizeof(buffer), format, pool_id, event_id);
             str = buffer;
         }
         else
         {
             char buffer[100];
             char const* format = GetMangosString(LANG_NPC_GO_INFO_POOL_STRING);
-            sprintf(buffer, format, pool_id);
+            snprintf(buffer, sizeof(buffer), format, pool_id);
             str = buffer;
         }
     }
@@ -4053,7 +4053,7 @@ std::string ChatHandler::PrepareStringNpcOrGoSpawnInformation(uint32 guid)
     {
         char buffer[100];
         char const* format = GetMangosString(LANG_NPC_GO_INFO_EVENT_STRING);
-        sprintf(buffer, format, event_id);
+        snprintf(buffer, sizeof(buffer), format, event_id);
         str = buffer;
     }
 

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -834,7 +834,7 @@ void PartyBotAI::UpdateAI(uint32 const diff)
             me->GetMotionMaster()->Clear(false, true);
             me->GetMotionMaster()->MoveIdle();
             char name[128] = {};
-            strcpy(name, pLeader->GetName());
+            snprintf(name, sizeof(name), "%s", pLeader->GetName());
             ChatHandler(me).HandleGonameCommand(name);
             return;
         }

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1775,7 +1775,7 @@ void World::SetInitialWorldSettings()
     time(&curr);
     local = *(localtime(&curr));                            // dereference and assign
     char isoDate[128];
-    sprintf(isoDate, "%04d-%02d-%02d %02d:%02d:%02d",
+    snprintf(isoDate, sizeof(isoDate), "%04d-%02d-%02d %02d:%02d:%02d",
             local.tm_year + 1900, local.tm_mon + 1, local.tm_mday, local.tm_hour, local.tm_min, local.tm_sec);
 
     LoginDatabase.PExecute("INSERT INTO `uptime` (`realmid`, `starttime`, `startstring`, `revision`) VALUES('%u', " UI64FMTD ", '%s', '%s')",

--- a/src/scripts/eastern_kingdoms/duskwood/duskwood.cpp
+++ b/src/scripts/eastern_kingdoms/duskwood/duskwood.cpp
@@ -50,7 +50,7 @@ void Handle_NightmareCorruption(/*const*/ Player* player)
     }
 
     char message[200];
-    sprintf(message, "Come, %s. See what the Nightmare brings...", player->GetName());
+    snprintf(message, sizeof(message), "Come, %s. See what the Nightmare brings...", player->GetName());
 
     corrupter->MonsterWhisper(message, player);
 }
@@ -174,7 +174,7 @@ struct npc_twilight_corrupterAI : ScriptedAI
                     if (player->IsDead())
                     {
                         char eMessage[200];
-                        sprintf(eMessage, "Twilight Corrupter squeezes the last bit of life out of %s and swallows their soul.", player->GetName());
+                        snprintf(eMessage, sizeof(eMessage), "Twilight Corrupter squeezes the last bit of life out of %s and swallows their soul.", player->GetName());
                         m_creature->MonsterTextEmote(eMessage, nullptr, false);
                         m_creature->CastSpell(m_creature, SPELL_SWELL_OF_SOULS, true);
                         guid = 0;

--- a/src/scripts/kalimdor/feralas/dire_maul/instance_dire_maul.cpp
+++ b/src/scripts/kalimdor/feralas/dire_maul/instance_dire_maul.cpp
@@ -1100,7 +1100,7 @@ struct GordokBruteAI : public ScriptedAI
                 break;
             case 2:
                 char eMessage[100];
-                sprintf(eMessage, "Raaar!!! Me smash %s!",pWho->GetName());
+                snprintf(eMessage, sizeof(eMessage), "Raaar!!! Me smash %s!",pWho->GetName());
                 m_creature->MonsterSay(eMessage);
                 break;
             default:
@@ -1136,7 +1136,7 @@ struct GordokBruteAI : public ScriptedAI
         if (m_creature->GetHealthPercent() < 30.0f && !m_bEnrage)
         {
             char eMessage[100];
-            sprintf(eMessage, "Gordok Brute puts his club away and begins swinging wildly!");
+            snprintf(eMessage, sizeof(eMessage), "Gordok Brute puts his club away and begins swinging wildly!");
             m_creature->LoadEquipment(0, true);
             m_creature->MonsterTextEmote(eMessage, nullptr, false);
 

--- a/src/shared/Common.h
+++ b/src/shared/Common.h
@@ -210,8 +210,9 @@ extern LocaleNameStr const fullLocaleNameList[];
 //operator new[] based version of strdup() function! Release memory by using operator delete[] !
 inline char* mangos_strdup(char const* source)
 {
-    char* dest = new char[strlen(source) + 1];
-    strcpy(dest, source);
+    size_t size = strlen(source) + 1;
+    char* dest = new char[size];
+    memcpy(dest, source, size);
     return dest;
 }
 

--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -336,7 +336,7 @@ bool Database::PExecuteLog(char const* format,...)
         time(&curr);                                        // get current time_t value
         local=*(localtime(&curr));                          // dereference and assign
         char fName[128];
-        sprintf(fName, "%04d-%02d-%02d_logSQL.sql", local.tm_year+1900, local.tm_mon+1, local.tm_mday);
+        snprintf(fName, sizeof(fName), "%04d-%02d-%02d_logSQL.sql", local.tm_year+1900, local.tm_mon+1, local.tm_mday);
 
         FILE* log_file;
         std::string logsDir_fname = m_logsDir+fName;

--- a/src/shared/ServiceWin32.cpp
+++ b/src/shared/ServiceWin32.cpp
@@ -60,7 +60,8 @@ bool WinServiceInstall()
         return false;
     }
 
-    std::strcat(path, " -s run");
+    size_t pathLen = strlen(path);
+    snprintf(path + pathLen, sizeof(path) - pathLen, " -s run");
 
     SC_HANDLE service = CreateService(serviceControlManager,
         serviceName,                                // name of service

--- a/src/shared/Util.cpp
+++ b/src/shared/Util.cpp
@@ -504,7 +504,7 @@ std::string ByteArrayToHexStr(uint8 const* bytes, uint32 arrayLen, bool reverse 
     std::ostringstream ss;
     for (int32 i = init; i != end; i += op) {
         char buffer[4];
-        sprintf(buffer, "%02X", bytes[i]);
+        snprintf(buffer, sizeof(buffer), "%02X", bytes[i]);
         ss << buffer;
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
This adds a macOS CI build ([as requested](https://github.com/vmangos/core/pull/3394#issuecomment-4448009942) by @ratkosrb), running on `macos-26` (Apple Silicon only; Intel Macs will be abandoned with macOS 27 this year anyway) for client version `1.12.1.5875`, matching the existing Ubuntu Clang and Windows builds.

Split into two commits:
- __[`Fix macOS build.`](https://github.com/vmangos/core/commit/0433255243e7ab1c4675ce31b3e3f256b57b01c2)__: code and CMake changes needed to compile on macOS with `-Werror`:
  - [`cmake/find/FindMySQL.cmake`](https://github.com/vmangos/core/blob/0433255243e7ab1c4675ce31b3e3f256b57b01c2/cmake/find/FindMySQL.cmake): use the `PATHS` keyword properly in `find_program` (the old syntax was silently treating paths as additional names; it only worked on Linux because `/usr/bin` is in the default search) and add Homebrew search paths (for both Apple Silicon and Intel, so Intel Mac users should still be able to compile on older macOS systems), mirroring what [`FindOpenSSL.cmake`](https://github.com/vmangos/core/blob/0433255243e7ab1c4675ce31b3e3f256b57b01c2/cmake/find/FindOpenSSL.cmake) already does.
  - [`cmake/platform/unix/settings.cmake`](https://github.com/vmangos/core/blob/0433255243e7ab1c4675ce31b3e3f256b57b01c2/cmake/platform/unix/settings.cmake): `STREQUAL "Clang"` was changed to `MATCHES "Clang"` so Apple's `AppleClang` compiler ID doesn't end up using the GCC branch and pick up GCC-only flags like `-Wno-nonnull-compare`.
  - [`dep/include/nlohmann/json.hpp`](https://github.com/vmangos/core/blob/0433255243e7ab1c4675ce31b3e3f256b57b01c2/dep/include/nlohmann/json.hpp): Made two whitespace-only changes because the PR runner image funnily got updated from Xcode 26.2 / AppleClang 17 to Xcode 26.4.1 / AppleClang 21 within the ~30 minutes between my fork run and the PR run, and AppleClang 21 enables `-Wdeprecated-literal-operator` by default.
  - All `sprintf` / `strcpy` / `strcat` call sites across `src/` and `contrib/` have been rewritten to `snprintf` / `memcpy`. Apple's SDK marks these with `__deprecated_msg`, so `-Werror,-Wdeprecated-declarations` fails the build otherwise. The replacements should be safe, but worth reviewing closely (I threw Claude Opus 4.7 Max at these replacements).
- __[`CI: Add macOS CI build.`](https://github.com/vmangos/core/commit/a6d01e71513425ef82a7a381f21d12bc5ae4a6dc)__: adds the actual CI build.

The alternative to the `sprintf`/`strcpy`/`strcat` rewrites would be suppressing the deprecation on Apple Clang only by adding `-Wno-deprecated-declarations` in `cmake/platform/unix/settings.cmake` gated on `CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"` and drop the relevant changes from the first commit. Happy to do that instead if preferred.
__Edit:__ and the same thing for `-Wdeprecated-literal-operator` since the PR runner image got updated.

Tested end-to-end in my fork: https://github.com/mserajnik/vmangos-core/actions/runs/25850039327

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
