### PR TITLE
Correct Revive Pet and Call Pet behavior.

### DIFF
--- a/src/game/Objects/Pet.cpp
+++ b/src/game/Objects/Pet.cpp
@@ -553,7 +553,7 @@ void Pet::SavePetToDB(PetSaveMode mode)
         savePet.addUInt32(uint32(mode));
         savePet.addString(m_name);
         savePet.addUInt32(uint32(HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_RENAME) ? 0 : 1));
-        savePet.addUInt32((curhealth < 1 ? 1 : curhealth));
+        savePet.addUInt32(curhealth);
         savePet.addUInt32(curmana);
         savePet.addUInt32(GetPower(POWER_HAPPINESS));
 

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -22,6 +22,7 @@
 #include "Spell.h"
 #include "Log.h"
 #include "Opcodes.h"
+#include "CharacterDatabaseCache.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
 #include "World.h"
@@ -6108,11 +6109,45 @@ SpellCastResult Spell::CheckCast(bool strict)
             case SPELL_EFFECT_SUMMON_DEAD_PET:
             {
                 Creature* pet = m_casterUnit ? m_casterUnit->GetPet() : nullptr;
-                if (!pet)
-                    return SPELL_FAILED_NO_PET;
+                Player* player = m_caster->ToPlayer();
 
-                if (pet->IsAlive())
-                    return SPELL_FAILED_ALREADY_HAVE_SUMMON;
+                if (pet)
+                {
+                    if (pet->IsAlive())
+                    {
+                        if (player)
+                            player->SendPetTameFailure(PETTAME_ANOTHERSUMMONACTIVE);
+                        return SPELL_FAILED_DONT_REPORT;
+                    }
+
+                    // Remove dead pet corpse before revive
+                    if (Pet* petObj = pet->ToPet())
+                        petObj->Unsummon(PET_SAVE_AS_CURRENT, player);
+
+                    break;
+                }
+
+                // No active pet - check database
+                if (player)
+                {
+                    CharacterPetCache* currentPet = sCharacterDatabaseCache.GetCharacterPetByOwner(player->GetGUIDLow());
+                    if (!currentPet)
+                    {
+                        player->SendPetTameFailure(PETTAME_NOPETAVAILABLE);
+                        return SPELL_FAILED_DONT_REPORT;
+                    }
+
+                    if (currentPet->currentHealth > 0)
+                    {
+                        player->SendPetTameFailure(PETTAME_NOTDEAD);
+                        return SPELL_FAILED_DONT_REPORT;
+                    }
+                    // Pet is dead in DB - allow revive
+                }
+                else
+                {
+                    return SPELL_FAILED_NO_PET;
+                }
 
                 break;
             }

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -22,6 +22,7 @@
 #include "Common.h"
 #include "SharedDefines.h"
 #include "WorldPacket.h"
+#include "CharacterDatabaseCache.h"
 #include "Opcodes.h"
 #include "Log.h"
 #include "World.h"
@@ -3145,6 +3146,27 @@ ObjectGuid Unit::EffectSummonPet(uint32 spellId, uint32 petEntry, uint32 petLeve
         return ObjectGuid();
     }
 
+    // Check database for current pet before attempting to load
+    if (GetTypeId() == TYPEID_PLAYER && !petEntry)
+    {
+        Player* player = (Player*)this;
+        CharacterPetCache* currentPet = sCharacterDatabaseCache.GetCharacterPetByOwner(player->GetGUIDLow());
+
+        if (!currentPet)
+        {
+            // No pet at all
+            player->SendPetTameFailure(PETTAME_NOPETAVAILABLE);
+            return ObjectGuid();
+        }
+
+        if (currentPet->currentHealth == 0)
+        {
+            // Pet is dead
+            player->SendPetTameFailure(PETTAME_DEAD);
+            return ObjectGuid();
+        }
+    }
+
     Pet* newSummon = new Pet;
 
     // petEntry==0 for hunter "call pet" (current pet summoned if any)
@@ -5466,27 +5488,31 @@ void Spell::EffectSummonDeadPet(SpellEffectIndex /*effIdx*/)
     if (!player)
         return;
 
-    Pet* pet = player->GetPet();
-    if (!pet)
+    // Load pet from database (corpse already despawned in CheckCast)
+    CharacterPetCache* currentPet = sCharacterDatabaseCache.GetCharacterPetByOwner(player->GetGUIDLow());
+    if (!currentPet)
         return;
-    if (pet->IsAlive())
+
+    Pet* newPet = new Pet;
+    if (!newPet->LoadPetFromDB(player, currentPet->entry, currentPet->id))
+    {
+        delete newPet;
         return;
+    }
 
     if (damage < 0)
         return;
 
-    // Chakor : Teleport the pet to the player's location
-    pet->NearTeleportTo(player->GetPosition(), false);
-    pet->SetUInt32Value(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_NONE);
-    pet->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);
-    pet->SetDeathState(ALIVE);
-    pet->ClearUnitState(UNIT_STATE_ALL_DYN_STATES);
-    pet->SetHealth(uint32(pet->GetMaxHealth() * (damage / 100)));
+    // Transition pet from dead to alive state
+    newPet->SetUInt32Value(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_NONE);
+    newPet->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);
+    newPet->SetDeathState(ALIVE);
+    newPet->ClearUnitState(UNIT_STATE_ALL_DYN_STATES);
+    newPet->SetHealth(uint32(newPet->GetMaxHealth() * damage / 100));
 
-    pet->AIM_Initialize();
+    newPet->AIM_Initialize();
 
-    // player->PetSpellInitialize(); -- action bar not removed at death and not required send at revive
-    pet->SavePetToDB(PET_SAVE_AS_CURRENT);
+    newPet->SavePetToDB(PET_SAVE_AS_CURRENT);
 }
 
 void Spell::EffectDestroyAllTotems(SpellEffectIndex /*effIdx*/)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR corrects the behavior of Revive Pet and Call Pet.

Previously in order to resurrect a dismissed pet, you would first have to summon its corpse by call pet and then revive it. 

Now Revive Pet is able to summon and revive dead pets.
You also are no longer able to summon dead pets with Call pet.

For whatever reason dead pet HP was always set to 1 in DB, which was originally added here back in 2007: https://github.com/cmangos/mangos-svn/commit/823e4136a53ef434b7a840eb14aaeb509957b377#diff-c592a4ca54e33e96ee02439b0966d6d45a6c6a5167461c5db21bdb35915ce0dc

This PR fixes that 19 year old bug as well.

Fixes all issues report in https://github.com/vmangos/core/issues/1669 except correct stable master handling, but that will be handled in another issue and possibly a future PR as it still requires more research (this PR does not change or impact any current stable master handling)

### Proof
<!-- Link resources as proof -->
- See linked issue, proof is vanilla videos and testing on classic PTR (a few years back)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/vmangos/core/issues/1669

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- See steps in linked issue.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
