### PR TITLE
Guard the honor system behind patch 1.4.0.

### DIFF
--- a/sql/migrations/20260529212939_world.sql
+++ b/sql/migrations/20260529212939_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260529212939');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260529212939');
+-- Add your query below.
+
+-- Error shown by honor commands when the honor system is unavailable (before patch 1.4.0).
+DELETE FROM `mangos_string` WHERE `entry` = 269;
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (269, 'The honor system is not available before patch 1.4.0.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -182,6 +182,7 @@ class ChatHandler
 
         bool HasLowerSecurity(Player* target, ObjectGuid guid = ObjectGuid(), bool strong = false);
         bool HasLowerSecurityAccount(WorldSession* target, uint32 account, bool strong = false);
+        bool HonorSystemDisabled();
 
         void SendGlobalSysMessage(char const* str);
 

--- a/src/game/Commands/CharacterCommands.cpp
+++ b/src/game/Commands/CharacterCommands.cpp
@@ -2426,8 +2426,21 @@ bool ChatHandler::HandleHonorShow(char* /*args*/)
     return true;
 }
 
+bool ChatHandler::HonorSystemDisabled()
+{
+    if (sWorld.IsHonorEnabled())
+        return false;
+
+    SendSysMessage(LANG_COMMAND_HONOR_DISABLED);
+    SetSentErrorMessage(true);
+    return true;
+}
+
 bool ChatHandler::HandleHonorAddCommand(char* args)
 {
+    if (HonorSystemDisabled())
+        return false;
+
     if (!*args)
         return false;
 
@@ -2450,6 +2463,9 @@ bool ChatHandler::HandleHonorAddCommand(char* args)
 
 bool ChatHandler::HandleHonorAddKillCommand(char* /*args*/)
 {
+    if (HonorSystemDisabled())
+        return false;
+
     Unit* target = GetSelectedUnit();
     if (!target)
     {
@@ -2467,6 +2483,9 @@ bool ChatHandler::HandleHonorAddKillCommand(char* /*args*/)
 
 bool ChatHandler::HandleModifyHonorCommand(char* args)
 {
+    if (HonorSystemDisabled())
+        return false;
+
     if (!*args)
         return false;
 
@@ -2537,6 +2556,9 @@ bool ChatHandler::HandleModifyHonorCommand(char* args)
 
 bool ChatHandler::HandleHonorResetCommand(char* /*args*/)
 {
+    if (HonorSystemDisabled())
+        return false;
+
     Player* target = GetSelectedPlayer();
     if (!target)
     {
@@ -2551,6 +2573,9 @@ bool ChatHandler::HandleHonorResetCommand(char* /*args*/)
 
 bool ChatHandler::HandleHonorSetRPCommand(char *args)
 {
+    if (HonorSystemDisabled())
+        return false;
+
     Player* target = GetSelectedPlayer();
     if (!target)
     {
@@ -3779,6 +3804,9 @@ bool ChatHandler::HandleListTalentsCommand(char* /*args*/)
 
 bool ChatHandler::HandleResetHonorCommand(char* args)
 {
+    if (HonorSystemDisabled())
+        return false;
+
     Player* target;
     if (!ExtractPlayerTarget(&args, &target))
         return false;

--- a/src/game/HonorMgr.cpp
+++ b/src/game/HonorMgr.cpp
@@ -787,6 +787,9 @@ void HonorMgr::Load(std::unique_ptr<QueryResult> result)
 
 bool HonorMgr::Add(float cp, uint8 type, Unit const* source)
 {
+    if (!sWorld.IsHonorEnabled())
+        return false;
+
     // Prevent give fake records to db with 0 honor
     if (!cp || !m_owner)
         return false;

--- a/src/game/Language.h
+++ b/src/game/Language.h
@@ -275,7 +275,7 @@ enum MangosStrings
     LANG_COMMAND_TARGETOBJNOTFOUND      = 266,
     LANG_COMMAND_GOOBJNOTFOUND          = 267,
     LANG_COMMAND_GOCREATNOTFOUND        = 268,
-    //                                    269, not used
+    LANG_COMMAND_HONOR_DISABLED         = 269,
     LANG_COMMAND_DELCREATMESSAGE        = 270,
     LANG_COMMAND_CREATUREMOVED          = 271,
     LANG_COMMAND_CREATUREATSAMEMAP      = 272,

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -677,7 +677,7 @@ void Player::SatisfyItemRequirements(ItemPrototype const* pItem)
 
     // Set required honor rank
     auto playerRank = (sWorld.getConfig(CONFIG_BOOL_ACCURATE_PVP_EQUIP_REQUIREMENTS) && sWorld.GetWowPatch() < WOW_PATCH_106) ? m_honorMgr.GetRank().rank : m_honorMgr.GetHighestRank().rank;
-    if (playerRank < (uint8)pItem->RequiredHonorRank)
+    if (sWorld.IsHonorEnabled() && playerRank < (uint8)pItem->RequiredHonorRank)
     {
         HonorRankInfo rank;
         rank.rank = pItem->RequiredHonorRank;
@@ -21932,10 +21932,6 @@ void Player::LootMoney(int32 money, Loot* loot)
 
 void Player::RewardHonor(Unit const* pVictim, uint32 groupSize)
 {
-    // Honor System was added in 1.4.
-    if (sWorld.GetWowPatch() < WOW_PATCH_104 && sWorld.getConfig(CONFIG_BOOL_ACCURATE_PVP_TIMELINE))
-        return;
-
     if (!pVictim)
         return;
 
@@ -21965,15 +21961,10 @@ void Player::RewardHonor(Unit const* pVictim, uint32 groupSize)
             return;
         }
     }
-    // for PvP see ::HonorRewardInPvP
 }
 
 void Player::RewardHonorOnDeath()
 {
-    // Honor System was added in 1.4.
-    if (sWorld.GetWowPatch() < WOW_PATCH_104 && sWorld.getConfig(CONFIG_BOOL_ACCURATE_PVP_TIMELINE))
-        return;
-
     if (HasAuraType(SPELL_AURA_NO_PVP_CREDIT)) // Honorless Target
         return;
 

--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -2596,7 +2596,7 @@ void CombatBotBaseAI::EquipRandomGearInEmptySlots()
 {
     LearnArmorProficiencies();
 
-    bool const onlyPvE = urand(0, 1) != 0;
+    bool const onlyPvE = !sWorld.IsHonorEnabled() || urand(0, 1) != 0;
     uint8 const honorRank = onlyPvE ? 0 : urand(5, 18);
 
     std::map<uint32 /*slot*/, std::vector<ItemPrototype const*>> itemsPerSlot;

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1815,8 +1815,11 @@ void World::SetInitialWorldSettings()
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Deleting expired bans...");
     LoginDatabase.Execute("DELETE FROM `ip_banned` WHERE `unbandate`<=UNIX_TIMESTAMP() AND `unbandate`<>`bandate`");
 
-    sHonorMaintenancer.Initialize();
-    sHonorMaintenancer.DoMaintenance();
+    if (IsHonorEnabled())
+    {
+        sHonorMaintenancer.Initialize();
+        sHonorMaintenancer.DoMaintenance();
+    }
 
     sLog.Out(LOG_BASIC, LOG_LVL_MINIMAL, "Starting Game Event system...");
     uint32 nextGameEvent = sGameEventMgr.Initialize();
@@ -2115,13 +2118,16 @@ void World::Update(uint32 diff)
     sMapPersistentStateMgr.Update();
 
     // Maintenance checker
-    if (m_MaintenanceTimeChecker < diff)
+    if (IsHonorEnabled())
     {
-        sHonorMaintenancer.CheckMaintenanceDay();
-        m_MaintenanceTimeChecker = 60000;
+        if (m_MaintenanceTimeChecker < diff)
+        {
+            sHonorMaintenancer.CheckMaintenanceDay();
+            m_MaintenanceTimeChecker = 60000;
+        }
+        else
+            m_MaintenanceTimeChecker -= diff;
     }
-    else
-        m_MaintenanceTimeChecker -= diff;
 
     // Update PlayerBotMgr
     sPlayerBotMgr.Update(diff);

--- a/src/game/World.h
+++ b/src/game/World.h
@@ -710,6 +710,9 @@ class World
 
         // Get current server's WoW Patch
         uint8 GetWowPatch() const { return m_wowPatch; }
+        // The PvP Honor System was introduced in 1.4.0.
+        // https://warcraft.wiki.gg/wiki/Patch_1.4.0#PvP_Honor_System
+        bool IsHonorEnabled() const { return !(GetWowPatch() < WOW_PATCH_104 && getConfig(CONFIG_BOOL_ACCURATE_PVP_TIMELINE)); }
         char const* GetPatchName() const;
 
         LocaleConstant GetDefaultDbcLocale() const { return m_defaultDbcLocale; }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This effectively disables the honor system pre patch `1.4.0` (when `PvP.AccurateTimeline` is also set `true`), including the weekly honor maintenance and all the honor-related GM commands.

A few edge cases not covered on purpose:
- If rank gets set through the database directly, VMaNGOS will still read the rank as-is; this could be tightened to force an in-memory rank of `0` when a higher one is detected with the honor system disabled, but I decided against overriding DB data (happy to add this if wanted).
- If a bot gets copied from a character with existing rank it will still inherit the rank; I think it would be incorrect to prevent the copy of the rank here if the bot is supposed to be a verbatim copy of the character (regardless of how the character acquired the rank).
- If a premade gear template includes an item with a required honor rank, that item is no longer auto-granted the rank and so ends up unequipped in the recipient's bags instead of being skipped outright; this could be tightened to skip such items entirely when the honor system is disabled, but that should only affect custom templates, so it didn't seem worth explicitly covering.

__Note:__ I also removed the now-redundant inline `1.4.0` guards in `Player::RewardHonor()` and `Player::RewardHonorOnDeath()`, since `HonorMgr::Add()` is guarded centrally now.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #2744

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None; not reachable on currently supported patches (>= `1.5.1`); only affects an unsupported pre-`1.4.0` config, so this is effectively just some groundwork for later.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
