### PR TITLE
CI: Add macOS development release.

### DIFF
--- a/.github/scripts/package-macos-release.sh
+++ b/.github/scripts/package-macos-release.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026-present  VMaNGOS  https://github.com/vmangos
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <install-dir> <archive-filename>" >&2
+  exit 1
+fi
+
+install_dir="$1"
+archive_filename="$2"
+package_name="vmangos-macos-arm64"
+stage_parent="$PWD/bin/macos-release"
+package_dir="$stage_parent/$package_name"
+lib_dir="$package_dir/lib"
+archive_path="$PWD/bin/$archive_filename"
+macho_files=()
+
+if [ ! -d "$install_dir" ]; then
+  echo "Could not find install directory at $install_dir." >&2
+  exit 1
+fi
+
+case "$archive_filename" in
+*/*)
+  echo "Archive filename must not contain a path." >&2
+  exit 1
+  ;;
+*.tar.gz)
+  ;;
+*)
+  echo "Archive filename must end in .tar.gz." >&2
+  exit 1
+  ;;
+esac
+
+is_macho() {
+  local file="$1"
+  local magic
+
+  if [ ! -f "$file" ]; then
+    return 1
+  fi
+
+  magic="$(head -c 4 "$file" 2>/dev/null || true)"
+
+  case "$magic" in
+  $'\xcf\xfa\xed\xfe' | $'\xfe\xed\xfa\xcf' | $'\xca\xfe\xba\xbe' | $'\xbe\xba\xfe\xca')
+    return 0
+    ;;
+  esac
+
+  return 1
+}
+
+is_system_library() {
+  local path="$1"
+
+  case "$path" in
+  /usr/lib/* | /System/*)
+    return 0
+    ;;
+  esac
+
+  return 1
+}
+
+collect_macho_files() {
+  local file
+
+  macho_files=()
+
+  while IFS= read -r -d '' file; do
+    if is_macho "$file"; then
+      macho_files+=("$file")
+    fi
+  done < <(find "$package_dir" -type f -print0)
+}
+
+extract_rpaths() {
+  local file="$1"
+
+  otool -l "$file" 2>/dev/null | awk '
+    /^[[:space:]]+cmd LC_RPATH/ { in_rpath = 1; next }
+    in_rpath && /^[[:space:]]+path / {
+      sub(/^[[:space:]]+path[[:space:]]+/, "")
+      sub(/[[:space:]]*\(offset.*\)$/, "")
+      print
+      in_rpath = 0
+    }
+  '
+}
+
+resolve_load_path() {
+  local load_path="$1"
+  local mach_file="$2"
+  local rpath
+  local candidate
+  local lib_name
+  local base
+
+  case "$load_path" in
+  /*)
+    if [ -f "$load_path" ]; then
+      printf '%s\n' "$load_path"
+    fi
+    return
+    ;;
+  @rpath/*)
+    lib_name="${load_path#@rpath/}"
+    while IFS= read -r rpath; do
+      case "$rpath" in
+      @loader_path/*)
+        # `@loader_path` resolves to the directory of the Mach-O file being
+        # processed, which is well-defined at build time.
+        # `@executable_path` is intentionally not handled here: at build time
+        # the eventual executable path is unknown, and Homebrew / CMake install
+        # trees emit absolute or `@loader_path`-relative references rather than
+        # `@executable_path`-relative ones.
+        base="$(dirname "$mach_file")"
+        rpath="${rpath#@loader_path/}"
+        candidate="$base/$rpath/$lib_name"
+        ;;
+      @executable_path/*)
+        continue
+        ;;
+      *)
+        candidate="$rpath/$lib_name"
+        ;;
+      esac
+      if [ -f "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done < <(extract_rpaths "$mach_file")
+    ;;
+  esac
+}
+
+list_load_paths() {
+  local file="$1"
+  local own_install_name
+  local own_basename
+  local line
+  local load_path
+
+  own_install_name="$(otool -D "$file" 2>/dev/null | tail -n +2)"
+  own_basename="$(basename "$file")"
+
+  otool -L "$file" 2>/dev/null | tail -n +2 | while IFS= read -r line; do
+    load_path="${line#"${line%%[![:space:]]*}"}"
+    load_path="${load_path% (compatibility *}"
+
+    if [ -n "$load_path" ] &&
+      [ "$load_path" != "$own_install_name" ] &&
+      [ "$(basename "$load_path")" != "$own_basename" ]; then
+      printf '%s\n' "$load_path"
+    fi
+  done
+}
+
+extract_dependency_paths() {
+  local file="$1"
+  local load_path
+  local resolved
+
+  while IFS= read -r load_path; do
+    resolved="$(resolve_load_path "$load_path" "$file")"
+    if [ -z "$resolved" ]; then
+      continue
+    fi
+
+    if is_system_library "$resolved"; then
+      continue
+    fi
+
+    printf '%s\n' "$resolved"
+  done < <(list_load_paths "$file")
+}
+
+copy_runtime_dependencies() {
+  local index
+  local mach_file
+  local dependency_path
+  local dependency_name
+  local bundled_dependency_path
+
+  collect_macho_files
+
+  index=0
+  while [ "$index" -lt "${#macho_files[@]}" ]; do
+    mach_file="${macho_files[$index]}"
+    index=$((index + 1))
+
+    while IFS= read -r dependency_path; do
+      dependency_name="$(basename "$dependency_path")"
+      bundled_dependency_path="$lib_dir/$dependency_name"
+
+      if [ -e "$bundled_dependency_path" ]; then
+        continue
+      fi
+
+      cp -L "$dependency_path" "$bundled_dependency_path"
+      chmod u+w "$bundled_dependency_path"
+
+      if is_macho "$bundled_dependency_path"; then
+        macho_files+=("$bundled_dependency_path")
+      fi
+    done < <(extract_dependency_paths "$mach_file")
+  done
+}
+
+patch_install_names() {
+  local mach_file
+  local mach_dir
+  local relative_dir
+  local rpath
+  local path_parts
+  local path_part
+  local load_path
+  local dep_basename
+  local existing_rpaths
+
+  collect_macho_files
+
+  for mach_file in "${macho_files[@]}"; do
+    mach_dir="$(dirname "$mach_file")"
+    relative_dir="${mach_dir#"$package_dir"}"
+    relative_dir="${relative_dir#/}"
+
+    rpath="@loader_path"
+
+    if [ "$relative_dir" != "lib" ]; then
+      IFS='/' read -r -a path_parts <<<"$relative_dir"
+
+      for path_part in "${path_parts[@]}"; do
+        if [ -n "$path_part" ]; then
+          rpath="$rpath/.."
+        fi
+      done
+
+      rpath="$rpath/lib"
+    fi
+
+    if [ "$relative_dir" = "lib" ]; then
+      install_name_tool -id "@rpath/$(basename "$mach_file")" "$mach_file"
+    fi
+
+    # Normalize every reference to a bundled dependency onto
+    # `@rpath/<basename>` so the single added rpath (`@loader_path/.../lib`)
+    # covers them all. This also catches `@loader_path/*` and absolute
+    # references whose basename matches a bundled library, rewriting them onto
+    # the same scheme.
+    while IFS= read -r load_path; do
+      dep_basename="$(basename "${load_path#@rpath/}")"
+      if [ -e "$lib_dir/$dep_basename" ] &&
+        [ "$load_path" != "@rpath/$dep_basename" ]; then
+        install_name_tool -change "$load_path" "@rpath/$dep_basename" "$mach_file"
+      fi
+    done < <(list_load_paths "$mach_file")
+
+    existing_rpaths="$(extract_rpaths "$mach_file")"
+    if ! grep -F -q -x -- "$rpath" <<<"$existing_rpaths"; then
+      install_name_tool -add_rpath "$rpath" "$mach_file"
+    fi
+  done
+}
+
+sign_macho_files() {
+  local mach_file
+
+  collect_macho_files
+
+  for mach_file in "${macho_files[@]}"; do
+    codesign --force --sign - "$mach_file"
+  done
+}
+
+verify_dependencies() {
+  local mach_file
+  local load_path
+  local missing_dependencies
+  local lib_name
+
+  collect_macho_files
+
+  missing_dependencies=0
+
+  for mach_file in "${macho_files[@]}"; do
+    while IFS= read -r load_path; do
+      case "$load_path" in
+      /usr/lib/* | /System/*)
+        ;;
+      @rpath/*)
+        lib_name="${load_path#@rpath/}"
+        if [ ! -e "$lib_dir/$lib_name" ]; then
+          echo "Missing bundled dependency in $mach_file: $load_path" >&2
+          missing_dependencies=1
+        fi
+        ;;
+      @loader_path/* | @executable_path/*)
+        # `patch_install_names` normalizes bundled deps onto `@rpath/*`, so any
+        # `@loader_path/*` or `@executable_path/*` reference left here is
+        # something we didn't recognize as bundled. Flag it so future
+        # regressions surface at build time rather than at runtime.
+        echo "Unrewritten loader-relative dependency in $mach_file: $load_path" >&2
+        missing_dependencies=1
+        ;;
+      /*)
+        echo "Unbundled absolute dependency in $mach_file: $load_path" >&2
+        missing_dependencies=1
+        ;;
+      esac
+    done < <(list_load_paths "$mach_file")
+  done
+
+  if [ "$missing_dependencies" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+rm -rf "$stage_parent"
+mkdir -p "$package_dir" "$lib_dir" "$(dirname "$archive_path")"
+
+cp -a "$install_dir/." "$package_dir/"
+
+copy_runtime_dependencies
+patch_install_names
+sign_macho_files
+verify_dependencies
+
+rm -f "$archive_path"
+tar -czf "$archive_path" -C "$stage_parent" "$package_name"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -98,8 +98,12 @@ jobs:
         run: sudo apt install -y --no-install-recommends clang
 
       - name: Install macOS build dependencies
+        # Pinned to match the macOS release build's dependencies so this job
+        # actually validates the configuration we ship; see the
+        # `Install macOS build dependencies` step in
+        # `.github/workflows/development-release.yaml` for the reasoning.
         if: matrix.config.os == 'macos-26'
-        run: brew install mysql-client
+        run: brew install openssl@3 mysql-client@8.4
 
       - name: Set up MSYS2 (MINGW64)
         if: matrix.config.use_mingw
@@ -140,6 +144,7 @@ jobs:
           cd build
           cmake ../ \
             -DCMAKE_INSTALL_PREFIX="../_install" \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@3);$(brew --prefix mysql-client@8.4)" \
             -DBUILD_EXTRACTORS=1 \
             -DENABLE_MAILSENDER=1 \
             -DBUILD_WARNINGS_AS_ERROR=1 \

--- a/.github/workflows/development-release.yaml
+++ b/.github/workflows/development-release.yaml
@@ -105,6 +105,101 @@ jobs:
           name: linux-development-build
           path: "${{ github.workspace }}/bin/${{ env.ARCHIVE_FILENAME }}"
 
+  build-macos:
+    name: Build macOS development release
+    runs-on: macos-26
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install macOS build dependencies
+        # `openssl@3` is preinstalled on `macos-26` today, but pin it
+        # explicitly so the build doesn't silently break if a future runner
+        # image stops shipping it.
+        #
+        # `mysql-client@8.4` is pinned (MySQL LTS through 2032) because the
+        # current `mysql-client` formula tracks MySQL 9, which removed the
+        # `mysql_native_password` authentication plugin that MariaDB still
+        # uses by default. MySQL 8.4 keeps the plugin built into the client
+        # library, so MariaDB users can connect out of the box. Matches the
+        # MySQL 8.0 ABI used by the Linux build's `libmysqlclient`.
+        run: brew install openssl@3 mysql-client@8.4
+
+      - name: Build release binaries
+        run: |
+          set -euo pipefail
+          mkdir -p build _install
+          cd build
+          cmake ../ \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=26.0 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install" \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@3);$(brew --prefix mysql-client@8.4)" \
+            -DBUILD_EXTRACTORS=1 \
+            -DBUILD_FOR_HOST_CPU=0 \
+            -DCONF_DIR:STRING=./etc \
+            -DDEBUG_SYMBOLS=0
+          make -j"$(sysctl -n hw.ncpu)"
+          make install
+
+      - name: Set release archive filename
+        run: |
+          echo "ARCHIVE_FILENAME=dev-macos-arm64-$(git rev-parse --short HEAD).tar.gz" >>"$GITHUB_ENV"
+
+      - name: Create release archive
+        run: |
+          set -euo pipefail
+          ./.github/scripts/package-macos-release.sh _install "$ARCHIVE_FILENAME"
+
+      - name: Smoke test release
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/vmangos-release
+          tar -xzf "$GITHUB_WORKSPACE/bin/$ARCHIVE_FILENAME" -C /tmp/vmangos-release
+
+          /tmp/vmangos-release/vmangos-macos-arm64/bin/realmd --version
+          /tmp/vmangos-release/vmangos-macos-arm64/bin/mangosd --version
+
+          missing=0
+          while IFS= read -r -d '' file; do
+            magic="$(head -c 4 "$file" 2>/dev/null || true)"
+            case "$magic" in
+            $'\xcf\xfa\xed\xfe' | $'\xfe\xed\xfa\xcf' | $'\xca\xfe\xba\xbe' | $'\xbe\xba\xfe\xca')
+              ;;
+            *)
+              continue
+              ;;
+            esac
+
+            while IFS= read -r dep; do
+              dep="${dep#"${dep%%[![:space:]]*}"}"
+              dep="${dep% (compatibility *}"
+              case "$dep" in
+              "" | /usr/lib/* | /System/* | @rpath/* | @loader_path/* | @executable_path/*)
+                ;;
+              *)
+                if [ "$(basename "$dep")" != "$(basename "$file")" ]; then
+                  echo "Unexpected dependency in $file: $dep" >&2
+                  missing=1
+                fi
+                ;;
+              esac
+            done < <(otool -L "$file" 2>/dev/null | tail -n +2)
+          done < <(find /tmp/vmangos-release/vmangos-macos-arm64 -type f -print0)
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-development-build
+          path: "${{ github.workspace }}/bin/${{ env.ARCHIVE_FILENAME }}"
+
   build-windows:
     name: Build Windows development release
     runs-on: windows-2022
@@ -146,7 +241,7 @@ jobs:
 
   publish:
     name: Publish development release
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-macos, build-windows]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -163,6 +258,12 @@ jobs:
           name: linux-development-build
           path: release-assets
 
+      - name: Download macOS release artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-development-build
+          path: release-assets
+
       - name: Download Windows release artifact
         uses: actions/download-artifact@v8
         with:
@@ -177,6 +278,15 @@ jobs:
           The Linux build is for `amd64` systems using `glibc` 2.39 or newer.
           It is built on Ubuntu 24.04 and bundles non-`glibc` runtime libraries.
           It is not expected to run on Alpine/`musl` or older `glibc` systems.
+
+          ## macOS compatibility
+
+          The macOS build is for Apple silicon (`arm64`) systems running macOS 26 or
+          newer.
+          If macOS refuses to launch the binaries with a Gatekeeper warning (typically
+          only when the archive was downloaded via a browser and the binaries are
+          launched from Finder), clear the quarantine flag with
+          `xattr -d -r com.apple.quarantine vmangos-macos-arm64/`.
 
           RELEASE_NOTES
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is an independent continuation of the Elysium / LightsHope codebase
 - Tools are great: Content creation should not require programming knowledge. We hope to eventually provide tools that allow for user-friendly editing of database scripts and content, with all data presented in human-readable form.
 
 ### Downloads
-- [![Development Release](https://github.com/vmangos/core/actions/workflows/development-release.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/latest) Latest development build (Linux and Windows)
+- [![Development Release](https://github.com/vmangos/core/actions/workflows/development-release.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/latest) Latest development build (Linux, macOS, and Windows)
 - [![Development Database Dump](https://github.com/vmangos/core/actions/workflows/development-db-dump.yaml/badge.svg)](https://github.com/vmangos/core/releases/tag/db_latest) Latest MySQL 5.6 development database snapshot; no updates required
 
 ### Useful Links


### PR DESCRIPTION
## 🍰 Pullrequest
This adds a macOS development release (`arm64`-only / Apple silicon) similar to the existing Linux and Windows releases, [as requested](https://github.com/vmangos/core/pull/3409#issuecomment-4455857890) by @ratkosrb.

The release is built on `macos-26` targeting macOS 26 (`CMAKE_OSX_DEPLOYMENT_TARGET=26.0`) and published as `dev-macos-arm64-<sha>.tar.gz` alongside the existing Linux and Windows assets on the `latest` tag.

As with the Linux release, the package is portable but not fully statically linked (macOS doesn't actually support fully static binaries; `libSystem.dylib` always stays dynamic). Instead, the package bundles non-system runtime libraries in `lib/` and uses `install_name_tool` to rewrite install names and `rpath`s, so binaries under `bin/` find the bundled libraries after extraction. Every Mach-O file is then ad-hoc signed (`codesign --force --sign -`) because `install_name_tool` rewrites invalidate any prior signature.

System libraries under `/usr/lib/` (e.g. `libc++.1.dylib`, `libSystem.B.dylib`, `libresolv.9.dylib`) and `/System/` are not bundled, so the archive is expected to work on Apple silicon Macs running macOS 26 or newer. Intel Macs are not supported (Apple is removing Intel support with macOS 27 anyway and I don't think complicating the workflow is worth it to add support for EOL Apple systems).

The build pins `mysql-client@8.4` (MySQL LTS through 2032) rather than the rolling `mysql-client` formula because MySQL 9 removed the `mysql_native_password` authentication plugin that MariaDB still uses by default. MySQL 8.4 keeps it built into the client library, so MariaDB users can connect out of the box. `openssl@3` is also pinned explicitly even though it's preinstalled on `macos-26` today, so a future runner image change can't silently break the build. The same pins are mirrored into the macOS CI build so we actually validate the release configuration.

The workflow includes a small smoke test (which I can also remove if unwanted) that extracts the archive on the same runner, runs `realmd --version` and `mangosd --version`, and walks every Mach-O file with `otool -L` to flag any dependency that is not part of the bundle and isn't under `/usr/lib/*` or `/System/*`.

Tested end-to-end on my Mac:
<img width="1279" height="1409" alt="image" src="https://github.com/user-attachments/assets/d7416bef-9131-4a1d-b893-6866be73343c" />

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
1. Download the macOS archive from [my fork's `latest` release](https://github.com/mserajnik/vmangos-core/releases/tag/latest) (`dev-macos-arm64-<sha>.tar.gz`).
2. Extract it and run from the archive root:
  ```sh
  cd vmangos-macos-arm64
  ```
3. Clear the quarantine flag (_Only if macOS refuses to launch the binaries with a Gatekeeper warning, typically when the archive was downloaded via a browser)_):
  ```sh
  xattr -d -r com.apple.quarantine .
  ```
4. Copy and edit the config files:
  ```sh
  cp etc/realmd.conf.dist etc/realmd.conf
  cp etc/mangosd.conf.dist etc/mangosd.conf
  ```
5. Adjust DB credentials and other settings as required for your setup.
6. Put extracted client data under the archive root, matching the default `DataDir = "."` (or put it elsewhere and adjust `DataDir` accordingly):
  ```
  vmangos-macos-arm64/
    maps/
    mmaps/
    vmaps/
    5875/
      dbc/
  ```
7. Start `realmd` and `mangosd` from the archive root:
  ```sh
  ./bin/realmd
  ./bin/mangosd
  ```

### Todo / Checklist
- [x] Test if it actually works