### PR TITLE
Fix wand hit calculation to use the Wands skill.

### DIFF
--- a/src/game/Objects/SpellCaster.cpp
+++ b/src/game/Objects/SpellCaster.cpp
@@ -217,6 +217,13 @@ SpellMissInfo SpellCaster::SpellHitResult(Unit* pVictim, SpellEntry const* spell
         case SPELL_DAMAGE_CLASS_NONE:
             return SPELL_MISS_NONE;
         case SPELL_DAMAGE_CLASS_MAGIC:
+            // Wands deal spell school damage but are ranged weapon attacks, so
+            // their hit roll uses the ranged hit table, which is keyed on the
+            // Wands skill, rather than the spell hit table, which is keyed on
+            // level difference. This mirrors the wand crit handling in
+            // Unit::IsSpellCrit.
+            if (spell->HasAttribute(SPELL_ATTR_EX3_NORMAL_RANGED_ATTACK))
+                return MeleeSpellHitResult(pVictim, spell, spellPtr);
             return MagicSpellHitResult(pVictim, spell, spellPtr);
         case SPELL_DAMAGE_CLASS_MELEE:
         case SPELL_DAMAGE_CLASS_RANGED:
@@ -379,7 +386,9 @@ float SpellCaster::MeleeSpellMissChance(Unit const* pVictim, WeaponAttackType at
 // Melee based spells hit result calculations
 SpellMissInfo SpellCaster::MeleeSpellHitResult(Unit const* pVictim, SpellEntry const* spell, Spell* spellPtr)
 {
-    WeaponAttackType attType = spell->DmgClass == SPELL_DAMAGE_CLASS_RANGED ? RANGED_ATTACK : BASE_ATTACK;
+    // Wands use the ranged attack type.
+    WeaponAttackType attType = (spell->DmgClass == SPELL_DAMAGE_CLASS_RANGED ||
+        spell->HasAttribute(SPELL_ATTR_EX3_NORMAL_RANGED_ATTACK)) ? RANGED_ATTACK : BASE_ATTACK;
 
     // Hammer of Wrath should not use weapon skill, but Bloodthirst should.
     // bonus from skills is 0.04% per skill Diff


### PR DESCRIPTION
## 🍰 Pullrequest
Wand `Shoot` (spell `5019`) deals spell damage but is, mechanically, [a ranged weapon attack](https://github.com/vmangos/core/issues/2361#issuecomment-1889567065).

`SpellCaster::SpellHitResult()` dispatches the hit roll purely on `DmgClass`, and because the wand's `DmgClass` is `SPELL_DAMAGE_CLASS_MAGIC` it gets resolved by `SpellCaster::MagicSpellHitChance()`. That formula is keyed on the attacker/target level difference and never looks at the Wands weapon skill (`228`).

As a result, wand hit chance is completely independent of the Wands skill: a level 60 character with `1/300` skill has the exact same chance to hit as with `300/300`. As the video evidence in #2361 shows, this is incorrect, at least for Classic.

Interestingly, VMaNGOS already treats wands as ranged for the crit roll via the `SPELL_ATTR_EX3_NORMAL_RANGED_ATTACK` attribute in `Unit::IsSpellCrit()` here: https://github.com/vmangos/core/blob/d41b70fb6a71232665e4b5e37d5b56979b93ef94/src/game/Objects/Unit.cpp#L5478-L5482

---

In CMaNGOS Classic, wand hit rate is resolved through the ranged weapon skill hit table (`CalculateEffectiveMissChance()` keyed on `GetWeaponSkillValue(RANGED_ATTACK)` for spells flagged `SPELL_ATTR_EX3_NORMAL_RANGED_ATTACK`).

This PR makes wands use ranged hit calculation, which aligns with CMaNGOS's approach:

In `SpellCaster::SpellHitResult()`, a `SPELL_DAMAGE_CLASS_MAGIC` spell flagged `SPELL_ATTR_EX3_NORMAL_RANGED_ATTACK` now goes to `SpellCaster::MeleeSpellHitResult()` here: https://github.com/vmangos/core/blob/bfc51c24dcd750e03fda2c11d95de3e7b6d360a8/src/game/Objects/SpellCaster.cpp#L219-L227

It is then given the ranged attack type here: https://github.com/vmangos/core/blob/bfc51c24dcd750e03fda2c11d95de3e7b6d360a8/src/game/Objects/SpellCaster.cpp#L389-L391

That path already derives the weapon skill from `GetWeaponSkillValue()` (which returns the Wands skill `228` for an equipped wand), so the hit roll now scales accordingly with the skill. Because wands use the ranged attack type, they still cannot be dodged, parried or blocked (the ranged path in `MeleeSpellHitResult()` returns before those rolls).

One side effect worth noting: a wand that fails its hit roll on the skill-based miss now reports `SPELL_MISS_MISS` (from the ranged hit table) instead of `SPELL_MISS_RESIST`, which also matches CMaNGOS. School-based resists still apply separately during damage calculation.

---

__Disclaimer:__ I wasn't able to find any Vanilla sources, but the Classic video evidence (I think it's fair to assume Classic matches Vanilla here) and the fact that CMaNGOS already does this both point to it being more correct than the current behavior.

Also noteworthy, `SPELL_ATTR_EX3_NORMAL_RANGED_ATTACK` is only set on `Shoot` from `1.9.4.5086` onward, so this change only applies to those builds; this is the same as the existing wand crit handling, which is gated on the same flag. I wasn't able to find patch note evidence that this was changed, so I'm assuming this was an undocumented change back then. Maybe someone can confirm if this is true.

### Proof
- See video evidence in #2361

### Issues
- Fixes #2361

### How2Test
- Create a Mage, Priest or Warlock character using a GM account
- `.levelup 59` (use level 60 if you also want to observe the base miss chance at the `300` skill cap)
- `.additem 5240 1` and equip the wand (Torchlight Wand)
- `.go creature 40917` (teleports you to an isolated level 59-60 Frostsaber Stalker in Winterspring)
- Start wanding the Frostsaber Stalker and observe the hit chance rise as your Wands skill increases; level it all the way to `300` and confirm the base miss chance is correct. If the mob dies while attacking it, attack another one.
- Without this change, the hit chance does not change at all as the wand skill increases.

### Todo / Checklist
- None