### PR TITLE
Ungroup two Molten Core spawns

### DIFF
--- a/sql/migrations/20260529030008_world.sql
+++ b/sql/migrations/20260529030008_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260529030008');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260529030008');
+-- Add your query below.
+
+-- Proof: https://www.youtube.com/watch?v=xkbKOzwAihw&t=226
+-- At 3:47, Firelord in background is pulled, and the other nearby Firelord does not aggro.
+DELETE FROM `creature_groups` WHERE `leader_guid` = 56800;
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
Deletes the creature group comprising two specific spawns in Molten Core.

### Proof
<!-- Link resources as proof -->
https://www.youtube.com/watch?v=xkbKOzwAihw&t=226 - uploaded 2006-11-23

At 3:47, Firelord in background is pulled, and the other nearby Firelord does not aggro.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- These two spawns are in a group, but should not be.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Enter Molten Core.
- Pull one of these creatures.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
