### PR TITLE
Fix misc early patch NPCs/objects.

### DIFF
--- a/sql/migrations/20260523232510_world.sql
+++ b/sql/migrations/20260523232510_world.sql
@@ -37,10 +37,13 @@ UPDATE `creature` SET `position_x` = -2714.4, `position_y` = -4999.92, `position
 UPDATE `creature` SET `id` = 12348 WHERE `guid` = 6405;
 -- Correct enytry for Mottled Raptor in Sen'jin is 12345, from wowemu
 UPDATE `creature` SET `id` = 12345 WHERE `guid` = 6404;
--- Dun morogh has wrong entries and wrong positions:
+-- The old Dun morogh rams have wrong entries and wrong positions:
 -- From wowemu, matches image from vanilla:
 UPDATE `creature` SET `id` = 12370, `position_x` = -5531.01, `position_y` = -1358.63, `position_z` = 398.819, `orientation` = 1.7709, `wander_distance` = 2.0, `movement_type` = 1 WHERE `guid` = 4156;
 UPDATE `creature` SET `id` = 12371, `position_x` = -5535.82, `position_y` = -1337.64, `position_z` = 398.894, `orientation` = 5.48232, `wander_distance` = 2.0, `movement_type` = 1 WHERE `guid` = 4155;
+-- The rams should be max level 2 according to Allakhazam
+UPDATE `creature_template` SET `level_max` = 2 WHERE `entry` = 12370;
+UPDATE `creature_template` SET `level_max` = 2 WHERE `entry` = 12371;
 
 -- Sniffed old AQ gong:
 -- Ahn'Qiraj Gong

--- a/sql/migrations/20260523232510_world.sql
+++ b/sql/migrations/20260523232510_world.sql
@@ -37,6 +37,7 @@ UPDATE `creature` SET `position_x` = -2714.4, `position_y` = -4999.92, `position
 UPDATE `creature` SET `id` = 12348 WHERE `guid` = 6405;
 -- Correct enytry for Mottled Raptor in Sen'jin is 12345, from wowemu
 UPDATE `creature` SET `id` = 12345 WHERE `guid` = 6404;
+
 -- The old Dun morogh rams have wrong entries and wrong positions:
 -- From wowemu, matches image from vanilla:
 UPDATE `creature` SET `id` = 12370, `position_x` = -5531.01, `position_y` = -1358.63, `position_z` = 398.819, `orientation` = 1.7709, `wander_distance` = 2.0, `movement_type` = 1 WHERE `guid` = 4156;
@@ -44,6 +45,41 @@ UPDATE `creature` SET `id` = 12371, `position_x` = -5535.82, `position_y` = -133
 -- The rams should be max level 2 according to Allakhazam
 UPDATE `creature_template` SET `level_max` = 2 WHERE `entry` = 12370;
 UPDATE `creature_template` SET `level_max` = 2 WHERE `entry` = 12371;
+-- Riding Tiger (White) should be Riding Nightsaber
+UPDATE `creature` SET `id` = 12361 WHERE `guid` = 49183;
+-- For some reason had display_scale1 = 1 in DB while all others had 0
+UPDATE `creature_template` SET `display_scale1` = 0 WHERE `entry` = 12361;
+-- Should have max level 2 according to Allakhazam
+UPDATE `creature_template` SET `display_scale1` = 0, `level_max` = 2 WHERE `entry` = 12361;
+
+-- Riding Tiger (Black) should be Riding Frostsaber
+UPDATE `creature` SET `id` = 12362 WHERE `guid` = 48577;
+-- Should have max level 2 according to Allakhazam
+UPDATE `creature_template` SET `display_scale1` = 0, `level_max` = 2 WHERE `entry` = 12362;
+
+-- Riding Stripped Nightsaber had diffrent spawn in pre 1.4
+-- Used to have the same location Riding Striped Frostsaber uses post 1.4
+UPDATE `creature` SET `patch_min` = 2 WHERE `guid` = 46332;
+INSERT INTO `creature` (`guid`, `id`, `id2`, `id3`, `id4`, `id5`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (217037, 12360, 0, 0, 0, 0, 1, 10132.7, 2526.33, 1325.56, 3.63028, 300, 300, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 1);
+INSERT INTO creature_addon
+(guid, patch, display_id, mount_display_id, equipment_id, stand_state, sheath_state, emote_state, auras)
+VALUES(217037, 0, 0, -1, -1, 3, 1, 0, NULL);
+
+-- Riding Spotted Frostsaber had diffrent spawn in pre 1.4
+-- Used to have the same location that Swift Stormsaber uses post 1.4:
+UPDATE `creature` SET `patch_min` = 2 WHERE `guid` = 46327;
+INSERT INTO `creature` (`guid`, `id`, `id2`, `id3`, `id4`, `id5`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (217038, 12359, 0, 0, 0, 0, 1, 10132.9, 2527.95, 1325.16, 4.01426, 300, 300, 0.0, 100.0, 0.0, 0, 0, 0.0, 0, 1);
+INSERT INTO creature_addon
+(guid, patch, display_id, mount_display_id, equipment_id, stand_state, sheath_state, emote_state, auras)
+VALUES(217038, 0, 0, -1, -1, 3, 1, 0, NULL);
+
+-- Riding Striped Frostsaber had diffrent spawn in pre 1.4
+-- Used to have the same location that Riding Spotted Frostsaber uses post 1.4:
+UPDATE `creature` SET `patch_min` = 2 WHERE `guid` = 46321;
+INSERT INTO `creature` (`guid`, `id`, `id2`, `id3`, `id4`, `id5`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (217039, 12358, 0, 0, 0, 0, 1, 10127.7, 2521.29, 1326.04, 1.8675, 300, 300, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 1);
+INSERT INTO creature_addon
+(guid, patch, display_id, mount_display_id, equipment_id, stand_state, sheath_state, emote_state, auras)
+VALUES(217039, 0, 0, -1, -1, 3, 1, 0, NULL);
 
 -- Sniffed old AQ gong:
 -- Ahn'Qiraj Gong

--- a/sql/migrations/20260523232510_world.sql
+++ b/sql/migrations/20260523232510_world.sql
@@ -1,0 +1,96 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260523232510');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260523232510');
+-- Add your query below.
+
+
+-- Sniffed Sulhasa position from wowemu, previous was handspawned by wowemu
+UPDATE `creature` SET `position_x` = -6353.49, `position_y` = -249.848, `position_z` = -1.88865, `orientation` = 4.31096 WHERE `guid` = 18;
+
+-- Sniffed Shaethis Darkoak position from wowemu, previous was handspawned by wowemu
+UPDATE `creature` SET `position_x` = -6422.37, `position_y` = -319.64, `position_z` = -0.942892, `orientation` = 4.90438 WHERE `guid` = 14;
+
+-- Pre naxx location NPC spawn should also be able to be human, from wowemu
+UPDATE `creature` SET `id2` = 8547 WHERE `guid` = 151317;
+
+-- Fix patch of chest at pre naxx location (originally from the 1.8 sniffs)
+-- Solid Chest
+UPDATE `gameobject` SET `patch_max` = 8 WHERE `guid` = 1034;
+
+-- Old sniffed Chylina position, previous was handspawned by wowemu
+UPDATE `creature` SET `position_x` = 2734.87, `position_y` = 1489.96, `position_z` = 237.593, `orientation` = 3.12414 WHERE `guid` = 32325;
+
+-- Old sniffed Augustus the Touched position, previous was handspawned
+UPDATE `creature` SET `position_x` = 2967.87, `position_y` = -2672.94, `position_z` = 99.0947, `orientation` = 6.16101 WHERE `guid` = 300233;
+
+-- Sniffed Varian Wrynn position, previous was handspawned
+UPDATE `creature` SET `position_x` = -2714.4, `position_y` = -4999.92, `position_z` = 7.16222, `orientation` = 4.76475 WHERE `guid` = 30879;
+
+-- All pre 1.4 mount trainer location has custom spawns and wrong entries
+-- Sen'jin has correct postions but wrong entries
+-- Correct entry for Ivory Raptor in Sen'jin is 12348, from wowemu
+UPDATE `creature` SET `id` = 12348 WHERE `guid` = 6405;
+-- Correct enytry for Mottled Raptor in Sen'jin is 12345, from wowemu
+UPDATE `creature` SET `id` = 12345 WHERE `guid` = 6404;
+-- Dun morogh has wrong entries and wrong positions:
+-- From wowemu, matches image from vanilla:
+UPDATE `creature` SET `id` = 12370, `position_x` = -5531.01, `position_y` = -1358.63, `position_z` = 398.819, `orientation` = 1.7709, `wander_distance` = 2.0, `movement_type` = 1 WHERE `guid` = 4156;
+UPDATE `creature` SET `id` = 12371, `position_x` = -5535.82, `position_y` = -1337.64, `position_z` = 398.894, `orientation` = 5.48232, `wander_distance` = 2.0, `movement_type` = 1 WHERE `guid` = 4155;
+
+-- Sniffed old AQ gong:
+-- Ahn'Qiraj Gong
+UPDATE `gameobject` SET `position_x` = -8067.785, `position_y` = 1568.161, `position_z` = 8.034219, `orientation` = 1.265365, `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.59131, `rotation3` = 0.806445 WHERE `guid` = 66333;
+
+-- Revantusk Village was added in patch 1.5, some objects were missing patch_min:
+-- Call to Arms!, Forge, Anvil, Campfire, Pupellyverbos Port, Troll Drum Sound Object
+UPDATE `gameobject` SET `patch_min` = 3 WHERE `guid` IN (46197, 46082, 46052, 46050, 46051, 46348, 46214, 46314);
+-- Riding Raptor:
+UPDATE `creature` SET `patch_min` = 3 WHERE `guid` = 92890;
+-- Missing campfire in pre 1.5, note this was found in 1.8 sniffs so this is an object blizz forgot to delete
+-- In post 1.5 it is barely visible as its inside a big clientside object:
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370857, 176786, 0, -501.6679, -4581.943, 8.715889, 3.141593, 0, 0, 1, 0, 3600, 3600, 100, 1, 0, 0.0, 0, 10);
+
+-- Add missing RFC objects from wowemu, all inside dungeon but outside portal, others like it were already spawned in DB
+-- Doodad_OrcSign_theSlowBlade
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370850, 175302, 389, 17.9547, 117.038, 12.5586, -0.026181, 0, 0, -0.01309, 0.999914, 3600, 3600, 100, 1, 0, 0.0, 0, 10);
+-- Doodad_MediumBrazierPurple11
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370851, 175306, 389, 66.9001, 75.5444, -9.23551, -2.54818, 0, 0, 0.956305, -0.292372, 3600, 3600, 100, 1, 0, 0.0, 0, 10);
+-- Doodad_OrcSign_IronwoodStavesandWands
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370852, 175311, 389, 63.9071, 88.004, -5.47027, -3.05433, 0, 0, 0.999048, -0.043619, 3600, 3600, 100, 1, 0, 0.0, 0, 10);
+
+-- Old ZG door pre ZG release, from wowemu:
+-- ZulGurubMainDoor01
+UPDATE `gameobject_template` SET `faction` = 114, `flags` = 20 WHERE `entry` = 177184;
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370853, 177184, 0, -11916.2, -1221.06, 92.279, -1.5708, 0, 0, -0.707107, 0.707107, 3600, 3600, 100, 1, 0, 0.0, 0, 4);
+-- Post release ZG door correct patch:
+-- Gates of Zul'Gurub
+UPDATE `gameobject_template` SET `patch` = 5 WHERE `entry` = 180323;
+UPDATE `gameobject` SET `patch_min` = 5 WHERE `guid` = 10698;
+
+-- Pre patch 1.4 IF vault doors, from wowemu:
+-- Vault Door
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370854, 177237, 0, -4842.93, -1061.82, 502.142, 1.35263, 0, 0, 0.625924, 0.779884, 3600, 3600, 100, 1, 0, 0.0, 0, 1);
+-- Vault Door
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370855, 177238, 0, -4831.81, -1052.61, 502.156, 3.09796, 0, 0, 0.999762, 0.021815, 3600, 3600, 100, 1, 0, 0.0, 0, 1);
+-- Set flag to 20 in according to wowemu, can't interact and untargetable
+UPDATE `gameobject_template` SET `flags` = 20 WHERE `entry` IN (177237, 177238);
+
+-- For some reason Caverns of Time door was deleted in 1.4 and replaced with serverside object
+-- Was later on added back as clientside object in 1.6
+-- CavernDoor01
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecsmin`, `spawntimesecsmax`, `animprogress`, `state`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES (370856, 179588, 1, -8173.24, -4747.53, 34.9166, 1.76278, 0, 0, 0.771625, 0.636078, 3600, 3600, 100, 1, 0, 0.0, 2, 3);
+-- Set flag to 20 in according to wowemu, can't interact and untargetable
+UPDATE `gameobject_template` SET `flags` = 20 WHERE `entry` = 179588;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- All of it is based on either  wowemu release 0.4735.1.1 full (the only "good" wowemu release) or the WoWD sniffs from 1.8.

WoWEmu 0.4735.1.1 full:
https://github.com/Daribon/Oldschool-WoW-Emu-Archive/blob/master/WoWEmu/WAD_original_Packages.rar

Here is the source from the WOWD sniffs:
The solid chest was missing min patch was added in this commit:
https://github.com/vmangos/core/blob/e13390f63e2b0001f8b782aed1428532a922c827/sql/migrations/20250223093249_world.sql#L131
On 1.12.1 map:
<img width="2023" height="1266" alt="Screenshot_20260521_214939" src="https://github.com/user-attachments/assets/5d5cbaf8-2b1f-4aa1-8f76-6a144f5ed4a1" />
With pre 1.11 map:
<img width="2023" height="1266" alt="Screenshot_20260521_215024" src="https://github.com/user-attachments/assets/df07bb8e-227e-47ed-b717-5f0f9b61c1aa" />
Was from sniff:
https://github.com/ratkosrb/VanillaSniffs/blob/ff119e685c0945833b76ab139e3d6b72dd4df898/1.8/western_and_eastern_plaguelands_1.8.1.4769_2005-11-01_20-29-07_parsed.txt
[3] GUID: Full: 0xF00010000002E4EF Type: DynamicObject Low: 17592186234095
[3] Object Type: 5 (GameObject)
[3] Movement Flags: 0 (None)
[3] Time: 0
[3] Position: X: 3118.88 Y: -3750.208 Z: 133.6201
[3] Orientation: 0.5585054
[3] Jump Fall Time: 0
[3] Walk Speed: 0
[3] Run Speed: 0.0000006124646
[3] RunBack Speed: -1585337
[3] Swim Speed: 7978968
[3] SwimBack Speed: 0
[3] Turn Speed: 0
[3] Update Flags: 0 (None)
[3] AttackCycle: 0
[3] TimerId: 1647117484
[3] Target GUID: Full: 0x108159558 Type: Player Low: 4430599512
[3] OBJECT_FIELD_GUID: Full: 0xF00010000002E4EF Type: DynamicObject Low: 17592186234095
[3] OBJECT_FIELD_TYPE: 33
[3] OBJECT_FIELD_ENTRY: 153453

Chylina:
https://github.com/ratkosrb/VanillaSniffs/blob/main/1.8/stonetalon_mountains_1.8.1.4769_2005-10-23_21-28-38_parsed.txt
[1] UpdateType: CreateObject1
[1] GUID: Full: 0xF000700000002AD6 Type: DynamicObject Low: 123145302321878
[1] Object Type: 3 (Unit)
[1] Movement Flags: 8388608 (CanFly)
[1] Time: 530205992
[1] Position: X: 2734.866 Y: 1489.965 Z: 237.5934
[1] Orientation: 3.124139
[1] Jump Fall Time: 0
[1] Walk Speed: 2.5
[1] Run Speed: 8
[1] RunBack Speed: 4.5
[1] Swim Speed: 4.722222
[1] SwimBack Speed: 2.5
[1] Turn Speed: 3.141593
[1] Update Flags: 0 (None)
[1] AttackCycle: 0
[1] TimerId: 1760666796
[1] Target GUID: 0x0
[1] OBJECT_FIELD_GUID: Full: 0xF000700000002AD6 Type: DynamicObject Low: 123145302321878
[1] OBJECT_FIELD_TYPE: 9
[1] OBJECT_FIELD_ENTRY: 4084

Augustus the Touched:
https://github.com/ratkosrb/VanillaSniffs/blob/main/1.8/western_and_eastern_plaguelands_1.8.1.4769_2005-11-01_20-29-07_parsed.txt
[2] UpdateType: CreateObject1
[2] GUID: Full: 0xF0001000000060D6 Type: DynamicObject Low: 17592186069206
[2] Object Type: 3 (Unit)
[2] Movement Flags: 8388608 (CanFly)
[2] Time: 1306955866
[2] Position: X: 2967.866 Y: -2672.935 Z: 99.09467
[2] Orientation: 6.161012
[2] Jump Fall Time: 0
[2] Walk Speed: 2.5
[2] Run Speed: 8
[2] RunBack Speed: 4.5
[2] Swim Speed: 4.722222
[2] SwimBack Speed: 2.5
[2] Turn Speed: 3.141593
[2] Update Flags: 0 (None)
[2] AttackCycle: 0
[2] TimerId: 1647117484
[2] Target GUID: 0x0
[2] OBJECT_FIELD_GUID: Full: 0xF0001000000060D6 Type: DynamicObject Low: 17592186069206
[2] OBJECT_FIELD_TYPE: 9
[2] OBJECT_FIELD_ENTRY: 12384
Comparison between the sniff and the previously custom spawn, left is sniff, right is handspawn:
<img width="2317" height="1109" alt="Screenshot_20260521_233732" src="https://github.com/user-attachments/assets/b110c216-47ef-49f9-abbd-d0a383a80091" />

Varian Wryn:
https://github.com/ratkosrb/VanillaSniffs/blob/main/1.8/dustwallow_marsh_1.8.1.4769_2005-10-35_00-14-46_parsed.txt
[3] UpdateType: CreateObject1
[3] GUID: Full: 0xF000700000004950 Type: DynamicObject Low: 123145302329680
[3] Object Type: 3 (Unit)
[3] Movement Flags: 8388608 (CanFly)
[3] Time: 1144810521
[3] Position: X: -2714.4 Y: -4999.92 Z: 7.162217
[3] Orientation: 4.764749
[3] Jump Fall Time: 0
[3] Walk Speed: 2.5
[3] Run Speed: 8
[3] RunBack Speed: 4.5
[3] Swim Speed: 4.722222
[3] SwimBack Speed: 2.5
[3] Turn Speed: 3.141593
[3] Update Flags: 0 (None)
[3] AttackCycle: 0
[3] TimerId: 1776276652
[3] Target GUID: 0x0
[3] OBJECT_FIELD_GUID: Full: 0xF000700000004950 Type: DynamicObject Low: 123145302329680
[3] OBJECT_FIELD_TYPE: 9
[3] OBJECT_FIELD_ENTRY: 11699

Ahn'Qiraj Gong:
https://github.com/ratkosrb/VanillaSniffs/blob/main/1.8/silithus_1.8.1.4769_2005-10-22_14-42-12_parsed.txt
[1] UpdateType: CreateObject1
[1] GUID: Full: 0xF00070000000033A Type: DynamicObject Low: 123145302311738
[1] Object Type: 5 (GameObject)
[1] Movement Flags: 0 (None)
[1] Time: 0
[1] Position: X: -8067.785 Y: 1568.161 Z: 8.034219
[1] Orientation: 1.265365
[1] Jump Fall Time: 0
[1] Walk Speed: 0
[1] Run Speed: 6585857
[1] RunBack Speed: -1589979
[1] Swim Speed: 1932988
[1] SwimBack Speed: 0
[1] Turn Speed: 0
[1] Update Flags: 0 (None)
[1] AttackCycle: 0
[1] TimerId: 1769985196
[1] Target GUID: Full: 0x1081594E8 Type: Player Low: 4430599400
[1] OBJECT_FIELD_GUID: Full: 0xF00070000000033A Type: DynamicObject Low: 123145302311738
[1] OBJECT_FIELD_TYPE: 33
[1] OBJECT_FIELD_ENTRY: 177223
[1] OBJECT_FIELD_SCALE_X: 1
[1] GAMEOBJECT_DISPLAYID: 4675
[1] GAMEOBJECT_ROTATION: X: 0 Y: 0 Z: 0.59131 W: 0.806445

Missing pre 1.5 Campfire, found in 1.8 sniff so appears blizz forgot to delete it when they added Revantusk Village:
https://github.com/ratkosrb/VanillaSniffs/blob/main/1.8/hinterlands_1.8.1.4769_2005-11-02_05-53-05_parsed.txt
[0] UpdateType: CreateObject1
[0] GUID: Full: 0xF000100000000495 Type: DynamicObject Low: 17592186045589
[0] Object Type: 5 (GameObject)
[0] Movement Flags: 0 (None)
[0] Time: 0
[0] Position: X: -501.6679 Y: -4581.943 Z: 8.715889
[0] Orientation: 3.141593
[0] Jump Fall Time: 0
[0] Walk Speed: 0
[0] Run Speed: 0.0000006124646
[0] RunBack Speed: -1585337
[0] Swim Speed: 7978968
[0] SwimBack Speed: 0
[0] Turn Speed: 0
[0] Update Flags: 0 (None)
[0] AttackCycle: 0
[0] TimerId: 1647117484
[0] Target GUID: Full: 0x108159558 Type: Player Low: 4430599512
[0] OBJECT_FIELD_GUID: Full: 0xF000100000000495 Type: DynamicObject Low: 17592186045589
[0] OBJECT_FIELD_TYPE: 33
[0] OBJECT_FIELD_ENTRY: 176786
The campfire spawned after applying this PR on pre 1.5 map:
<img width="2559" height="1351" alt="Screenshot_20260523_235546" src="https://github.com/user-attachments/assets/acf34107-c7f2-4357-bfb4-49e56063e9b0" />


Image from vanilla showing pre 1.4 ram trainer area:
https://vanilla-archive.thealphaproject.eu/?folders=Dun_Morogh&img=WoW25.jpg

Image below shows Caverns of time entrance on 1.4. Blizz for some reason replaced the clientside object 1.4 and 1.5 with a serverside object.
In 1.6 they added the clientside object back. This PR adds the serverside object from wowemu for those patches.
<img width="1924" height="1072" alt="Screenshot_20260523_011617" src="https://github.com/user-attachments/assets/20bdc496-9acf-47ea-a51b-563f56695df1" />

In Ironforge before 1.4 the vault doors in the throne room weren't clientside objects but instead serverside objects.
Without this PR, on pre 1.4 client you would be able to walk down to old IF without any vault door blocking you.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Just .go creature and .go ob the guids.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
