### PR TITLE
Improve map extraction tools and fix navmesh generation bugs

### DIFF
--- a/contrib/extractor/System.cpp
+++ b/contrib/extractor/System.cpp
@@ -19,6 +19,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include <stdio.h>
+#include <cstring>
 #include <deque>
 #include <set>
 #include <cstdlib>
@@ -83,6 +84,8 @@ enum Extract
 
 // Select data for extract
 int   CONF_extract = EXTRACT_MAP | EXTRACT_DBC | EXTRACT_CAMERA;
+// Skip all interactive prompts (for scripted runs)
+bool  CONF_silent = false;
 // This option allow limit minimum height to some value (Allow save some memory)
 // see contrib/mmap/src/TerrainBuilder.h, INVALID_MAP_LIQ_HEIGHT
 bool  CONF_allow_height_limit = true;
@@ -135,6 +138,7 @@ void Usage(char* prg)
         "-o set output path\n"\
         "-e extract only MAP(1)/DBC(2)/Camera(4) - standard: all(7)\n"\
         "-f height stored as int (less map size but lost some accuracy) 1 by default\n"\
+        "--silent skip all interactive prompts (for scripted runs)\n"\
         "Example: %s -f 0 -i \"c:\\games\\game\"", prg, prg);
     exit(1);
 }
@@ -148,6 +152,12 @@ void HandleArgs(int argc, char* arg[])
         // e - extract only MAP(1)/DBC(2) - standard both(3)
         // f - use float to int conversion
         // h - limit minimum height
+        if (strcmp(arg[c], "--silent") == 0)
+        {
+            CONF_silent = true;
+            continue;
+        }
+
         if (arg[c][0] != '-')
             Usage(arg[0]);
 
@@ -911,6 +921,39 @@ int main(int argc, char* arg[])
 
     HandleArgs(argc, arg);
 
+    // Prompt user for map resolution (skipped with --silent, keeping the command line settings)
+    bool highRes = !CONF_allow_float_to_int;
+    bool fullHeight = !CONF_allow_height_limit;
+
+    if (!CONF_silent)
+    {
+        std::string userInput;
+        std::cout << "Extract maps with high resolution (default = " << (highRes ? "y" : "n") << ")? [y/n]" << std::endl;
+        std::getline(std::cin, userInput);
+        if (!userInput.empty())
+            highRes = userInput.compare("y") == 0;
+
+        userInput.clear();
+        std::cout << "Extract maps with full height (default = " << (fullHeight ? "y" : "n") << ")? [y/n]" << std::endl;
+        std::getline(std::cin, userInput);
+        if (!userInput.empty())
+            fullHeight = userInput.compare("y") == 0;
+    }
+
+    std::cout << "High resolution = " << highRes << std::endl;
+    std::cout << "Full height     = " << fullHeight << std::endl;
+
+    if (!CONF_silent)
+    {
+        std::cout << "Press enter to start extracting maps." << std::endl;
+        std::cout << "=====================================" << std::endl;
+        std::cin.get();
+    }
+
+    // Overwrite due to user input or explicit setting
+    CONF_allow_float_to_int = highRes ? false : true;
+    CONF_allow_height_limit = fullHeight ? false : true;
+
     // Open MPQs
     LoadCommonMPQFiles();
 
@@ -927,6 +970,12 @@ int main(int argc, char* arg[])
 
     // Close MPQs
     CloseMPQFiles();
+
+    if (!CONF_silent)
+    {
+        std::cout << "Extraction complete. Press enter to close..." << std::endl;
+        std::cin.get();
+    }
 
     return 0;
 }

--- a/contrib/mmap/config.json
+++ b/contrib/mmap/config.json
@@ -1,14 +1,15 @@
 {
-	"_example_map_ID_override":
+	"_Info": "Map overrides: top-level key = numeric map ID (e.g. \"0\" = Eastern Kingdoms). Rename '_map_override_template' to a map ID to activate it.",
+	"_Info2": "Tile overrides: key inside a map object = zero-padded tileX+tileY, e.g. tile (3,7) -> \"0307\". Omitted parameters use the compiled-in defaults.",
+	"_Info3": "walkableClimbModelTransition: max step height (voxels) at terrain<->model transitions; 0 = same as walkableClimb.",
+	"_map_override_template":
 	{
-		"_Info": "Map-level override: replace the key name with a numeric map ID (e.g. \"0\" for Eastern Kingdoms).",
-		"_Info2": "Any parameter listed below can be set here; omitted parameters use the compiled-in defaults.",
 		"walkableSlopeAngle":      75.0,
 		"walkableSlopeAngleVMaps": 61.0,
 		"walkableRadius":          2,
 		"walkableClimb":           0,
-		"walkableHeight":          0,
 		"walkableClimbModelTransition": 0,
+		"walkableHeight":          0,
 		"borderSize":              5,
 		"maxEdgeLen":              45,
 		"maxSimplificationError":  1.8,
@@ -18,14 +19,10 @@
 		"detailSampleMaxError":    0.5,
 		"quick":                   -1,
 
-		"_example_tile_override":
+		"0307":
 		{
-			"_Info": "Tile-level override: key is zero-padded tileX+tileY, e.g. tile (3,7) -> \"0307\".",
-			"_Info2": "Overrides the map-level values for that specific tile only.",
-			"0307":
-			{
-				"walkableSlopeAngle": 50.0
-			}
+			"_Info": "Tile-level override for tile (3,7): sits directly inside the map object and replaces its values for that tile only.",
+			"walkableSlopeAngle": 50.0
 		}
 	}
 }

--- a/contrib/mmap/config.json
+++ b/contrib/mmap/config.json
@@ -1,12 +1,31 @@
 {
-	"0": {
-		"3147": {
-			"maxSimplificationError": 1.0,
-			"detailSampleDist": 0.5,
-			"_Info": "stomrwind keep - pathing guard"
-		},
-		"3050": {
-			"_Info": "TODO:westbrook garrison"
+	"_example_map_ID_override":
+	{
+		"_Info": "Map-level override: replace the key name with a numeric map ID (e.g. \"0\" for Eastern Kingdoms).",
+		"_Info2": "Any parameter listed below can be set here; omitted parameters use the compiled-in defaults.",
+		"walkableSlopeAngle":      75.0,
+		"walkableSlopeAngleVMaps": 61.0,
+		"walkableRadius":          2,
+		"walkableClimb":           0,
+		"walkableHeight":          0,
+		"walkableClimbModelTransition": 0,
+		"borderSize":              5,
+		"maxEdgeLen":              45,
+		"maxSimplificationError":  1.8,
+		"mergeRegionArea":         10,
+		"minRegionArea":           30,
+		"detailSampleDist":        2.0,
+		"detailSampleMaxError":    0.5,
+		"quick":                   -1,
+
+		"_example_tile_override":
+		{
+			"_Info": "Tile-level override: key is zero-padded tileX+tileY, e.g. tile (3,7) -> \"0307\".",
+			"_Info2": "Overrides the map-level values for that specific tile only.",
+			"0307":
+			{
+				"walkableSlopeAngle": 50.0
+			}
 		}
 	}
 }

--- a/contrib/mmap/offmesh.txt
+++ b/contrib/mmap/offmesh.txt
@@ -1,7 +1,7 @@
 // Format: mapID tileX,tileY (start_x start_y start_z) (end_x end_y end_z) size
 //   size: width/radius of the connection path
-30 32,33 (-759.16 -350.45 68.96) (-758.2 -348.56 67.56) 2.5                          // AV - Tower entrance
-30 32,33 (-761.69 -349.45 69.0) (-761 -347.83 67.61) 2.5                             // AV - Tower entrance
-30 32,33 (-765.1 -348 69) (-764.53 -346.58 67.66) 2.5                                // AV - Tower entrance
-189 29,28 (1827.839478 1315.610962 17.235508) (1830.25244 1315.189697 19.016930) 2.5 // Scarlet Monastery Graveyard - path out of spawn position
-36 33,32 (-23.427919 -797.150940 20.145432) (-23.941082 -797.715393 19.456278) 2.5   // The Deadmines - Mr. Smite ship -> bridge
+// Endpoints must lie strictly inside a navmesh polygon (e.g. on a poly centroid) - points
+// next to a poly get clamped onto its boundary edge at link time, and a connection whose
+// endpoints resolve to the same poly is a dead self-loop A* never uses.
+189 29,28 (1827.839478 1315.610962 17.235508) (1830.25244 1315.189697 19.016930) 2.5  // Scarlet Monastery Graveyard - path out of spawn position
+0 31,59 (-14425.5 448.4 15.1) (-14426.576 450.133 15.529) 2.5                         // Booty Bay: dock stairs top -> boardwalk (mesh gap between stair poly and boardwalk poly)

--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -16,6 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <cctype>
+#include <cstdlib>
 #include <fstream>
 #include "MMapCommon.h"
 #include "MapBuilder.h"
@@ -42,16 +44,30 @@ namespace MMAP
         m_terrainBuilder(nullptr),
         m_debug(debug),
         m_offMeshFilePath(offMeshFilePath),
+        m_skipLiquid(skipLiquid),
         m_skipContinents(skipContinents),
         m_skipJunkMaps(skipJunkMaps),
         m_skipBattlegrounds(skipBattlegrounds),
         m_quick(quick),
         m_rcContext(nullptr),
+        m_cancel(false),
+        m_anyError(false),
         m_threads(threads)
     {
         std::ifstream jsonConfig(configInputPath);
         if (jsonConfig)
-            m_config = json::parse(jsonConfig);
+        {
+            try
+            {
+                m_config = json::parse(jsonConfig);
+            }
+            catch (json::parse_error const& e)
+            {
+                printf("Failed to parse %s: %s\n", configInputPath, e.what());
+                exit(EXIT_FAILURE);
+            }
+            validateConfig(configInputPath);
+        }
 
         m_terrainBuilder = new TerrainBuilder(skipLiquid, quick);
 
@@ -64,6 +80,68 @@ namespace MMAP
     {
         delete m_terrainBuilder;
         delete m_rcContext;
+    }
+
+    void MapBuilder::validateConfig(char const* configInputPath)
+    {
+        json const defaults = TileWorker::getDefaultConfig();
+
+        // keys starting with '_' are comments ("_Info"); nested objects are tile
+        // overrides and are checked separately by the caller
+        auto checkParams = [&](json const& section, std::string const& where)
+        {
+            for (json::const_iterator it = section.begin(); it != section.end(); ++it)
+            {
+                if (!it.key().empty() && it.key()[0] == '_')
+                    continue;
+                if (it.value().is_object())
+                    continue;
+                if (defaults.find(it.key()) == defaults.end())
+                {
+                    printf("%s: unknown parameter '%s' in %s will be ignored!\n", configInputPath, it.key().c_str(), where.c_str());
+                    continue;
+                }
+                if (!it.value().is_number() && !it.value().is_boolean())
+                {
+                    // a non-numeric value would throw inside a worker thread later,
+                    // which terminates the process without any context
+                    printf("%s: parameter '%s' in %s must be a number!\n", configInputPath, it.key().c_str(), where.c_str());
+                    exit(EXIT_FAILURE);
+                }
+            }
+        };
+
+        for (json::const_iterator mapIt = m_config.begin(); mapIt != m_config.end(); ++mapIt)
+        {
+            if (!mapIt.value().is_object())
+            {
+                printf("%s: entry '%s' is not a map config object!\n", configInputPath, mapIt.key().c_str());
+                exit(EXIT_FAILURE);
+            }
+
+            std::string const mapWhere = "map " + mapIt.key();
+            checkParams(mapIt.value(), mapWhere);
+
+            for (json::const_iterator it = mapIt.value().begin(); it != mapIt.value().end(); ++it)
+            {
+                if (!it.value().is_object() || (!it.key().empty() && it.key()[0] == '_'))
+                    continue;
+
+                // tile override keys must match the zero-padded "XXYY" format built
+                // by TileWorker::getTileConfig, otherwise they never apply
+                std::string const& key = it.key();
+                bool validKey = key.size() == 4;
+                for (uint32 c = 0; c < key.size() && validKey; ++c)
+                {
+                    if (!isdigit(static_cast<unsigned char>(key[c])))
+                        validKey = false;
+                }
+                if (!validKey)
+                    printf("%s: tile key '%s' in %s is not in zero-padded XXYY format and will never match a tile!\n", configInputPath, key.c_str(), mapWhere.c_str());
+
+                checkParams(it.value(), mapWhere + " tile " + key);
+            }
+        }
     }
 
     void MapBuilder::discoverTiles()
@@ -172,7 +250,7 @@ namespace MMAP
         std::vector<std::unique_ptr<TileWorker>> workers;
         for (uint8 i = 0; i < m_threads; ++i)
         {
-            workers.emplace_back(std::make_unique<TileWorker>(this, false, m_quick, m_debug, m_config));
+            workers.emplace_back(std::make_unique<TileWorker>(this, m_skipLiquid, m_quick, m_debug, m_config));
         }
 
         while (!m_tileQueue.Empty() && !m_cancel.load())
@@ -245,16 +323,18 @@ namespace MMAP
             uint32 minX, minY, maxX, maxY;
             getGridBounds(mapID, minX, minY, maxX, maxY);
 
-            // Only add the requested tile to avoid allocating NavMesh for entire map
-            // when building a single tile (which would cause massive memory overhead).
-            if (tileX >= minX && tileX <= maxX && tileY >= minY && tileY <= maxY)
-                tiles.insert(StaticMapTree::packTileID(tileX, tileY));
-        }
+            // Add all tiles within bounds - buildNavMesh derives the .mmap header
+            // (orig, maxTiles) from this list, and a header derived from a single
+            // tile would not match .mmtile files written by an earlier full build.
+            for (uint32 i = minX; i <= maxX; ++i)
+                for (uint32 j = minY; j <= maxY; ++j)
+                    tiles.insert(StaticMapTree::packTileID(i, j));
 
-        if (!tiles.size())
-        {
-            printf("[Map %03i] Tile [%02u,%02u] not found in valid tile range!\n", mapID, tileX, tileY);
-            return;
+            if (!tiles.count(StaticMapTree::packTileID(tileX, tileY)))
+            {
+                printf("[Map %03i] Tile [%02u,%02u] not found in valid tile range!\n", mapID, tileX, tileY);
+                return;
+            }
         }
 
         dtNavMesh* navMesh = nullptr;

--- a/contrib/mmap/src/MapBuilder.h
+++ b/contrib/mmap/src/MapBuilder.h
@@ -96,9 +96,16 @@ namespace MMAP
 
             bool IsBusy();
 
+            // true if any tile failed to build - lets the process exit non-zero
+            // instead of pretending the run succeeded
+            bool HasErrors() const { return m_anyError.load(); }
+
         private:
             // detect maps and tiles
             void discoverTiles();
+            // warn about unknown config.json keys and reject non-numeric values that
+            // would otherwise throw (and std::terminate) inside a worker thread
+            void validateConfig(char const* configInputPath);
             std::set<uint32>& getTileList(uint32 mapID);
 
             void buildMap(uint32 mapID);
@@ -116,6 +123,7 @@ namespace MMAP
             bool m_debug;
 
             const char* m_offMeshFilePath;
+            bool m_skipLiquid;
             bool m_skipContinents;
             bool m_skipJunkMaps;
             bool m_skipBattlegrounds;
@@ -128,6 +136,7 @@ namespace MMAP
             mutable std::mutex m_tilesMutex;
             ProducerConsumerQueue<TileInfo> m_tileQueue;
             std::atomic<bool> m_cancel;
+            std::atomic<bool> m_anyError;
             uint8 m_threads;
     };
 }

--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -31,7 +31,7 @@ static void IgnoreResult(T const&)
 
 namespace MMAP
 {
-    TerrainBuilder::TerrainBuilder(bool skipLiquid, bool quick) : m_skipLiquid(skipLiquid), m_V9(nullptr), m_V8(nullptr), m_quick(quick), m_mapId(0) { }
+    TerrainBuilder::TerrainBuilder(bool skipLiquid, bool quick) : m_skipLiquid(skipLiquid), m_V9(nullptr), m_V8(nullptr), m_heightDataValid(false), m_heightDataTileX(0), m_heightDataTileY(0), m_quick(quick), m_mapId(0) { }
     TerrainBuilder::~TerrainBuilder()
     {
         if (m_V8)
@@ -82,6 +82,9 @@ namespace MMAP
     /**************************************************************************/
     void TerrainBuilder::loadMap(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData)
     {
+        // invalidate before loading: if this tile has no terrain (or no .map file at
+        // all), getHeight() must not answer with the previous tile's heights
+        m_heightDataValid = false;
         if (loadMap(mapID, tileX, tileY, meshData, ENTIRE))
         {
             loadMap(mapID, tileX + 1, tileY, meshData, LEFT);
@@ -191,6 +194,9 @@ namespace MMAP
                     m_V9 = new float[V9_SIZE_SQ];
                 memcpy(m_V8, V8, V8_SIZE_SQ * sizeof(float));
                 memcpy(m_V9, V9, V9_SIZE_SQ * sizeof(float));
+                m_heightDataValid = true;
+                m_heightDataTileX = tileX;
+                m_heightDataTileY = tileY;
             }
 
             int count = meshData.solidVerts.size() / 3;
@@ -251,8 +257,11 @@ namespace MMAP
                 }
                 else
                 {
+                    // uniform liquid over the whole tile - the type is taken from the
+                    // header, so it counts as loaded (otherwise useLiquid is never set)
                     std::fill_n(&liquid_entry[0][0], 16 * 16, lheader.liquidType);
                     std::fill_n(&liquid_flags[0][0], 16 * 16, lheader.liquidFlags);
+                    liquid_type_loaded = true;
                 }
 
                 if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
@@ -751,12 +760,20 @@ namespace MMAP
         meshData.vmapLastTriangle = meshData.solidTris.size() / 3;
         if (m_quick)
             return true;
-        float* terrainInsideModelsVerts = new float[meshData.solidVerts.size()];
-        for (int i = 0; i < meshData.solidVerts.size(); ++i)
+        // only terrain vertices (the first mapVertsCount / 3 entries of solidVerts) are
+        // ever marked; model vertices and the vertices appended by the clipping pass
+        // below are never "inside a model" - insideDist() answers -1 for them
+        int const terrainVertsCount = mapVertsCount / 3;
+        float* terrainInsideModelsVerts = new float[terrainVertsCount];
+        for (int i = 0; i < terrainVertsCount; ++i)
             terrainInsideModelsVerts[i] = -1.0f;
+        auto insideDist = [&](int vertIdx) -> float
+        {
+            return vertIdx < terrainVertsCount ? terrainInsideModelsVerts[vertIdx] : -1.0f;
+        };
         for (uint32 i = 0; i < count; ++i)
         {
-            ModelInstance instance = models[i];
+            ModelInstance& instance = models[i];
 
             // model instances exist in tree even though there are instances of that model in this tile
             std::shared_ptr<WorldModel> worldModel = instance.getWorldModel();
@@ -772,6 +789,11 @@ namespace MMAP
             // transform data
             float scale = instance.iScale;
             G3D::Matrix3 rotation = G3D::Matrix3::fromEulerAnglesXYZ(G3D::pi() * instance.iRot.z / -180.f, G3D::pi() * instance.iRot.x / -180.f, G3D::pi() * instance.iRot.y / -180.f);
+            G3D::Matrix3 rotationInv = rotation.inverse();
+            // world up transformed into model space, scaled so intersection distances
+            // come back in world units - same convention as ModelInstance::isUnderModel,
+            // otherwise the thresholds below are wrong for tilted or scaled instances
+            Vector3 up = Vector3::unitZ() * rotationInv / scale;
             Vector3 position = instance.iPos;
             position.x -= 32 * GRID_SIZE;
             position.y -= 32 * GRID_SIZE;
@@ -779,25 +801,28 @@ namespace MMAP
             /// Check every map vertice
             // x, y * -1
 
-            for (vector<GroupModel>::iterator it = groupModels.begin(); it != groupModels.end(); ++it)
-                for (int t = 0; t < mapVertsCount / 3; ++t)
-                {
-                    // y, z, x
-                    Vector3 v(meshData.solidVerts[3*t+2], meshData.solidVerts[3*t], meshData.solidVerts[3*t+1] + 0.2f);
-                    v.x *= -1.f;
-                    v.y *= -1.f;
-                    v -= position;
-                    v = v * rotation.inverse() / scale;
+            for (int t = 0; t < terrainVertsCount; ++t)
+            {
+                // y, z, x
+                Vector3 v(meshData.solidVerts[3*t+2], meshData.solidVerts[3*t], meshData.solidVerts[3*t+1] + 0.2f);
+                v.x *= -1.f;
+                v.y *= -1.f;
+                v -= position;
+                v = v * rotationInv / scale;
 
+                for (vector<GroupModel>::iterator it = groupModels.begin(); it != groupModels.end(); ++it)
+                {
                     float outDist = -1.0f;
                     float inDist  = -1.0f;
-                    if (it->IsUnderObject(v, Vector3::unitZ(), isM2, &outDist, &inDist)) // up // inDist < outDist
+                    if (it->IsUnderObject(v, up, isM2, &outDist, &inDist)) // up // inDist < outDist
                     {
                         //if there are less than 5.0y between terrain and model then mark the terrain as unwalkable
-                        if (inDist < 5.0f)
+                        // several models/groups may cover this vertex - keep the closest one
+                        if (inDist < 5.0f && (terrainInsideModelsVerts[t] < 0.0f || inDist < terrainInsideModelsVerts[t]))
                             terrainInsideModelsVerts[t] = inDist;
                     }
                 }
+            }
         }
         /// Correct triangles partially under models
         for (int i = 0; i < mapTrisCount / 3; ++i)
@@ -808,14 +833,17 @@ namespace MMAP
             for (int j = 0; j < 3; ++j)
             {
                 vertIdx[j]     = meshData.solidTris[i*3+j];
-                if (vertIdx[j] < mapVertsCount)
-                    insideModel[j] = (terrainInsideModelsVerts[vertIdx[j]] >= 0.1f);
+                insideModel[j] = (insideDist(int(vertIdx[j])) >= 0.1f);
                 tri[j]         = Vector3(meshData.solidVerts[3*vertIdx[j]+2], meshData.solidVerts[3*vertIdx[j]], meshData.solidVerts[3*vertIdx[j]+1]);
             }
 
             // First case: nothing to do =)
-            if (terrainInsideModelsVerts[vertIdx[0]] < 1.0f && terrainInsideModelsVerts[vertIdx[1]] < 1.0f && terrainInsideModelsVerts[vertIdx[2]] < 1.0f)
+            if (insideDist(int(vertIdx[0])) < 1.0f && insideDist(int(vertIdx[1])) < 1.0f && insideDist(int(vertIdx[2])) < 1.0f)
                 continue;
+            // Known gap: one vertex >= 1.0 with the others in [0.1, 1.0) passes the gate
+            // above but all corners count as "inside" here, so the triangle is neither
+            // clipped nor removed by the pass below (which requires >= 1.0 on all three).
+            // Low-clearance leftovers are culled later by rcFilterWalkableLowHeightSpans.
             if (insideModel[0] == insideModel[1] && insideModel[1] == insideModel[2])
                 continue;
 
@@ -904,9 +932,8 @@ namespace MMAP
             bool    allInBorder = true;
             for (int j = 0; j < 3; ++j)
             {
-                if (meshData.solidTris[i*3+j] < mapVertsCount)
-                    insideModel[j] = (terrainInsideModelsVerts[meshData.solidTris[i*3+j]] >= 1.0f);
-                if (terrainInsideModelsVerts[meshData.solidTris[i*3+j]] >= 1.5f)
+                insideModel[j] = (insideDist(meshData.solidTris[i*3+j]) >= 1.0f);
+                if (insideDist(meshData.solidTris[i*3+j]) >= 1.5f)
                     allInBorder = false;
             }
 
@@ -1078,18 +1105,23 @@ namespace MMAP
 
     float TerrainBuilder::getHeight(float x, float y) const
     {
-        if (!m_V8 || !m_V9)
+        if (!m_heightDataValid || !m_V8 || !m_V9)
             return -50000;
 
-        x = MAP_RESOLUTION * (32 - x / GRID_SIZE);
-        y = MAP_RESOLUTION * (32 - y / GRID_SIZE);
+        // make the position local to the loaded tile (first param runs along the
+        // m_heightDataTileY axis, second along m_heightDataTileX - see getHeightCoord).
+        // Positions outside the tile (border skirt, models leaning over the tile edge)
+        // have no height data here - they must not wrap around to the opposite border.
+        x = MAP_RESOLUTION * (32 - x / GRID_SIZE) - float(m_heightDataTileY) * MAP_RESOLUTION;
+        y = MAP_RESOLUTION * (32 - y / GRID_SIZE) - float(m_heightDataTileX) * MAP_RESOLUTION;
+
+        if (x < 0.0f || y < 0.0f || x >= float(MAP_RESOLUTION) || y >= float(MAP_RESOLUTION))
+            return -50000;
 
         int x_int = (int)x;
         int y_int = (int)y;
         x -= x_int;
         y -= y_int;
-        x_int &= (MAP_RESOLUTION - 1);
-        y_int &= (MAP_RESOLUTION - 1);
 
         // Height stored as: h5 - its v8 grid, h1-h4 - its v9 grid
         // +--------------> X

--- a/contrib/mmap/src/TerrainBuilder.h
+++ b/contrib/mmap/src/TerrainBuilder.h
@@ -145,6 +145,11 @@ namespace MMAP
             TerrainBuilder(const TerrainBuilder& tb);
             float* m_V9;
             float* m_V8;
+            /// m_V9/m_V8 hold data of exactly one tile - getHeight() must know which
+            /// one, and must not serve stale data from a previously built tile
+            bool m_heightDataValid;
+            uint32 m_heightDataTileX;
+            uint32 m_heightDataTileY;
             bool m_quick;
             uint32 m_mapId;
             VMAP::VMapManager2 vmapManager;

--- a/contrib/mmap/src/TileWorker.cpp
+++ b/contrib/mmap/src/TileWorker.cpp
@@ -482,7 +482,9 @@ namespace MMAP
         if (config.walkableClimb == 0)
             config.walkableClimb = (int)floorf(agentMaxClimbModelTerrainTransition / config.ch); // For models
         uint32 walkableClimbTerrain = (int)floorf(agentMaxClimbTerrain / config.ch);
-        uint32 walkableClimbModelTransition = config.walkableClimb; // default derived above; config.json can override
+        uint32 walkableClimbModelTransition = config.walkableClimb; // follows walkableClimb unless overridden below
+        if (int const climbOverride = jsonTileConfig["walkableClimbModelTransition"].get<int>())
+            walkableClimbModelTransition = climbOverride;
 
         config.width = config.tileSize + config.borderSize * 2;
         config.height = config.tileSize + config.borderSize * 2;
@@ -987,19 +989,20 @@ namespace MMAP
     {
         return
         {
-            { "borderSize",              5     }, // Non-navigable border around heightfield (voxels) - if overriding walkableRadius per tile, also override this (= walkableRadius + 3)
-            { "detailSampleDist",        2.0f  }, // Sampling distance for detail mesh height data (world units)
-            { "detailSampleMaxError",    0.5f  }, // Max deviation of detail mesh from heightfield data (world units)
-            { "maxEdgeLen",              45    }, // Max length for contour edges along mesh border (voxels - 12 world units / BASE_UNIT_DIM)
-            { "maxSimplificationError",  1.8f  }, // Max distance simplified contour can deviate from raw contour (voxels)
-            { "mergeRegionArea",         10    }, // Regions with span count < this will merge with larger regions (voxels)
-            { "minRegionArea",           30    }, // Min voxels allowed to form isolated island areas (voxels)
-            { "walkableClimb",           0     }, // Max ledge height that is traversable (voxels) - calculated at runtime
-            { "walkableHeight",          0     }, // Min floor to ceiling height for walkable area (voxels) - calculated at runtime
-            { "walkableRadius",          2     }, // Distance to erode walkable area away from obstructions (voxels, ~0.53yd)
-            { "walkableSlopeAngle",      75.0f }, // Max slope angle for terrain that is considered walkable (degrees)
-            { "walkableSlopeAngleVMaps", 61.0f }, // Max slope angle for WMO/M2 models that is considered walkable (degrees)
-            { "quick",                   -1    }, // -1=use global, 0=thorough build, 1=skip undermesh removal for faster build
+            { "borderSize",                   5     }, // Non-navigable border around heightfield (voxels) - if overriding walkableRadius per tile, also override this (= walkableRadius + 3)
+            { "detailSampleDist",             2.0f  }, // Sampling distance for detail mesh height data (world units)
+            { "detailSampleMaxError",         0.5f  }, // Max deviation of detail mesh from heightfield data (world units)
+            { "maxEdgeLen",                   45    }, // Max length for contour edges along mesh border (voxels - 12 world units / BASE_UNIT_DIM)
+            { "maxSimplificationError",       1.8f  }, // Max distance simplified contour can deviate from raw contour (voxels)
+            { "mergeRegionArea",              10    }, // Regions with span count < this will merge with larger regions (voxels)
+            { "minRegionArea",                30    }, // Min voxels allowed to form isolated island areas (voxels)
+            { "walkableClimb",                0     }, // Max ledge height that is traversable (voxels) - calculated at runtime
+            { "walkableClimbModelTransition", 0     }, // Max ledge height at terrain<->model transitions (voxels) - 0 = same as walkableClimb
+            { "walkableHeight",               0     }, // Min floor to ceiling height for walkable area (voxels) - calculated at runtime
+            { "walkableRadius",               2     }, // Distance to erode walkable area away from obstructions (voxels, ~0.53yd)
+            { "walkableSlopeAngle",           75.0f }, // Max slope angle for terrain that is considered walkable (degrees)
+            { "walkableSlopeAngleVMaps",      61.0f }, // Max slope angle for WMO/M2 models that is considered walkable (degrees)
+            { "quick",                        -1    }, // -1=use global, 0=thorough build, 1=skip undermesh removal for faster build
         };
     }
 

--- a/contrib/mmap/src/TileWorker.cpp
+++ b/contrib/mmap/src/TileWorker.cpp
@@ -1,6 +1,7 @@
 #include "TileWorker.h"
 #include "MapBuilder.h"
 #include "Maps/GridMapDefines.h"
+#include "DetourNavMeshQuery.h"
 
 inline static void calcTriNormal(const float* v0, const float* v1, const float* v2, float* norm)
 {
@@ -66,10 +67,11 @@ static void filterWalkableLowHeightSpansWith(rcHeightfield& filter, rcHeightfiel
         {
             for (rcSpan* spanOut = out.spans[x + y * w]; spanOut; spanOut = spanOut->next)
                 for (rcSpan* spanFilter = filter.spans[x + y * w]; spanFilter; spanFilter = spanFilter->next)
-                    if (spanOut->area == AREA_GROUND) // No steep slopes here.
+                {
+                    const int bot = (int)(spanOut->smax);
+                    const int top = (int)(spanFilter->smin);
+                    if (spanOut->area == AREA_GROUND)
                     {
-                        const int bot = (int)(spanOut->smax);
-                        const int top = (int)(spanFilter->smin);
                         if ((top - bot) <= max && (top - bot) >= 0)
                         {
                             if ((top - bot) >= min)
@@ -78,6 +80,16 @@ static void filterWalkableLowHeightSpansWith(rcHeightfield& filter, rcHeightfiel
                                 spanOut->area = AREA_WATER_TRANSITION;
                         }
                     }
+                    else if (spanOut->area == AREA_STEEP_SLOPE)
+                    {
+                        // fully submerged steep slopes are swimmable - the slope only
+                        // matters for ground movement. Shallow water over steep slopes is
+                        // deliberately left alone: a transition area would grant NAV_GROUND
+                        // and change ground pathing.
+                        if ((top - bot) >= min && (top - bot) <= max)
+                            spanOut->area = spanFilter->area;
+                    }
+                }
         }
     }
 }
@@ -224,28 +236,25 @@ namespace MMAP
             }
 
             TileInfo tileInfo;
-            if (m_mapBuilder->m_tileQueue.WaitAndPop(tileInfo))
-            {
-                if (m_mapBuilder->m_cancel.load())
-                {
-                    return;
-                }
-
-                dtNavMesh* navMesh = dtAllocNavMesh();
-                if (!navMesh->init(&tileInfo.m_navMeshParams))
-                {
-                    printf("[Map %03i] Failed creating navmesh for tile %i,%i !\n", tileInfo.m_mapId, tileInfo.m_tileX, tileInfo.m_tileY);
-                    dtFreeNavMesh(navMesh);
-                    return;
-                }
-
-                buildTile(tileInfo.m_mapId, tileInfo.m_tileX, tileInfo.m_tileY, navMesh, tileInfo.m_curTile, tileInfo.m_tileCount, tileInfo.m_forceRebuild);
-                dtFreeNavMesh(navMesh);
-            }
-            else
+            if (!m_mapBuilder->m_tileQueue.WaitAndPop(tileInfo))
             {
                 return;
             }
+
+            // once a tile has been popped it must be built - checking m_cancel here
+            // would silently drop the tile when the main thread sees the empty queue
+            // and cancels while we sit between the pop and the check
+            dtNavMesh* navMesh = dtAllocNavMesh();
+            if (!navMesh || !navMesh->init(&tileInfo.m_navMeshParams))
+            {
+                printf("[Map %03i] Failed creating navmesh for tile %i,%i !\n", tileInfo.m_mapId, tileInfo.m_tileX, tileInfo.m_tileY);
+                m_mapBuilder->m_anyError.store(true);
+                dtFreeNavMesh(navMesh);
+                continue;
+            }
+
+            buildTile(tileInfo.m_mapId, tileInfo.m_tileX, tileInfo.m_tileY, navMesh, tileInfo.m_curTile, tileInfo.m_tileCount, tileInfo.m_forceRebuild);
+            dtFreeNavMesh(navMesh);
         }
     }
 
@@ -442,8 +451,10 @@ namespace MMAP
         memset(&config, 0, sizeof(rcConfig));
         json jsonTileConfig = getTileConfig(mapID, tileX, tileY);
         int const quickFromConfig = jsonTileConfig["quick"].get<int>();
+        // -1 = use the global (command line) value; must not leak into later tiles on this worker
+        bool quick = m_quick;
         if (quickFromConfig >= 0)
-            m_quick = quickFromConfig == 0 ? false : true;
+            quick = quickFromConfig != 0;
         config = jsonTileConfig;
 
         rcVcopy(config.bmin, bmin);
@@ -471,18 +482,12 @@ namespace MMAP
         if (config.walkableClimb == 0)
             config.walkableClimb = (int)floorf(agentMaxClimbModelTerrainTransition / config.ch); // For models
         uint32 walkableClimbTerrain = (int)floorf(agentMaxClimbTerrain / config.ch);
-        uint32 walkableClimbModelTransition = (int)floorf(agentMaxClimbModelTerrainTransition / config.ch);
-        if (config.walkableRadius == 0)
-            config.walkableRadius = (int)ceilf(agentRadius / config.cs);
-        if (config.maxEdgeLen == 0)
-            config.maxEdgeLen = (int)(12 / config.cs);
-        if (config.borderSize == 0)
-            config.borderSize = config.walkableRadius + 3;
+        uint32 walkableClimbModelTransition = config.walkableClimb; // default derived above; config.json can override
 
         config.width = config.tileSize + config.borderSize * 2;
         config.height = config.tileSize + config.borderSize * 2;
 
-        int inWaterGround = config.walkableHeight;
+        int inWaterGround = config.walkableHeight / 2; // AREA_WATER_TRANSITION up to half agent height (~0.75yd), deeper becomes AREA_WATER (non-swimmers stop here)
         int stepForGroundInheriteWater = (int)ceilf(30.0f / config.ch);
 
         // allocate subregions : tiles
@@ -579,7 +584,7 @@ namespace MMAP
                     }
                     // Now we remove underterrain triangles (actually set flags to 0)
                     // This prevents selecting wrong poly for a player in the server later.
-                    if (!terrain && areas[i] && !m_quick)
+                    if (!terrain && areas[i] && !quick)
                     {
                         // Get triangle corners (as usual, yzx positions)
                         // (actually we push these corners towards the center a bit to prevent collision with border models etc...)
@@ -717,6 +722,7 @@ namespace MMAP
             delete[] pmmerge;
             delete[] dmmerge;
             printf("%s alloc iv.polyMesh FAILED!                          \r", tileString);
+            m_mapBuilder->m_anyError.store(true);
             return;
         }
         rcMergePolyMeshes(m_rcContext, pmmerge, nmerge, *iv.polyMesh);
@@ -728,6 +734,7 @@ namespace MMAP
             delete[] tiles;
             delete[] pmmerge;
             delete[] dmmerge;
+            m_mapBuilder->m_anyError.store(true);
             return;
         }
         rcMergePolyMeshDetails(m_rcContext, dmmerge, nmerge, *iv.polyMeshDetail);
@@ -821,8 +828,10 @@ namespace MMAP
             }
             if (params.vertCount >= 0xffff)
             {
+                // skip only this tile - killing the whole build here (and with exit
+                // code 0 on top) makes scripted pipelines believe the run succeeded
                 printf("%s Too many vertices! (0x%8x)                         \n", tileString, params.vertCount);
-                exit(0);
+                m_mapBuilder->m_anyError.store(true);
                 continue;
             }
             if (!params.vertCount || !params.verts)
@@ -852,6 +861,7 @@ namespace MMAP
             if (!dtCreateNavMeshData(&params, &navData, &navDataSize))
             {
                 printf("%s Failed building navmesh tile!                      \n", tileString);
+                m_mapBuilder->m_anyError.store(true);
                 continue;
             }
 
@@ -863,8 +873,11 @@ namespace MMAP
             if (!tileRef || dtStatusFailed(dtResult))
             {
                 printf("%s Failed adding tile to navmesh (0x%x)               \n", tileString, dtResult);
+                m_mapBuilder->m_anyError.store(true);
                 continue;
             }
+
+            validateOffMeshConnections(meshData, navMesh, params, tileString);
 
             // file output
             char fileName[255];
@@ -875,6 +888,7 @@ namespace MMAP
                 char message[1024];
                 snprintf(message, sizeof(message), "[Map %03i] Failed to open %s for writing!             \n", mapID, fileName);
                 perror(message);
+                m_mapBuilder->m_anyError.store(true);
                 navMesh->removeTile(tileRef, nullptr, nullptr);
                 continue;
             }
@@ -918,23 +932,74 @@ namespace MMAP
         } while (0);
     }
 
+    /**
+     * Off-mesh connections whose endpoints do not land on a navmesh polygon are
+     * silently dropped by Detour - warn about them so broken offmesh.txt entries
+     * are visible at build time instead of failing quietly at runtime.
+     */
+    void TileWorker::validateOffMeshConnections(MeshData const& meshData, dtNavMesh const* navMesh, dtNavMeshCreateParams const& params, char const* tileString)
+    {
+        int const conCount = meshData.offMeshConnections.size() / 6;
+        if (!conCount)
+            return;
+
+        dtNavMeshQuery* query = dtAllocNavMeshQuery();
+        if (!query || dtStatusFailed(query->init(navMesh, 2048)))
+        {
+            dtFreeNavMeshQuery(query);
+            return;
+        }
+
+        dtQueryFilter filter;
+        float const* verts = meshData.offMeshConnections.getCArray();
+        for (int i = 0; i < conCount; ++i)
+        {
+            float const rad = meshData.offMeshConnectionRads[i];
+            // same search box Detour uses when linking the connection at runtime
+            float const halfExtents[3] = { rad, params.walkableClimb, rad };
+            for (int p = 0; p < 2; ++p)
+            {
+                float const* point = &verts[i * 6 + p * 3];
+
+                // the end point may legitimately lie in a neighboring tile (linked via
+                // connectExtOffMeshLinks once that tile is loaded) - only points inside
+                // this tile can be validated against its polygons
+                if (p == 1 && (point[0] < params.bmin[0] || point[0] > params.bmax[0] ||
+                               point[2] < params.bmin[2] || point[2] > params.bmax[2]))
+                {
+                    continue;
+                }
+
+                dtPolyRef nearestRef = 0;
+                float nearestPt[3];
+                if (dtStatusFailed(query->findNearestPoly(point, halfExtents, &filter, &nearestRef, nearestPt)) || !nearestRef)
+                {
+                    // print in offmesh.txt coordinate order (x y z) for easy lookup
+                    printf("%s Off-mesh connection %s point (%.2f %.2f %.2f) is not on any polygon - connection will not work!\n",
+                           tileString, p == 0 ? "start" : "end", point[2], point[0], point[1]);
+                }
+            }
+        }
+        dtFreeNavMeshQuery(query);
+    }
+
     json TileWorker::getDefaultConfig()
     {
         return
         {
-            { "borderSize",              0     }, // placeholder
-            { "detailSampleDist",        2.0f  },
-            { "detailSampleMaxError",    0.5f  },
-            { "maxEdgeLen",              0     }, // placeholder
-            { "maxSimplificationError",  1.8f  },
-            { "mergeRegionArea",         10    },
-            { "minRegionArea",           30    },
-            { "walkableClimb",           0     }, // placeholder
-            { "walkableHeight",          0     }, // placeholder
-            { "walkableRadius",          0     }, // placeholder
-            { "walkableSlopeAngle",      75.0f }, // slope terrain
-            { "walkableSlopeAngleVMaps", 61.0f }, // slope model (WMO...)
-            { "quick",                   -1    }, // skip 'undermesh removal'
+            { "borderSize",              5     }, // Non-navigable border around heightfield (voxels) - if overriding walkableRadius per tile, also override this (= walkableRadius + 3)
+            { "detailSampleDist",        2.0f  }, // Sampling distance for detail mesh height data (world units)
+            { "detailSampleMaxError",    0.5f  }, // Max deviation of detail mesh from heightfield data (world units)
+            { "maxEdgeLen",              45    }, // Max length for contour edges along mesh border (voxels - 12 world units / BASE_UNIT_DIM)
+            { "maxSimplificationError",  1.8f  }, // Max distance simplified contour can deviate from raw contour (voxels)
+            { "mergeRegionArea",         10    }, // Regions with span count < this will merge with larger regions (voxels)
+            { "minRegionArea",           30    }, // Min voxels allowed to form isolated island areas (voxels)
+            { "walkableClimb",           0     }, // Max ledge height that is traversable (voxels) - calculated at runtime
+            { "walkableHeight",          0     }, // Min floor to ceiling height for walkable area (voxels) - calculated at runtime
+            { "walkableRadius",          2     }, // Distance to erode walkable area away from obstructions (voxels, ~0.53yd)
+            { "walkableSlopeAngle",      75.0f }, // Max slope angle for terrain that is considered walkable (degrees)
+            { "walkableSlopeAngleVMaps", 61.0f }, // Max slope angle for WMO/M2 models that is considered walkable (degrees)
+            { "quick",                   -1    }, // -1=use global, 0=thorough build, 1=skip undermesh removal for faster build
         };
     }
 
@@ -951,7 +1016,9 @@ namespace MMAP
 
     json TileWorker::getTileConfig(uint32 mapId, uint32 tileX, uint32 tileY)
     {
-        std::string key = std::to_string(tileX) + std::to_string(tileY);
+        // zero-padded so keys are unambiguous: tile (1,23) -> "0123", tile (12,3) -> "1203"
+        char key[8];
+        snprintf(key, sizeof(key), "%02u%02u", tileX, tileY);
 
         json config = getMapIdConfig(mapId);
         if (config.find(key) != config.end())

--- a/contrib/mmap/src/TileWorker.h
+++ b/contrib/mmap/src/TileWorker.h
@@ -156,8 +156,9 @@ namespace MMAP
         bool shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY);
         void buildTile(uint32 mapID, uint32 tileX, uint32 tileY, dtNavMesh* navMesh, uint32 curTile, uint32 tileCount, bool forceRebuild = false);
         void buildMoveMapTile(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData, float bmin[3], float bmax[3], dtNavMesh* navMesh);
+        void validateOffMeshConnections(MeshData const& meshData, dtNavMesh const* navMesh, dtNavMeshCreateParams const& params, char const* tileString);
 
-        json getDefaultConfig();
+        static json getDefaultConfig();
         json getMapIdConfig(uint32 mapId);
         json getTileConfig(uint32 mapId, uint32 tileX, uint32 tileY);
 

--- a/contrib/mmap/src/generator.cpp
+++ b/contrib/mmap/src/generator.cpp
@@ -126,6 +126,12 @@ bool handleArgs(int argc, char** argv,
 
             char* stileX = strtok(param, ",");
             char* stileY = strtok(nullptr, ",");
+            if (!stileX || !stileY)
+            {
+                printf("invalid tile coords.\n");
+                return false;
+            }
+
             int tilex = atoi(stileX);
             int tiley = atoi(stileY);
 
@@ -307,6 +313,12 @@ int main(int argc, char** argv)
     while (builder.IsBusy())
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+
+    if (builder.HasErrors())
+    {
+        printf("MoveMapGenerator finished with errors! Some tiles were not built.\n");
+        return silent ? EXIT_FAILURE : finish("Press any key to close...", EXIT_FAILURE);
     }
 
     if (silent)

--- a/contrib/vmap_assembler/vmap_assembler.cpp
+++ b/contrib/vmap_assembler/vmap_assembler.cpp
@@ -16,8 +16,10 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <cstring>
 #include <string>
 #include <iostream>
+#include <vector>
 #ifdef WIN32
 #include "direct.h"
 #else
@@ -29,9 +31,30 @@
 //=======================================================
 int main(int argc, char* argv[])
 {
+    // Skip all interactive prompts (for scripted runs)
+    bool silent = false;
+    std::vector<std::string> args;
+    for (int i = 1; i < argc; ++i)
+    {
+        if (strcmp(argv[i], "--silent") == 0)
+            silent = true;
+        else
+            args.push_back(argv[i]);
+    }
+
+    std::cout << "VMap Assembler" << std::endl;
+    std::cout << "======================================" << std::endl;
+
+    if (!silent)
+    {
+        std::cout << "Press enter to start assembling vmaps." << std::endl;
+        std::cout << "======================================" << std::endl;
+        std::cin.get();
+    }
+
     std::string src;
     std::string dest;
-    if (argc != 3)
+    if (args.size() != 2)
     {
         //std::cout << "usage: " << argv[0] << " <raw data dir> <vmap dest dir>" << std::endl;
         //return 1;
@@ -47,8 +70,8 @@ int main(int argc, char* argv[])
     }
     else
     {
-        src = argv[1];
-        dest = argv[2];
+        src = args[0];
+        dest = args[1];
     }
 
     std::cout << "using " << src << " as source directory and writing output to " << dest << std::endl;
@@ -59,10 +82,20 @@ int main(int argc, char* argv[])
     {
         std::cout << "exit with errors" << std::endl;
         delete ta;
+        if (!silent)
+        {
+            std::cout << "Press enter to close." << std::endl;
+            std::cin.get();
+        }
         return 1;
     }
 
     delete ta;
     std::cout << "Ok, all done" << std::endl;
+    if (!silent)
+    {
+        std::cout << "Press enter to close." << std::endl;
+        std::cin.get();
+    }
     return 0;
 }

--- a/contrib/vmap_extractor/vmapextract/model.cpp
+++ b/contrib/vmap_extractor/vmapextract/model.cpp
@@ -82,7 +82,7 @@ bool Model::ConvertToVMAPModel(const char* outfilename)
         printf("Can't create the output file '%s'\n", outfilename);
         return false;
     }
-    fwrite(szRawVMAPMagic, 8, 1, output);
+    fwrite(RAW_VMAP_MAGIC, 8, 1, output);
 
     uint32 nVertices = header.nBoundingVertices;
     fwrite(&nVertices, sizeof(int), 1, output);

--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -74,13 +74,15 @@ char output_path[128] = ".";
 char input_path[1024] = ".";
 bool hasInputPathParam = false;
 bool preciseVectorData = true;
+// Skip all interactive prompts (for scripted runs)
+bool CONF_silent = false;
 std::unordered_map<std::string, WMODoodadData> WmoDoodads;
 
 // Constants
 
 //static const char * szWorkDirMaps = ".\\Maps";
 const char* szWorkDirWmo = "./Buildings";
-const char* szRawVMAPMagic = "VMAPs05";
+const char* RAW_VMAP_MAGIC = "VMAPs05";
 
 std::map<std::pair<uint32, uint16>, uint32> uniqueObjectIds;
 
@@ -337,6 +339,7 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
     snprintf(path, sizeof(path), "%sbase.MPQ", input_path);
     pArchiveNames.push_back(path);
     snprintf(path, sizeof(path), "%smisc.MPQ", input_path);
+    pArchiveNames.push_back(path);
 
     // now, scan for the patch levels in the core dir
     printf("Scanning patch levels from data directory.\n");
@@ -379,13 +382,17 @@ bool processArgv(int argc, char** argv)
                 result = false;
             }
         }
-        else if (strcmp("-?", argv[1]) == 0)
+        else if (strcmp("-?", argv[i]) == 0)
         {
             result = false;
         }
         else if (strcmp("-l", argv[i]) == 0)
         {
             preciseVectorData = true;
+        }
+        else if (strcmp("--silent", argv[i]) == 0)
+        {
+            CONF_silent = true;
         }
         else
         {
@@ -395,11 +402,12 @@ bool processArgv(int argc, char** argv)
     }
     if (!result)
     {
-        printf("Extract for %s.\n", szRawVMAPMagic);
-        printf("%s [-?][-s][-l][-d <path>]\n", argv[0]);
+        printf("Extract for %s.\n", RAW_VMAP_MAGIC);
+        printf("%s [-?][-s][-l][-d <path>][--silent]\n", argv[0]);
         printf("   -s : small size (data size optimization), ~500MB less vmap data.\n");
         printf("   -l : (default) large size, ~500MB more vmap data. (might contain more details)\n");
         printf("   -d <path>: Path to the vector data source folder.\n");
+        printf("   --silent : skip all interactive prompts (for scripted runs).\n");
         printf("   -? : This message.\n");
     }
     return result;
@@ -432,14 +440,41 @@ int main(int argc, char** argv)
         if (!stat(sdir.c_str(), &status) || !stat(sdir_bin.c_str(), &status))
         {
             printf("Your output directory seems to be polluted, please use an empty directory!\n");
-            printf("<press return to exit>");
-            char garbage[2];
-            IgnoreResult(scanf("%c", garbage));
+            if (!CONF_silent)
+            {
+                printf("<press return to exit>");
+                char garbage[2];
+                IgnoreResult(scanf("%c", garbage));
+            }
             return 1;
         }
     }
 
-    printf("Extract for %s. Beginning work ....\n", szRawVMAPMagic);
+    // Prompt user for vmap resolution (empty input or --silent keeps the -s/-l command line setting)
+    bool highRes = preciseVectorData;
+
+    if (!CONF_silent)
+    {
+        std::string userInput;
+        std::cout << "Extract vmaps with high resolution (default = " << (highRes ? "y" : "n") << ")? [y/n]" << std::endl;
+        std::getline(std::cin, userInput);
+        if (!userInput.empty())
+            highRes = userInput.compare("y") == 0;
+    }
+
+    std::cout << "High resolution = " << highRes << std::endl;
+
+    if (!CONF_silent)
+    {
+        std::cout << "Press enter to start extracting vmaps." << std::endl;
+        std::cout << "=====================================" << std::endl;
+        std::cin.get();
+    }
+
+    // Overwrite due to user input
+    preciseVectorData = highRes;
+
+    printf("Extract for %s. Beginning work ....\n", RAW_VMAP_MAGIC);
     //xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     // Create the working directory
     if (mkdir(szWorkDirWmo
@@ -500,14 +535,20 @@ int main(int argc, char** argv)
 
         printf("\n");
         if (hasWarnings)
-            printf("Extract for %s. Work complete with warnings.\n", szRawVMAPMagic);
+            printf("Extract for %s. Work complete with warnings.\n", RAW_VMAP_MAGIC);
         else
-            printf("Extract for %s. Work complete. No errors.\n", szRawVMAPMagic);
+            printf("Extract for %s. Work complete. No errors.\n", RAW_VMAP_MAGIC);
     }
     else
     {
         printf("\n");
-        printf("ERROR: Extract for %s. Work NOT complete.\n", szRawVMAPMagic);
+        printf("ERROR: Extract for %s. Work NOT complete.\n", RAW_VMAP_MAGIC);
+    }
+
+    if (!CONF_silent)
+    {
+        std::cout << "Press enter to close." << std::endl;
+        std::cin.get();
     }
 
     return success ? 0 : 1;

--- a/contrib/vmap_extractor/vmapextract/vmapexport.h
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.h
@@ -39,7 +39,7 @@ enum ModelFlags
 struct WMODoodadData;
 
 extern const char* szWorkDirWmo;
-extern const char* szRawVMAPMagic;                          // vmap magic string for extracted raw vmap data
+extern const char* RAW_VMAP_MAGIC;                          // vmap magic string for extracted raw vmap data
 extern std::unordered_map<std::string, WMODoodadData> WmoDoodads;
 
 uint32 GenerateUniqueObjectId(uint32 clientId, uint16 clientDoodadId);

--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -153,7 +153,7 @@ bool WMORoot::ConvertToVMAPRootWmo(FILE* pOutfile)
 {
     //printf("Convert RootWmo...\n");
 
-    fwrite(szRawVMAPMagic, 1, 8, pOutfile);
+    fwrite(RAW_VMAP_MAGIC, 1, 8, pOutfile);
     unsigned int nVectors = 0;
     fwrite(&nVectors, sizeof(nVectors), 1, pOutfile); // will be filled later
     fwrite(&nGroups, 4, 1, pOutfile);

--- a/dep/recastnavigation/Detour/Source/DetourNavMeshQuery.cpp
+++ b/dep/recastnavigation/Detour/Source/DetourNavMeshQuery.cpp
@@ -2517,14 +2517,7 @@ dtStatus dtNavMeshQuery::raycast(dtPolyRef startRef, const float* startPos, cons
 		if (n < hit->maxPath)
 			hit->path[n++] = curRef;
 		else
-		{
 			status |= DT_BUFFER_TOO_SMALL;
-
-			// Fix: Return early when path buffer is full to prevent continuing with invalid state.
-			// Set pathCount to the number of items we successfully stored before hitting the limit.
-			hit->pathCount = n;
-			return status;
-		}
 
 		// Ray end is completely inside the polygon.
 		if (segMax == -1)

--- a/dep/recastnavigation/Detour/Source/DetourNavMeshQuery.cpp
+++ b/dep/recastnavigation/Detour/Source/DetourNavMeshQuery.cpp
@@ -2517,7 +2517,14 @@ dtStatus dtNavMeshQuery::raycast(dtPolyRef startRef, const float* startPos, cons
 		if (n < hit->maxPath)
 			hit->path[n++] = curRef;
 		else
+		{
 			status |= DT_BUFFER_TOO_SMALL;
+
+			// Fix: Return early when path buffer is full to prevent continuing with invalid state.
+			// Set pathCount to the number of items we successfully stored before hitting the limit.
+			hit->pathCount = n;
+			return status;
+		}
 
 		// Ray end is completely inside the polygon.
 		if (segMax == -1)

--- a/src/game/Commands/DebugCommands.cpp
+++ b/src/game/Commands/DebugCommands.cpp
@@ -2494,65 +2494,101 @@ bool ChatHandler::HandleMmap(char* args)
     return true;
 }
 
-bool ChatHandler::HandleMmapConnection(char* /*args*/)
+bool ChatHandler::HandleMmapConnection(char* args)
 {
-    static bool hasStartPoint = false;
-    static float startX = 0.0f, startY = 0.0f, startZ = 0.0f;
-    static uint32 startMapId = 0;
+    struct OffMeshStartPoint
+    {
+        uint32 mapId;
+        float x, y, z;
+    };
 
+    static std::map<ObjectGuid, OffMeshStartPoint> startPoints;
     Player* pPlayer = m_session->GetPlayer();
+    ObjectGuid const playerGuid = pPlayer->GetObjectGuid();
 
-    if (!hasStartPoint)
+    if (ExtractLiteralArg(&args, "cancel"))
+    {
+        if (startPoints.erase(playerGuid))
+            SendSysMessage("Offmesh start point discarded.");
+        else
+            SendSysMessage("No offmesh start point recorded.");
+        return true;
+    }
+
+    std::map<ObjectGuid, OffMeshStartPoint>::iterator itr = startPoints.find(playerGuid);
+    if (itr == startPoints.end())
     {
         // First call: record start position
-        pPlayer->GetPosition(startX, startY, startZ);
-        startMapId = pPlayer->GetMapId();
-        hasStartPoint = true;
-        PSendSysMessage("Start point recorded at (%.2f, %.2f, %.2f). Move to end point and run command again.", startX, startY, startZ);
+        OffMeshStartPoint start;
+        start.mapId = pPlayer->GetMapId();
+        pPlayer->GetPosition(start.x, start.y, start.z);
+        startPoints[playerGuid] = start;
+        PSendSysMessage("Start point recorded at (%.2f, %.2f, %.2f).", start.x, start.y, start.z);
+        SendSysMessage("Move to the end point and run the command again (optional argument: agent radius, default 2.5).");
+        SendSysMessage("Use '.mmap connect cancel' to discard the start point.");
+        return true;
+    }
+
+    // Second call: record end position and write connection
+    if (pPlayer->GetMapId() != itr->second.mapId)
+    {
+        SendSysMessage("Error: You changed maps! Connection cancelled. Start again.");
+        startPoints.erase(itr);
+        return true;
+    }
+
+    // parse the radius before consuming the start point, so a bad argument does not discard it
+    float radius;
+    if (!ExtractOptFloat(&args, radius, 2.5f) || radius <= 0.0f)
+    {
+        SendSysMessage("Invalid radius argument. Start point kept - run the command again.");
+        return true;
+    }
+
+    OffMeshStartPoint const start = itr->second;
+    startPoints.erase(itr);
+
+    float endX, endY, endZ;
+    pPlayer->GetPosition(endX, endY, endZ);
+
+    // Detour only stores a connection whose START point lies inside the tile, so
+    // the tile must be derived from the start position. Axes are switched: the
+    // offmesh.txt tile convention is tileX from world Y, tileY from world X.
+    int32 tileX = int32(32 - start.y / SIZE_OF_GRIDS);
+    int32 tileY = int32(32 - start.x / SIZE_OF_GRIDS);
+
+    float const dist = sqrt(pow(endX - start.x, 2) + pow(endY - start.y, 2) + pow(endZ - start.z, 2));
+    if (dist > 100.0f)
+        PSendSysMessage("Warning: connection is %.0f yd long - did you forget an earlier start point? Check the output before using it.", dist);
+
+    int32 endTileX = int32(32 - endY / SIZE_OF_GRIDS);
+    int32 endTileY = int32(32 - endX / SIZE_OF_GRIDS);
+    if (endTileX != tileX || endTileY != tileY)
+        PSendSysMessage("Note: end point lies in neighboring tile [%d,%d] - this works, the connection is stored in the start point's tile.", endTileX, endTileY);
+
+    // Format: mapID tileX,tileY (start_x start_y start_z) (end_x end_y end_z) size
+    PSendSysMessage("Offmesh connection recorded:");
+    PSendSysMessage("%u %d,%d (%.6f %.6f %.6f) (%.6f %.6f %.6f) %.2f",
+                    start.mapId, tileX, tileY,
+                    start.x, start.y, start.z,
+                    endX, endY, endZ, radius);
+    PSendSysMessage("Copy the line into offmesh.txt, then rebuild: MoveMapGenerator %u --tile %d,%d --threads 1 --silent", start.mapId, tileX, tileY);
+    sLog.Out(LOG_BASIC, LOG_LVL_BASIC, "Copy the line into offmesh.txt, then rebuild: MoveMapGenerator %u --tile %d,%d --threads 1 --silent", start.mapId, tileX, tileY);
+
+    // Write to file
+    FILE* file = fopen("offmesh_connections.txt", "a");
+    if (file)
+    {
+        fprintf(file, "%u %d,%d (%.6f %.6f %.6f) (%.6f %.6f %.6f) %.2f\n",
+                start.mapId, tileX, tileY,
+                start.x, start.y, start.z,
+                endX, endY, endZ, radius);
+        fclose(file);
+        SendSysMessage("Written to offmesh_connections.txt");
     }
     else
     {
-        // Second call: record end position and write connection
-        if (pPlayer->GetMapId() != startMapId)
-        {
-            SendSysMessage("Error: You changed maps! Connection cancelled. Start again.");
-            hasStartPoint = false;
-            startX = startY = startZ = 0.0f;
-            return true;
-        }
-
-        // Switched x/y
-        int32 tileY = 32 - pPlayer->GetPositionX() / SIZE_OF_GRIDS;
-        int32 tileX = 32 - pPlayer->GetPositionY() / SIZE_OF_GRIDS;
-
-        // Format: mapID tileX,tileY (start_x start_y start_z) (end_x end_y end_z) size
-        PSendSysMessage("Offmesh connection recorded:");
-        PSendSysMessage("%u %d,%d (%.6f %.6f %.6f) (%.6f %.6f %.6f) 2.5",
-                        pPlayer->GetMapId(), tileX, tileY,
-                        startX, startY, startZ,
-                        pPlayer->GetPositionX(), pPlayer->GetPositionY(), pPlayer->GetPositionZ());
-        PSendSysMessage("Rebuild with: MoveMapGenerator %u --tile %d,%d", pPlayer->GetMapId(), tileX, tileY);
-        sLog.Out(LOG_BASIC, LOG_LVL_BASIC, "Rebuild with: MoveMapGenerator %u --tile %d,%d", pPlayer->GetMapId(), tileX, tileY);
-
-        // Write to file
-        FILE* file = fopen("offmesh_connections.txt", "a");
-        if (file)
-        {
-            fprintf(file, "%u %d,%d (%.6f %.6f %.6f) (%.6f %.6f %.6f) 2.5\n",
-                    pPlayer->GetMapId(), tileX, tileY,
-                    startX, startY, startZ,
-                    pPlayer->GetPositionX(), pPlayer->GetPositionY(), pPlayer->GetPositionZ());
-            fclose(file);
-            SendSysMessage("Written to offmesh_connections.txt");
-        }
-        else
-        {
-            SendSysMessage("Warning: Could not write to offmesh_connections.txt");
-        }
-
-        // Reset state
-        hasStartPoint = false;
-        startX = startY = startZ = 0.0f;
+        SendSysMessage("Warning: Could not write to offmesh_connections.txt");
     }
 
     return true;

--- a/src/game/Maps/MoveMap.cpp
+++ b/src/game/Maps/MoveMap.cpp
@@ -138,7 +138,7 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
     if (mmap->mmapLoadedTiles.find(packedGridPos) != mmap->mmapLoadedTiles.end())
         return false;
 
-    // load this tile :: mmaps/MMMXXYY.mmtile
+    // load this tile :: mmaps/MMMYYXX.mmtile
     uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%03i%02i%02i.mmtile") + 1;
     char *fileName = new char[pathLen];
     snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%03i%02i%02i.mmtile").c_str(), mapId, y, x);
@@ -162,7 +162,7 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
 
     if (fileHeader.mmapMagic != MMAP_MAGIC)
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Bad header in mmap %03u%02i%02i.mmtile", mapId, x, y);
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Bad header in mmap %03u%02i%02i.mmtile", mapId, y, x);
         fclose(file);
         return false;
     }
@@ -170,7 +170,7 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
     if (fileHeader.mmapVersion != MMAP_VERSION)
     {
         sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: %03u%02i%02i.mmtile was built with generator v%i, expected v%i",
-                      mapId, x, y, fileHeader.mmapVersion, MMAP_VERSION);
+                      mapId, y, x, fileHeader.mmapVersion, MMAP_VERSION);
         fclose(file);
         return false;
     }
@@ -178,7 +178,7 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
     unsigned char* data = (unsigned char*)dtAlloc(fileHeader.size, DT_ALLOC_PERM);
     if (!data)
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Failed to load mmap %03u%02i%02i.mmtile", mapId, x, y);
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Failed to load mmap %03u%02i%02i.mmtile", mapId, y, x);
         fclose(file);
         return false;
     }
@@ -186,7 +186,7 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
     size_t result = fread(data, fileHeader.size, 1, file);
     if (!result)
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Bad header or data in mmap %03u%02i%02i.mmtile", mapId, x, y);
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Bad header or data in mmap %03u%02i%02i.mmtile", mapId, y, x);
         fclose(file);
         return false;
     }
@@ -206,7 +206,7 @@ bool MMapManager::loadMap(uint32 mapId, int32 x, int32 y)
     }
     else
     {
-        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Could not load %03u%02i%02i.mmtile into navmesh [result 0x%x]", mapId, x, y, dResult);
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:loadMap: Could not load %03u%02i%02i.mmtile into navmesh [result 0x%x]", mapId, y, x, dResult);
         dtFree(data);
         return false;
     }
@@ -220,7 +220,7 @@ bool MMapManager::unloadMap(uint32 mapId, int32 x, int32 y)
     if (loadedMMaps.find(mapId) == loadedMMaps.end())
     {
         // file may not exist, therefore not loaded
-        sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "MMAP:unloadMap: Asked to unload not loaded navmesh map. %03u%02i%02i.mmtile", mapId, x, y);
+        sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "MMAP:unloadMap: Asked to unload not loaded navmesh map. %03u%02i%02i.mmtile", mapId, y, x);
         return false;
     }
 
@@ -231,7 +231,7 @@ bool MMapManager::unloadMap(uint32 mapId, int32 x, int32 y)
     if (mmap->mmapLoadedTiles.find(packedGridPos) == mmap->mmapLoadedTiles.end())
     {
         // file may not exist, therefore not loaded
-        sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "MMAP:unloadMap: Asked to unload not loaded navmesh tile. %03u%02i%02i.mmtile", mapId, x, y);
+        sLog.Out(LOG_BASIC, LOG_LVL_DEBUG, "MMAP:unloadMap: Asked to unload not loaded navmesh tile. %03u%02i%02i.mmtile", mapId, y, x);
         return false;
     }
 
@@ -244,7 +244,7 @@ bool MMapManager::unloadMap(uint32 mapId, int32 x, int32 y)
         // this is technically a memory leak
         // if the grid is later reloaded, dtNavMesh::addTile will return error but no extra memory is used
         // we cannot recover from this error - assert out
-        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:unloadMap: Could not unload %03u%02i%02i.mmtile from navmesh", mapId, x, y);
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:unloadMap: Could not unload %03u%02i%02i.mmtile from navmesh", mapId, y, x);
         MANGOS_ASSERT(false);
     }
     else
@@ -274,7 +274,7 @@ bool MMapManager::unloadMap(uint32 mapId)
         uint32 y = (i->first & 0x0000FFFF);
         dtStatus dtResult = mmap->navMesh->removeTile(i->second, nullptr, nullptr);
         if (dtStatusFailed(dtResult))
-            sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:unloadMap: Could not unload %03u%02i%02i.mmtile from navmesh", mapId, x, y);
+            sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "MMAP:unloadMap: Could not unload %03u%02i%02i.mmtile from navmesh", mapId, y, x);
         else
             --loadedTiles;
     }

--- a/src/game/Maps/PathFinder.cpp
+++ b/src/game/Maps/PathFinder.cpp
@@ -983,9 +983,11 @@ dtStatus PathInfo::findSmoothPath(float const* startPos, float const* endPos,
                 }
                 // Move position at the other side of the off-mesh link.
                 dtVcopy(iterPos, endPos);
-                if (dtStatusFailed(m_navMeshQuery->getPolyHeight(polys[0], iterPos, &iterPos[1])))
-                    return DT_FAILURE;
-                iterPos[1] += 0.2f;
+                // getPolyHeight can fail when the link's end point was clamped onto the
+                // landing poly's boundary edge at link time; the stored height is already
+                // the landing poly's height there, so keep it instead of failing the path.
+                if (dtStatusSucceed(m_navMeshQuery->getPolyHeight(polys[0], iterPos, &iterPos[1])))
+                    iterPos[1] += 0.2f;
             }
         }
 

--- a/src/game/Movement/MotionMaster.cpp
+++ b/src/game/Movement/MotionMaster.cpp
@@ -262,7 +262,7 @@ void MotionMaster::DelayedClean(bool reset, bool all)
 
     if (!m_expList)
         m_expList = new ExpireList();
-;
+
     std::vector<MovementGenerator*> mvtGensToFinalize;
     while (all ? !empty() : size() > 1)
     {
@@ -890,6 +890,17 @@ bool MotionMaster::MoveDistance(Unit const* pTarget, float distance)
         return false;
 
     if (m_owner->GetDistanceSqr(x, y, z) == 0.0f)
+        return false;
+
+    // LOS alone does not catch navmesh borders (fences, cliffs), and without
+    // a valid path the spline shortcuts straight through geometry, so verify
+    // reachability first. A shortcut flagged PATHFIND_NORMAL is a legitimate
+    // direct move (swimming to shore, maps without mmaps) and stays allowed.
+    PathFinder path(m_owner);
+    path.calculate(x, y, z);
+    PathType const pathType = path.getPathType();
+    if ((pathType & PATHFIND_NOPATH) ||
+        ((pathType & PATHFIND_SHORTCUT) && !(pathType & PATHFIND_NORMAL)))
         return false;
 
     if (m_owner->IsPlayer())

--- a/src/game/vmap/MapTree.h
+++ b/src/game/vmap/MapTree.h
@@ -69,7 +69,7 @@ namespace VMAP
         public:
             static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);
             static uint32 packTileID(uint32 tileX, uint32 tileY) { return tileX << 16 | tileY; }
-            static void unpackTileID(uint32 ID, uint32& tileX, uint32& tileY) { tileX = ID >> 16; tileY = ID & 0xFF; }
+            static void unpackTileID(uint32 ID, uint32& tileX, uint32& tileY) { tileX = ID >> 16; tileY = ID & 0xFFFF; }
             static bool CanLoadMap(std::string const& vmapPath, uint32 mapID, uint32 tileX, uint32 tileY);
 
             StaticMapTree(uint32 mapID, std::string const& basePath);

--- a/src/game/vmap/TileAssembler.cpp
+++ b/src/game/vmap/TileAssembler.cpp
@@ -89,9 +89,15 @@ namespace VMAP
                 }
                 else if (entry->second.flags & MOD_WORLDSPAWN) // WMO maps and terrain maps use different origin, so we need to adapt :/
                 {
-                    // TODO: remove extractor hack and uncomment below line:
-                    // entry->second.iPos += Vector3(533.33333f*32, 533.33333f*32, 0.f);
-                    entry->second.iBound = entry->second.iBound + Vector3(533.33333f * 32, 533.33333f * 32, 0.f);
+                    // WMO world spawns (instances) use a different coordinate system than terrain maps.
+                    // The extractor applies the offset only to iPos, and only when the raw position is (0,0,z)
+                    // (see WMOInstance::WMOInstance in wmo.cpp) - in practice that matches the WDT global-map
+                    // WMOs which get the MOD_WORLDSPAWN flag. Bounds never get the offset, so we apply it here.
+                    //
+                    // NOTE: If there are worldspawns with non-zero initial positions, their iPos may be incorrect.
+                    // The original TODO comment suggested this is an "extractor hack" that should be resolved properly.
+                    Vector3 offset(533.33333f * 32, 533.33333f * 32, 0.f);
+                    entry->second.iBound = entry->second.iBound + offset;
                 }
                 mapSpawns.push_back(&(entry->second));
                 spawnedModelFiles.insert(entry->second.name);


### PR DESCRIPTION
## 🍰 Pullrequest

### Extractors
  - Add `--silent` flag for scripted runs and interactive prompts for resolution options
  - Fix `misc.MPQ` never being added to the archive list in the vmap extractor

### MoveMapGenerator
  - Validate `config.json` at startup, document all parameters, use zero-padded tile keys (`XXYY`)
  - Fix `--skipLiquid` being ignored and per-tile `quick` override leaking into later tiles
  - Fix single-tile builds writing an `.mmap` header incompatible with full builds
  - Fix stale/wrapped terrain height data in `TerrainBuilder::getHeight` and uniform liquid being ignored
  - Fix under-mesh removal for tilted/scaled and overlapping model instances
  - Treat fully submerged steep slopes as swimmable
  - Validate off-mesh connections at build time, clean up `offmesh.txt`
  - Exit non-zero when tiles fail to build instead of pretending success

### Server / Detour
  - `.mmap connect`: per-player state, `cancel` subcommand, radius argument, tile derived from start point
  - Fix swapped x/y in `.mmtile` log filenames and `unpackTileID` masking tileY with `0xFF`
  - PathFinder: keep stored height instead of failing the path when `getPolyHeight` fails at an off-mesh link landing
  - ~~Detour: return early from `raycast` when the path buffer is full~~

### Checked plenty of known problematic spots:
- deadmines bridge no longer needs an offmesh and works both ways dock <-> ship
- stormwind castle pathing seems flawless now
- npc no longer "bump in the air" when walking around fences/bridges
- tested many tents (tanaris, barrens) - ok
- Razorfen (Glutton) - ok
- many more spots...

Co-Authored by Claude Fable 5

### Proof
- None

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None