### PR TITLE
Implement Volume Caching

### DIFF
--- a/dep/recastnavigation/Detour/Include/DetourNavMeshQuery.h
+++ b/dep/recastnavigation/Detour/Include/DetourNavMeshQuery.h
@@ -28,7 +28,7 @@
 // setting is to use non-virtual functions, the actual implementations of the functions
 // are declared as inline for maximum speed. 
 
-//#define DT_VIRTUAL_QUERYFILTER 1
+#define DT_VIRTUAL_QUERYFILTER 1
 
 /// Defines polygon filtering and traversal costs for navigation mesh query operations.
 /// @ingroup detour

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1606,6 +1606,9 @@ void Map::UnloadAll(bool pForce)
         sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Non empty bones list, probably leaking. Please report.");
         m_bones.clear();
     }
+
+    // Clear collision volume cache
+    ClearVolumeCache();
 }
 
 bool Map::CheckGridIntegrity(Creature* c, bool moved)

--- a/src/game/Maps/Map.h
+++ b/src/game/Maps/Map.h
@@ -38,6 +38,7 @@
 #include "SQLStorages.h"
 #include "ScriptCommands.h"
 #include "CreatureLinkingMgr.h"
+#include <G3D/AABox.h>
 
 #include <bitset>
 #include <list>
@@ -174,6 +175,13 @@ struct AreaEntry
 struct AreaLocale
 {
     std::vector<std::string> Name;
+};
+
+struct VolumeCache
+{
+    ObjectGuid guid;
+    G3D::AABox worldBounds;
+    bool enabled;
 };
 
 #define MIN_UNLOAD_DELAY      1                             // immediate unload
@@ -520,6 +528,34 @@ class Map : public GridRefManager<NGridType>
         WorldObject* GetWorldObject(ObjectGuid guid);         // only use if sure that need objects at current map, specially for player case
         WorldObject* GetWorldObjectOrPlayer(ObjectGuid guid); // Returns a world object from current map, or player anywhere.
 
+        // Volume caching for movement generators
+        const std::vector<VolumeCache>& GetVolumeCache() const { return m_volumeCache; }
+        void ClearVolumeCache() { m_volumeCache.clear(); }
+        void AddVolumeCacheEntry(ObjectGuid objGuid, G3D::AABox bounds, bool enabled)
+        {
+            sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Volume Box Created - GUID: %u", objGuid);
+            m_volumeCache.push_back( { objGuid, bounds, enabled } );
+        }
+        void RemoveVolumeCacheEntry(ObjectGuid guid)
+        {
+            sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Volume Box Deleted - GUID: %u", guid);
+            m_volumeCache.erase(std::remove_if(m_volumeCache.begin(), m_volumeCache.end(), [guid](const VolumeCache& obj) { return obj.guid == guid; }), m_volumeCache.end());
+        }
+        void SetVolumeCollisionState(ObjectGuid guid, bool active) // Enabled/disabled local volumes
+        {
+            for (auto& obj : m_volumeCache)
+            {
+                if (obj.guid == guid)
+                {
+                    sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "Volume Box %s - GUID: %u - Low: %.2f %.2f %.2f | High: %.2f %.2f %.2f", active ? "Enabled" : "Disabled", obj.guid,
+                    obj.worldBounds.low().x, obj.worldBounds.low().y, obj.worldBounds.low().z, obj.worldBounds.high().x, obj.worldBounds.high().y, obj.worldBounds.high().z);
+
+                    obj.enabled = active;
+                    break;
+                }
+            }
+        }
+
         template <typename T> void InsertObject(ObjectGuid const& guid, T* ptr)
         {
             std::lock_guard<std::shared_timed_mutex> lock(m_objectsStore_lock);
@@ -730,6 +766,9 @@ class Map : public GridRefManager<NGridType>
 
         InstanceData* m_data = nullptr;
         uint32 m_scriptId = 0;
+
+        // Volume caching for movement generators
+        std::vector<VolumeCache> m_volumeCache;
 
         // Map local low guid counters
         mutable std::mutex m_guidGenerators_lock;

--- a/src/game/Maps/PathFinder.cpp
+++ b/src/game/Maps/PathFinder.cpp
@@ -26,6 +26,7 @@
 #include "Geometry.h"
 
 #include "Detour/Include/DetourCommon.h"
+#include "Detour/Include/DetourNavMeshQuery.h"
 
 // Distance to target
 #define SMOOTH_PATH_SLOP 0.4f
@@ -71,6 +72,15 @@ bool PathInfo::calculate(Vector3 const& start, Vector3 dest, bool forceDest, boo
     setEndPosition(dest);
     setStartPosition(start);
 
+    // Volume Box Filter handles door collision
+    VolumeBoxFilter volumeFilter(m_sourceUnit->GetMap());
+    volumeFilter.setIncludeFlags(m_filter.getIncludeFlags());
+    volumeFilter.setExcludeFlags(m_filter.getExcludeFlags());
+    for (int i = 0; i < DT_MAX_AREAS; ++i)
+    {
+        volumeFilter.setAreaCost(i, m_filter.getAreaCost(i));
+    }
+
     // A m_navMeshQuery object is not thread safe, but a same PathInfo can be shared between threads.
     // So need to get a new one.
     MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
@@ -85,7 +95,7 @@ bool PathInfo::calculate(Vector3 const& start, Vector3 dest, bool forceDest, boo
     }
     else if (!(m_navMeshQuery = mmap->GetNavMeshQuery(m_sourceUnit->GetMapId())))
     {
-        BuildPathWithoutMMaps(start, dest);
+        BuildPathWithoutMMaps(start, dest, &volumeFilter);
         return true;
     }
 
@@ -99,7 +109,7 @@ bool PathInfo::calculate(Vector3 const& start, Vector3 dest, bool forceDest, boo
     if (!m_navMesh || !m_navMeshQuery || m_sourceUnit->HasUnitState(UNIT_STATE_IGNORE_PATHFINDING) ||
         !HaveTiles(start) || !HaveTiles(dest))
     {
-        BuildShortcut();
+        BuildShortcut(&volumeFilter);
         m_type = PathType(PATHFIND_NORMAL | PATHFIND_NOT_USING_PATH);
         return true;
     }
@@ -119,8 +129,7 @@ bool PathInfo::calculate(Vector3 const& start, Vector3 dest, bool forceDest, boo
     }
     else
     {
-        // target moved, so we need to update the poly path
-        BuildPolyPath(start, dest);
+        BuildPolyPath(start, dest, &volumeFilter);
         return true;
     }
 }
@@ -142,12 +151,11 @@ dtPolyRef PathInfo::FindWalkPoly(dtNavMeshQuery const* query, float const* point
     return polyRef;
 }
 
-dtPolyRef PathInfo::getPolyByLocation(float const* point, float *distance, uint32 allowedFlags)
+dtPolyRef PathInfo::getPolyByLocation(float const* point, float *distance, dtQueryFilter* filter, uint32 allowedFlags)
 {
     float closestPoint[VERTEX_SIZE] = {0.0f, 0.0f, 0.0f};
-    dtQueryFilter filter;
-    filter.setIncludeFlags(m_filter.getIncludeFlags() | allowedFlags);
-    dtPolyRef polyRef = FindWalkPoly(m_navMeshQuery, point, filter, closestPoint);
+    filter->setIncludeFlags(filter->getIncludeFlags() | allowedFlags);
+    dtPolyRef polyRef = FindWalkPoly(m_navMeshQuery, point, *filter, closestPoint);
     if (polyRef != INVALID_POLYREF)
     {
         *distance = dtVdist(closestPoint, point);
@@ -156,7 +164,7 @@ dtPolyRef PathInfo::getPolyByLocation(float const* point, float *distance, uint3
     return INVALID_POLYREF;
 }
 
-void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
+void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos, dtQueryFilter* filter)
 {
     // *** getting start/end poly logic ***
 
@@ -174,10 +182,10 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
         if (!m_sourceUnit->GetMap()->FindCollisionModel(startPos.x, startPos.y, startPos.z, endPos.x, endPos.y, endPos.z))
         {
             if (canSwimToDestination)
-                BuildUnderwaterPath();
+                BuildUnderwaterPath(filter);
             else
             {
-                BuildShortcut();
+                BuildShortcut(filter);
                 m_type = PathType(PATHFIND_NORMAL | PATHFIND_NOT_USING_PATH | PATHFIND_FLYPATH);
             }
             return;
@@ -185,8 +193,8 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
         else if (m_sourceUnit->CanFly())
             m_forceDestination = true;
     }
-    dtPolyRef startPoly = getPolyByLocation(startPoint, &distToStartPoly);
-    dtPolyRef endPoly = getPolyByLocation(endPoint, &distToEndPoly, m_targetAllowedFlags);
+    dtPolyRef startPoly = getPolyByLocation(startPoint, &distToStartPoly, filter);
+    dtPolyRef endPoly = getPolyByLocation(endPoint, &distToEndPoly, filter, m_targetAllowedFlags);
 
     // we have a hole in our mesh
     // make shortcut path and mark it as NOPATH ( with flying exception )
@@ -194,7 +202,7 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
     if (startPoly == INVALID_POLYREF || endPoly == INVALID_POLYREF)
     {
         //DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (startPoly == 0 || endPoly == 0)\n");
-        BuildShortcut();
+        BuildShortcut(filter);
         // Check for swimming or flying shortcut
         if ((startPoly == INVALID_POLYREF && m_sourceUnit->GetTerrain()->IsSwimmable(startPos.x, startPos.y, startPos.z)) ||
             (endPoly == INVALID_POLYREF && m_sourceUnit->GetTerrain()->IsSwimmable(endPos.x, endPos.y, endPos.z)))
@@ -213,13 +221,13 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
         if (canSwimToDestination)
         {
             //DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: underWater case\n");
-            BuildUnderwaterPath();
+            BuildUnderwaterPath(filter);
             return;
         }
 
         if (m_sourceUnit->CanFly())
         {
-            BuildShortcut();
+            BuildShortcut(filter);
             m_type = PathType(PATHFIND_NORMAL | PATHFIND_NOT_USING_PATH);
             return;
         }
@@ -312,14 +320,15 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
                 if (dtStatusFailed(m_navMeshQuery->closestPointOnPoly(suffixStartPoly, endPoint, suffixEndPoint, &PosOverBody)))
                 {
                     // suffixStartPoly is still invalid, error state
-                    BuildShortcut();
+                    BuildShortcut(filter);
                     m_type = PATHFIND_NOPATH;
                     return;
                 }
             }
             else
             {
-                BuildShortcut();
+                // suffixStartPoly is still invalid, error state
+                BuildShortcut(filter);
                 m_type = PATHFIND_NOPATH;
                 return;
             }
@@ -332,7 +341,7 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
                                 endPoly,            // end polygon
                                 suffixEndPoint,     // start position
                                 endPoint,           // end position
-                                &m_filter,            // polygon search filter
+                                filter,             // polygon search filter
                                 m_pathPolyRefs + prefixPolyLength - 1,    // [out] path
                                 (int*)&suffixPolyLength,
                                 MAX_PATH_LENGTH - prefixPolyLength); // max number of polygons in output path
@@ -371,7 +380,7 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
                                 endPoly,            // end polygon
                                 startPoint,         // start position
                                 endPoint,           // end position
-                                &m_filter,           // polygon search filter
+                                filter,             // polygon search filter
                                 m_pathPolyRefs,     // [out] path
                                 (int*)&m_polyLength,
                                 MAX_PATH_LENGTH);   // max number of polygons in output path
@@ -380,7 +389,7 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
         {
             // only happens if we passed bad data to findPath(), or navmesh is messed up
             sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "%u's Path Build failed: 0 length path. Result=0x%x", m_sourceUnit->GetGUIDLow(), dtResult);
-            BuildShortcut();
+            BuildShortcut(filter);
             m_type = PATHFIND_NOPATH;
             return;
         }
@@ -392,10 +401,10 @@ void PathInfo::BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos)
     else
         m_type = PATHFIND_INCOMPLETE;
 
-    BuildPointPath(startPoint, endPoint, distToStartPoly, distToEndPoly);
+    BuildPointPath(startPoint, endPoint, distToStartPoly, distToEndPoly, filter);
 }
 
-void PathInfo::BuildPointPath(float const* startPoint, float const* endPoint, float distToStartPoly, float distToEndPoly)
+void PathInfo::BuildPointPath(float const* startPoint, float const* endPoint, float distToStartPoly, float distToEndPoly, dtQueryFilter* filter)
 {
     // generate the point-path out of our up-to-date poly-path
     float pathPoints[MAX_POINT_PATH_LENGTH * VERTEX_SIZE];
@@ -417,13 +426,14 @@ void PathInfo::BuildPointPath(float const* startPoint, float const* endPoint, fl
     else
     {
         dtResult = findSmoothPath(
-                       startPoint,         // start position
-                       endPoint,           // end position
-                       m_pathPolyRefs,     // current path
-                       m_polyLength,       // length of current path
-                       pathPoints,         // [out] path corner points
-                       (int*)&pointCount,
-                       m_pointPathLimit);    // maximum number of points
+                       startPoint,          // start position
+                       endPoint,            // end position
+                       m_pathPolyRefs,      // current path
+                       m_polyLength,        // length of current path
+                       pathPoints,          // [out] path corner points
+                       (int*)&pointCount,   // number of points
+                       m_pointPathLimit,    // maximum number of points
+                       filter);             // filter used    
     }
 
     if (pointCount < 2 || dtStatusFailed(dtResult))
@@ -432,7 +442,7 @@ void PathInfo::BuildPointPath(float const* startPoint, float const* endPoint, fl
         // single point paths can be generated here
         // TODO : check the exact cases
         //DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::BuildPointPath FAILED! path sized %d returned\n", pointCount);
-        BuildShortcut();
+        BuildShortcut(filter);
         m_type = PATHFIND_NOPATH;
         return;
     }
@@ -462,7 +472,7 @@ void PathInfo::BuildPointPath(float const* startPoint, float const* endPoint, fl
         else
         {
             setActualEndPosition(getEndPosition());
-            BuildShortcut();
+            BuildShortcut(filter);
         }
 
         
@@ -474,23 +484,31 @@ void PathInfo::BuildPointPath(float const* startPoint, float const* endPoint, fl
     //DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::BuildPointPath path type %d size %d poly-size %d\n", m_type, pointCount, m_polyLength);
 }
 
-void PathInfo::BuildShortcut()
+void PathInfo::BuildShortcut(dtQueryFilter* filter)
 {
     clear();
 
     // make two point path, our curr pos is the start, and dest is the end
     m_pathPoints.resize(2);
 
-    // set start and a default next position
-    m_pathPoints[0] = getStartPosition();
-    m_pathPoints[1] = getActualEndPosition();
-
-    m_type = PATHFIND_SHORTCUT;
-    if (m_sourceUnit->CanFly())
-        m_type |= PATHFIND_FLYPATH | PATHFIND_NORMAL;
+    // Check if we're experiencing door collision
+    if (const VolumeBoxFilter* isVolumeFilter = dynamic_cast<const VolumeBoxFilter*>(filter))
+    {
+        m_pathPoints[0] = getStartPosition();
+        m_pathPoints[1] = getStartPosition(); // Set both at start to terminate path
+        m_type = PATHFIND_NOPATH;
+    }
+    else
+    {
+        m_pathPoints[0] = getStartPosition();
+        m_pathPoints[1] = getActualEndPosition();
+        m_type = PATHFIND_SHORTCUT;
+        if (m_sourceUnit->CanFly())
+            m_type |= PATHFIND_FLYPATH | PATHFIND_NORMAL;
+    }
 }
 
-void PathInfo::BuildUnderwaterPath()
+void PathInfo::BuildUnderwaterPath(dtQueryFilter* filter)
 {
     clear();
 
@@ -599,26 +617,26 @@ bool BuildPathStep(Vector3 const& currentPos, Vector3 const& targetPos, Map cons
     return false;
 }
 
-void PathInfo::BuildPathWithoutMMaps(Vector3 const& start, Vector3 const& dest)
+void PathInfo::BuildPathWithoutMMaps(Vector3 const& start, Vector3 const& dest, dtQueryFilter* filter)
 {
     bool const destInWater = m_sourceUnit->CanSwimAtPosition(dest);
 
     if (!m_sourceUnit->CanSwim() && destInWater)
     {
-        BuildShortcut();
+        BuildShortcut(filter);
         m_type = PathType(PATHFIND_NOPATH);
         return;
     }
 
     if (m_sourceUnit->CanFly())
     {
-        BuildShortcut();
+        BuildShortcut(filter);
         return;
     }
 
     if (!m_sourceUnit->CanWalk() && !destInWater)
     {
-        BuildShortcut();
+        BuildShortcut(filter);
         m_type = PathType(PATHFIND_NOPATH);
         return;
     }
@@ -627,7 +645,7 @@ void PathInfo::BuildPathWithoutMMaps(Vector3 const& start, Vector3 const& dest)
     if (totalDistance <= STEP_SIZE ||
         (m_sourceUnit->CanSwim() && destInWater && m_sourceUnit->CanSwimAtPosition(start)))
     {
-        BuildShortcut();
+        BuildShortcut(filter);
         m_type |= PATHFIND_NORMAL;
         return;
     }
@@ -649,7 +667,7 @@ void PathInfo::BuildPathWithoutMMaps(Vector3 const& start, Vector3 const& dest)
     }
     else
     {
-        BuildShortcut();
+        BuildShortcut(filter);
         m_type = PathType(PATHFIND_NORMAL | PATHFIND_NOT_USING_PATH);
     }
 }
@@ -749,6 +767,42 @@ uint32 PathInfo::fixupCorridor(dtPolyRef* path, uint32 const npath, uint32 const
         path[i] = visited[(nvisited - 1) - i];
 
     return req + size;
+}
+
+bool PathInfo::IntersectVolumeBox(const float* pa, const float* pb, const G3D::AABox& box)
+{
+    G3D::Vector3 low = box.low();
+    G3D::Vector3 high = box.high();
+    float boxMin[3] = { low.y,  low.z,  low.x  };
+    float boxMax[3] = { high.y, high.z, high.x };
+    float dir[3] = { pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2] };
+    float tmin = 0.0f;
+    float tmax = 1.0f;
+
+    for (int i = 0; i < 3; ++i)
+    {
+        if (std::abs(dir[i]) < 0.000001f)
+        {
+            if (pa[i] < boxMin[i] || pa[i] > boxMax[i])
+                return false;
+        }
+        else
+        {
+            float invDir = 1.0f / dir[i];
+            float t1 = (boxMin[i] - pa[i]) * invDir;
+            float t2 = (boxMax[i] - pa[i]) * invDir;
+
+            if (t1 > t2) 
+                std::swap(t1, t2);
+
+            if (t1 > tmin) tmin = t1;
+            if (t2 < tmax) tmax = t2;
+
+            if (tmin > tmax)
+                return false;
+        }
+    }
+    return true;
 }
 
 int fixupShortcuts(dtPolyRef* path, int npath, dtNavMeshQuery const* navQuery)
@@ -869,7 +923,7 @@ float Distance2DPointToLineYZX(float* lineA, float* lineB, float* point)
 
 dtStatus PathInfo::findSmoothPath(float const* startPos, float const* endPos,
                                   dtPolyRef const* polyPath, uint32 polyPathSize,
-                                  float* smoothPath, int* smoothPathSize, uint32 maxSmoothPathSize)
+                                  float* smoothPath, int* smoothPathSize, uint32 maxSmoothPathSize, dtQueryFilter* filter)
 {
     bool simplifyPath = false;
     *smoothPathSize = 0;
@@ -926,7 +980,7 @@ dtStatus PathInfo::findSmoothPath(float const* startPos, float const* endPos,
         dtPolyRef visited[MAX_VISIT_POLY];
 
         uint32 nvisited = 0;
-        if (dtStatusFailed(m_navMeshQuery->moveAlongSurface(polys[0], iterPos, moveTgt, &m_filter, result, visited, (int*)&nvisited, MAX_VISIT_POLY)))
+        if (dtStatusFailed(m_navMeshQuery->moveAlongSurface(polys[0], iterPos, moveTgt, filter, result, visited, (int*)&nvisited, MAX_VISIT_POLY)))
             return DT_FAILURE;
         npolys = fixupCorridor(polys, npolys, MAX_PATH_LENGTH, visited, nvisited);
         npolys = fixupShortcuts(polys, npolys, m_navMeshQuery);
@@ -1100,21 +1154,6 @@ bool PathInfo::UpdateForMelee(Unit* pTarget, float meleeReach)
         }
     }
     return false;
-}
-
-
-void PathInfo::CutPathWithDynamicLoS()
-{
-    uint32 maxIndex = m_pathPoints.size() - 1;
-    Vector3 out;
-    // We have always keep at least 2 points (else, there is no mvt !)
-    for (uint32 i = 1; i <= maxIndex; ++i)
-        if (m_sourceUnit->GetMap()->GetDynamicObjectHitPos(m_pathPoints[i - 1], m_pathPoints[i], out, -0.1f))
-        {
-            m_pathPoints[i] = out;
-            m_pathPoints.resize(i + 1);
-            break;
-        }
 }
 
 float PathInfo::Length() const

--- a/src/game/Maps/PathFinder.h
+++ b/src/game/Maps/PathFinder.h
@@ -21,6 +21,7 @@
 
 #include "Path.h"
 #include "MoveMapSharedDefines.h"
+#include "../recastnavigation/Detour/Include/DetourCommon.h"
 #include "../recastnavigation/Detour/Include/DetourNavMesh.h"
 #include "../recastnavigation/Detour/Include/DetourNavMeshQuery.h"
 #include "MoveSplineInitArgs.h"
@@ -83,13 +84,14 @@ class PathInfo
         // Nostalrius
         bool UpdateForCaster(Unit* pTarget, float castRange);
         bool UpdateForMelee(Unit* pTarget, float meleeReach);
-        void CutPathWithDynamicLoS();
         float Length() const;
         void ExcludeSteepSlopes() { m_filter.setExcludeFlags(NAV_STEEP_SLOPES); }
         static dtPolyRef FindWalkPoly(dtNavMeshQuery const* query, float const* pointYZX, dtQueryFilter const& filter, float* closestPointYZX, float zSearchDist = 10.0f);
         void SetTransport(GenericTransport* t) { m_transport = t; }
         GenericTransport* GetTransport() const { return m_transport; }
         void FillTargetAllowedFlags(Unit* target);
+        static bool IntersectVolumeBox(const float* pa, const float* pb, const G3D::AABox& box);
+
     private:
 
         dtPolyRef       m_pathPolyRefs[MAX_PATH_LENGTH];   // array of detour polygon references
@@ -126,14 +128,14 @@ class PathInfo
         static float dist3DSqr(Vector3 const& p1, Vector3 const& p2);
         static bool inRangeYZX(float const* v1, float const* v2, float r, float h);
 
-        dtPolyRef getPolyByLocation(float const* point, float *distance, uint32 flags = 0);
+        dtPolyRef getPolyByLocation(float const* point, float *distance, dtQueryFilter* filter, uint32 flags = 0);
         bool HaveTiles(Vector3 const& p) const;
 
-        void BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos);
-        void BuildPointPath(float const* startPoint, float const* endPoint, float distToStartPoly, float distToEndPoly);
-        void BuildShortcut();
-        void BuildUnderwaterPath();
-        void BuildPathWithoutMMaps(Vector3 const& start, Vector3 const& dest); // build path using only maps following terrain (no vmap or mmap)
+        void BuildPolyPath(Vector3 const& startPos, Vector3 const& endPos, dtQueryFilter* filter);
+        void BuildPointPath(float const* startPoint, float const* endPoint, float distToStartPoly, float distToEndPoly, dtQueryFilter* filter);
+        void BuildShortcut(dtQueryFilter* filter);
+        void BuildUnderwaterPath(dtQueryFilter* filter);
+        void BuildPathWithoutMMaps(Vector3 const& start, Vector3 const& dest, dtQueryFilter* filter); // build path using only maps following terrain (no vmap or mmap)
 
         void createFilter();
         void updateFilter();
@@ -146,7 +148,50 @@ class PathInfo
                             unsigned char& steerPosFlag, dtPolyRef& steerPosRef) const;
         dtStatus findSmoothPath(float const* startPos, float const* endPos,
                                 dtPolyRef const* polyPath, uint32 polyPathSize,
-                                float* smoothPath, int* smoothPathSize, uint32 maxSmoothPathSize);
+                                float* smoothPath, int* smoothPathSize, uint32 maxSmoothPathSize, dtQueryFilter* filter);
+};
+
+class VolumeBoxFilter : public dtQueryFilter
+{
+public:
+    const Map* m_map;
+
+    VolumeBoxFilter(const Map* map) : m_map(map) {}
+
+    virtual bool passFilter(dtPolyRef ref, const dtMeshTile* tile, const dtPoly* poly) const override
+    {
+        if ((poly->flags & getIncludeFlags()) == 0)
+            return false;
+
+        if (poly->flags & getExcludeFlags())
+            return false;
+
+        float polyMin[3] = {FLT_MAX, FLT_MAX, FLT_MAX};
+        float polyMax[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+
+        for (int i = 0; i < poly->vertCount; ++i)
+        {
+            const float* vertex = &tile->verts[poly->verts[i] * 3];
+            for (int axis = 0; axis < 3; ++axis)
+            {
+                if (vertex[axis] < polyMin[axis])
+                    polyMin[axis] = vertex[axis];
+                if (vertex[axis] > polyMax[axis])
+                    polyMax[axis] = vertex[axis];
+            }
+        }
+
+        for (const auto& obj : m_map->GetVolumeCache())
+        {
+            if (!obj.enabled)
+                continue;
+
+            if (PathInfo::IntersectVolumeBox(polyMin, polyMax, obj.worldBounds))
+                return false;
+        }
+
+        return true;
+    }
 };
 
 typedef PathInfo PathFinder;

--- a/src/game/Maps/PathFinder.h
+++ b/src/game/Maps/PathFinder.h
@@ -166,18 +166,18 @@ public:
         if (poly->flags & getExcludeFlags())
             return false;
 
-        float polyMin[3] = {FLT_MAX, FLT_MAX, FLT_MAX};
-        float polyMax[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+        float boxMin[3] = {FLT_MAX, FLT_MAX, FLT_MAX};
+        float boxMax[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
 
         for (int i = 0; i < poly->vertCount; ++i)
         {
             const float* vertex = &tile->verts[poly->verts[i] * 3];
             for (int axis = 0; axis < 3; ++axis)
             {
-                if (vertex[axis] < polyMin[axis])
-                    polyMin[axis] = vertex[axis];
-                if (vertex[axis] > polyMax[axis])
-                    polyMax[axis] = vertex[axis];
+                if (vertex[axis] < boxMin[axis])
+                    boxMin[axis] = vertex[axis];
+                if (vertex[axis] > boxMax[axis])
+                    boxMax[axis] = vertex[axis];
             }
         }
 
@@ -186,7 +186,7 @@ public:
             if (!obj.enabled)
                 continue;
 
-            if (PathInfo::IntersectVolumeBox(polyMin, polyMax, obj.worldBounds))
+            if (PathInfo::IntersectVolumeBox(boxMin, boxMax, obj.worldBounds))
                 return false;
         }
 

--- a/src/game/Movement/ConfusedMovementGenerator.cpp
+++ b/src/game/Movement/ConfusedMovementGenerator.cpp
@@ -79,7 +79,6 @@ bool ConfusedMovementGenerator<T>::Update(T &unit, uint32 const& diff)
     path.ExcludeSteepSlopes();
     path.setPathLengthLimit(4.0f);
     path.calculate(x, y, z, false, true);
-    path.CutPathWithDynamicLoS();
 
     Movement::MoveSplineInit init(unit, "ConfusedMovementGenerator<T>::Update");
     init.Move(&path);

--- a/src/game/Movement/FearMovementGenerator.cpp
+++ b/src/game/Movement/FearMovementGenerator.cpp
@@ -38,7 +38,6 @@ void FearMovementGenerator<T>::_setTargetLocation(T &owner)
     path.ExcludeSteepSlopes();
     path.setPathLengthLimit(PATH_LENGTH_LIMIT);
     path.calculate(x, y, z);
-    path.CutPathWithDynamicLoS();
 
     if (path.getPathType() & PATHFIND_NOPATH)
     {

--- a/src/game/Movement/FleeingMovementGenerator.cpp
+++ b/src/game/Movement/FleeingMovementGenerator.cpp
@@ -56,7 +56,6 @@ void FleeingMovementGenerator<T>::_setTargetLocation(T &owner)
     path.ExcludeSteepSlopes();
     path.setPathLengthLimit(30.0f);
     path.calculate(x, y, z);
-    path.CutPathWithDynamicLoS();
     if (path.getPathType() & PATHFIND_NOPATH)
     {
         i_nextCheckTime.Reset(urand(1000, 1500));

--- a/src/game/Movement/TargetedMovementGenerator.cpp
+++ b/src/game/Movement/TargetedMovementGenerator.cpp
@@ -368,11 +368,14 @@ bool ChaseMovementGenerator<T>::Update(T &owner, uint32 const&  time_diff)
             {
                 if (!creature->HasExtraFlag(CREATURE_FLAG_EXTRA_CHASE_GEN_NO_BACKING) && !creature->IsPet() && !i_target.getTarget()->IsMoving())
                 {
-                    if (owner.IsWithinLOSInMap(i_target.getTarget()))
+                    if (m_bRecalculateTravel && TargetDeepInBounds(owner, i_target.getTarget()))
                     {
-                        if (m_bRecalculateTravel && TargetDeepInBounds(owner, i_target.getTarget()))
+                        if (owner.IsWithinLOSInMap(i_target.getTarget()))
                             DoBackMovement(owner, i_target.getTarget());
-                        else if (m_bCanSpread)
+                    }
+                    else if (m_bCanSpread)
+                    {
+                        if (owner.IsWithinLOSInMap(i_target.getTarget()))
                             DoSpreadIfNeeded(owner, i_target.getTarget());
                     }
                 }

--- a/src/game/Movement/TargetedMovementGenerator.cpp
+++ b/src/game/Movement/TargetedMovementGenerator.cpp
@@ -189,17 +189,6 @@ void ChaseMovementGenerator<T>::_setTargetLocation(T &owner)
     if (pathType == PATHFIND_NOPATH)
         return;
 
-    if (owner.IsPet())
-    {
-        // prevent pets from going through closed doors
-        path.CutPathWithDynamicLoS();
-        if (path.getPath().size() == 2 && path.Length() < 0.1f)
-        {
-            m_bReachable = false;
-            return;
-        }
-    }
-
     if (!m_bReachable && !!(pathType & PATHFIND_INCOMPLETE) && owner.HasUnitState(UNIT_STATE_ALLOW_INCOMPLETE_PATH))
         m_bReachable = true;
 
@@ -379,10 +368,13 @@ bool ChaseMovementGenerator<T>::Update(T &owner, uint32 const&  time_diff)
             {
                 if (!creature->HasExtraFlag(CREATURE_FLAG_EXTRA_CHASE_GEN_NO_BACKING) && !creature->IsPet() && !i_target.getTarget()->IsMoving())
                 {
-                    if (m_bRecalculateTravel && TargetDeepInBounds(owner, i_target.getTarget()))
-                        DoBackMovement(owner, i_target.getTarget());
-                    else if (m_bCanSpread)
-                        DoSpreadIfNeeded(owner, i_target.getTarget());
+                    if (owner.IsWithinLOSInMap(i_target.getTarget()))
+                    {
+                        if (m_bRecalculateTravel && TargetDeepInBounds(owner, i_target.getTarget()))
+                            DoBackMovement(owner, i_target.getTarget());
+                        else if (m_bCanSpread)
+                            DoSpreadIfNeeded(owner, i_target.getTarget());
+                    }
                 }
             }
         }

--- a/src/game/Objects/GameObject.cpp
+++ b/src/game/Objects/GameObject.cpp
@@ -127,12 +127,17 @@ void GameObject::AddToWorld()
             m_zoneScript->OnGameObjectCreate(this);
 
         if (m_model)
+        {
             GetMap()->InsertGameObjectModel(*m_model);
+
+            if (GetGoType() == GAMEOBJECT_TYPE_DOOR)
+                GetMap()->AddVolumeCacheEntry(GetObjectGuid(), m_model->getBounds(), m_model->collisionEnabled());
+        }
     }
     Object::AddToWorld();
 
     // After Object::AddToWorld so that for initial state the GO is added to the world (and hence handled correctly)
-    UpdateCollisionState();
+    UpdateCollisionState(true);
 
     if (!m_AI)
         AIM_Initialize();
@@ -157,6 +162,9 @@ void GameObject::RemoveFromWorld()
 
         if (m_zoneScript)
             m_zoneScript->OnGameObjectRemove(this);
+
+        if (GetGoType() == GAMEOBJECT_TYPE_DOOR)
+            GetMap()->RemoveVolumeCacheEntry(GetObjectGuid());
 
         RemoveAllDynObjects();
 
@@ -2249,14 +2257,14 @@ void GameObject::SetLootState(LootState state)
     }
 
     m_lootState = state;
-    UpdateCollisionState();
+    UpdateCollisionState(false);
 }
 
 void GameObject::SetGoState(GOState state)
 {
     //SetByteValue(GAMEOBJECT_BYTES_1, 0, state); // 3.3.5
     SetUInt32Value(GAMEOBJECT_STATE, state);
-    UpdateCollisionState();
+    UpdateCollisionState(true);
 }
 
 void GameObject::SetDisplayId(uint32 modelId)
@@ -2347,13 +2355,24 @@ bool GameObject::HasStaticDBSpawnData() const
     return sObjectMgr.GetGOData(GetGUIDLow()) != nullptr;
 }
 
-void GameObject::UpdateCollisionState()
+void GameObject::UpdateCollisionState(bool polyCull)
 {
     if (!m_model || !IsInWorld())
         return;
 
     bool enabled = GetGoType() == GAMEOBJECT_TYPE_CHEST ? getLootState() == GO_READY : GetGoState() == GO_STATE_READY;
     m_model->enable(enabled);
+
+    if (polyCull)
+    {
+        if (GetGoType() == GAMEOBJECT_TYPE_DOOR && GetMap()) // Currently we only use this system for doors
+        {
+            if (GetGoState() == GO_STATE_READY)
+                GetMap()->SetVolumeCollisionState(GetObjectGuid(), true);
+            else
+                GetMap()->SetVolumeCollisionState(GetObjectGuid(), false);
+        }
+    }
 }
 
 void GameObject::UpdateModel()

--- a/src/game/Objects/GameObject.h
+++ b/src/game/Objects/GameObject.h
@@ -225,7 +225,7 @@ class GameObject : public SpellCaster
         void AIM_Initialize();
         GameObjectAI* AI() { return m_AI; }
 
-        void UpdateCollisionState();
+        void UpdateCollisionState(bool polyCull = false);
         void UpdateModel();                                 // updates model in case displayId were changed
         GameObjectModel* m_model;
         void UpdateModelPosition();
@@ -259,6 +259,7 @@ class GameObject : public SpellCaster
         bool IsAtInteractDistance(Player const* player, uint32 maxRange = 0) const;
 
         SpellEntry const* GetSpellForLock(Player const* player) const;
+
     protected:
         bool        m_visible;
         uint32      m_spellId;

--- a/src/game/vmap/GameObjectModel.h
+++ b/src/game/vmap/GameObjectModel.h
@@ -60,6 +60,7 @@ class GameObjectModel
         /** Enables\disables collision. */
         void disable() { collision_enabled = false;}
         void enable(bool enabled) { collision_enabled = enabled;}
+        bool collisionEnabled() const { return collision_enabled; }
 
         bool intersectRay(G3D::Ray const& ray, float& MaxDist, bool StopAtFirstHit, bool ignoreM2Model) const;
 


### PR DESCRIPTION
This commit adds volume collision caching. This caches object bounding boxes on AddToWorld and used in dtNavMeshQuery filter construction, allowing dynamic collision to be calculated. This system is done as efficiently as possible, using small vectors with Slab Method calculation to determine movepoints and whether or not they fall within bounds for an object within that specific map instance.

This PR enables DT Virtual Functions in order to override passFilter checks where the volume collision is culled. Currently, we use dynamic ray casting at each movepoint to determine collision with CutPathWithDynamicLoS(); this new system requires no raycasting, which should yield a performance increase in all movement functions.

Currently, only door objects are flagged to be cached; this can be updated to include more object types if necessary.