### PR TITLE
Correct spawn position for 3 old NPC.

### DIFF
--- a/sql/migrations/20260528232744_world.sql
+++ b/sql/migrations/20260528232744_world.sql
@@ -1,0 +1,30 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260528232744');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260528232744');
+-- Add your query below.
+
+
+-- Sniffed Magister Kalendris, previous was hand spawned
+UPDATE `creature` SET `position_x` = -106.239, `position_y` = 575.648, `position_z` = -4.3122, `orientation` = 5.68977 WHERE `guid` = 56802;
+
+-- Sniffed Storm Shadowhoof from wowemu, previous was hand spawned
+UPDATE `creature` SET `position_x` = 5107.82, `position_y` = -361.647, `position_z` = 357.204, `orientation` = 0.733038 WHERE `guid` = 41759;
+
+-- Sniffed Grazzle from wowemu, previous was hand spawned
+UPDATE `creature` SET `position_x` = 6821.94, `position_y` = -2082.56, `position_z` = 623.264, `orientation` = 3.31613 WHERE `guid` = 39107;
+
+-- Twilight Avenger was missing min patch in area that was changed in 1.8
+UPDATE `creature` SET `patch_min` = 6 WHERE `guid` = 42985;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

This PR corrects position for the below NPCs on early patches:
- Magister Kalendris
- Storm Shadowhoof
- Grazzle 

It also includes a fix to Twilight Avenger that shouldn't be spawned pre patch 1.8


### Proof
<!-- Link resources as proof -->
- WoWD sniff from patch 1.8 and the DB from WoWEmu 0.4735.1.1 full.

- Magister Kalendris sniff from 1.8 (this was also matching the wowemu DB above)
https://github.com/ratkosrb/VanillaSniffs/blob/main/1.8/diremaul_north_west_1.8.1.4769_2005-10-31_06-34-59_parsed.txt
[0] UpdateType: CreateObject1
[0] GUID: Full: 0xF009200000083380 Type: DynamicObject Low: 2568459163022208
[0] Object Type: 3 (Unit)
[0] Movement Flags: 8388608 (CanFly)
[0] Time: 1164616758
[0] Position: X: -106.2386 Y: 575.648 Z: -4.312203
[0] Orientation: 5.689773
[0] Jump Fall Time: 0
[0] Walk Speed: 2.5
[0] Run Speed: 8
[0] RunBack Speed: 4.5
[0] Swim Speed: 4.722222
[0] SwimBack Speed: 2.5
[0] Turn Speed: 3.141593
[0] Update Flags: 0 (None)
[0] AttackCycle: 0
[0] TimerId: 1473238188
[0] Target GUID: 0x0
[0] OBJECT_FIELD_GUID: Full: 0xF009200000083380 Type: DynamicObject Low: 2568459163022208
[0] OBJECT_FIELD_TYPE: 9
[0] OBJECT_FIELD_ENTRY: 11487

<img width="1591" height="667" alt="Screenshot_20260529_010205" src="https://github.com/user-attachments/assets/167d299d-fe06-4f1d-bd91-5e52f86b4cb5" />
Targeted is old vmangos spawn. The one nearest me is the new sniff spawn.

--- 
<img width="2559" height="1157" alt="Screenshot_20260528_021801" src="https://github.com/user-attachments/assets/e993fea4-be9f-4c3a-a75a-d4dce7ea6395" />
Storm Shadowhoof from WoWEmu is seen targeted in above screenshot, vmangos seen in background.
As all other spawns next to the NPC in WoWEmu matches vmangos exactly, it is safe to say it is sniffed.

--- 
https://vanilla-archive.thealphaproject.eu/?folders=Felwood&img=WoWScrnShot_052205_012503.jpg
Image showing Grazzle from patch 1.4.2.

<img width="2559" height="1157" alt="Screenshot_20260528_021423" src="https://github.com/user-attachments/assets/63488a87-ba52-45d0-9894-7766b6e99a45" />
Target shows Grazzles position from this PR (taken from WoWEmu), which matches the 1.4.2 screenshot above (unlike the old vmangos spawn which can be seen on the right in the same picture). Combined with nearby unsorted sniffed NPCs (not shown in pic), this confirms Grazzles location is sniffed.


### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Just .go creature