### PR TITLE
fix creatures not facing their target (client visual bug)

### DIFF
--- a/sql/migrations/20260704124546_world.sql
+++ b/sql/migrations/20260704124546_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260704124546');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260704124546');
+-- Add your query below.
+
+
+-- Fix creatures not facing their target
+UPDATE `creature_addon` SET `emote_state` = 0 WHERE `guid` IN (49199, 53247, 53282, 6854, 27675, 27681, 27683, 27684, 27685);
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/scripts/spells/spell_special.cpp
+++ b/src/scripts/spells/spell_special.cpp
@@ -261,8 +261,11 @@ struct OpeningBattlegroundBannerScript : public SpellScript
             LockEntry const* lockInfo = sLockStore.LookupEntry(go->GetGOInfo()->GetLockId());
             if (lockInfo && lockInfo->Index[1] == LOCKTYPE_SLOW_OPEN)
             {
-                Spell* visual = new Spell(spell->m_casterUnit, sSpellMgr.GetSpellEntry(24390), true);
-                visual->prepare();
+                if (SpellEntry const* pSpellEntry = sSpellMgr.GetSpellEntry(24390))
+                {
+                    Spell* visual = new Spell(spell->m_casterUnit, pSpellEntry, true);
+                    visual->prepare();
+                }
             }
         }
     }


### PR DESCRIPTION
On the video you can see how emote state 193 (EMOTE_STATE_SPELLPRECAST) messes with their facing on the client.

https://github.com/user-attachments/assets/b9cbbc1c-9c91-41a6-897e-d9cb47f9f3a3


https://github.com/user-attachments/assets/ad56916f-31bf-4b2d-968c-6deadfe2f829

