### PR TITLE
Change interaction distance check for GO with empty displayInfo bounds

### DIFF
--- a/src/game/Objects/GameObject.cpp
+++ b/src/game/Objects/GameObject.cpp
@@ -2380,7 +2380,7 @@ void GameObject::GetLosCheckPosition(float& x, float& y, float& z) const
 {
     if (GameObjectDisplayInfoAddon const* displayInfo = sGameObjectDisplayInfoAddonStorage.LookupEntry<GameObjectDisplayInfoAddon>(GetDisplayId()))
     {
-        if (displayInfo->min_x || displayInfo->min_y || displayInfo->min_z || displayInfo->max_x || displayInfo->max_y || displayInfo->max_z)
+        if (displayInfo->HasBounds())
         {
             float scale = GetObjectScale();
 
@@ -2579,21 +2579,24 @@ bool GameObject::IsAtInteractDistance(Position const& pos, float radius) const
 {
     if (GameObjectDisplayInfoAddon const* displayInfo = sGameObjectDisplayInfoAddonStorage.LookupEntry<GameObjectDisplayInfoAddon>(GetDisplayId()))
     {
-        float scale = GetObjectScale();
+        if (displayInfo->HasBounds())
+        {
+            float scale = GetObjectScale();
 
-        float minX = displayInfo->min_x * scale - radius;
-        float minY = displayInfo->min_y * scale - radius;
-        float minZ = displayInfo->min_z * scale - radius;
-        float maxX = displayInfo->max_x * scale + radius;
-        float maxY = displayInfo->max_y * scale + radius;
-        float maxZ = displayInfo->max_z * scale + radius;
+            float minX = displayInfo->min_x * scale - radius;
+            float minY = displayInfo->min_y * scale - radius;
+            float minZ = displayInfo->min_z * scale - radius;
+            float maxX = displayInfo->max_x * scale + radius;
+            float maxY = displayInfo->max_y * scale + radius;
+            float maxZ = displayInfo->max_z * scale + radius;
 
-        QuaternionData worldRotation = GetLocalRotation();
-        G3D::Quat worldRotationQuat(worldRotation.x, worldRotation.y, worldRotation.z, worldRotation.w);
+            QuaternionData worldRotation = GetLocalRotation();
+            G3D::Quat worldRotationQuat(worldRotation.x, worldRotation.y, worldRotation.z, worldRotation.w);
 
         return G3D::CoordinateFrame{ { worldRotationQuat },{ GetPositionX(), GetPositionY(), GetPositionZ() } }
             .toWorldSpace(G3D::Box{ { minX, minY, minZ },{ maxX, maxY, maxZ } })
             .contains({ pos.x, pos.y, pos.z });
+        }
     }
 
     return GetDistance3dToCenter(pos) <= radius;

--- a/src/game/Objects/GameObject.cpp
+++ b/src/game/Objects/GameObject.cpp
@@ -2593,7 +2593,7 @@ bool GameObject::IsAtInteractDistance(Position const& pos, float radius) const
             QuaternionData worldRotation = GetLocalRotation();
             G3D::Quat worldRotationQuat(worldRotation.x, worldRotation.y, worldRotation.z, worldRotation.w);
 
-        return G3D::CoordinateFrame{ { worldRotationQuat },{ GetPositionX(), GetPositionY(), GetPositionZ() } }
+            return G3D::CoordinateFrame{ { worldRotationQuat },{ GetPositionX(), GetPositionY(), GetPositionZ() } }
             .toWorldSpace(G3D::Box{ { minX, minY, minZ },{ maxX, maxY, maxZ } })
             .contains({ pos.x, pos.y, pos.z });
         }

--- a/src/game/Objects/GameObjectDefines.h
+++ b/src/game/Objects/GameObjectDefines.h
@@ -841,6 +841,10 @@ struct GameObjectDisplayInfoAddon
     float max_x;
     float max_y;
     float max_z;
+    bool HasBounds() const
+    {
+        return min_x != 0.0f || min_y != 0.0f || min_z != 0.0f || max_x != 0.0f || max_y != 0.0f || max_z != 0.0f;
+    }
 };
 
 struct QuaternionData


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Add bounds check in GameObject::IsAtInteractDistance

the function now falls back to a distance to center check instead of creating/rotating a box

Alternative solutions:
  - do not load entries with no bounds from gameobject_display_info_addon
 - or filter entries after loading

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
