### PR TITLE
fix empty loot after group loot roll ends

### DIFF
--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -1123,6 +1123,8 @@ void Group::CountSingleLooterRoll(Roll* roll)
                 player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
             if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
                 player->OnReceivedItem(newItem);
+            if (roll->getLoot()->isLooted())
+                player->GetSession()->DoLootRelease(roll->getLoot()->GetLootTarget()->GetObjectGuid());
         }
         else
         {
@@ -1184,6 +1186,8 @@ void Group::CountTheRoll(Rolls::iterator& rollI)
                              player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
                     if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
                         player->OnReceivedItem(newItem);
+                    if (roll->getLoot()->isLooted())
+                        player->GetSession()->DoLootRelease(roll->getLoot()->GetLootTarget()->GetObjectGuid());
                 }
                 else
                 {
@@ -1235,6 +1239,8 @@ void Group::CountTheRoll(Rolls::iterator& rollI)
                              player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
                     if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
                         player->OnReceivedItem(newItem);
+                    if (roll->getLoot()->isLooted())
+                        player->GetSession()->DoLootRelease(roll->getLoot()->GetLootTarget()->GetObjectGuid());
                 }
                 else
                 {


### PR DESCRIPTION
Fixes an issue with empty loot frame if group loot ends and noone is actively looting the corpse (very common situation).
Before:

https://github.com/user-attachments/assets/fe9e5707-6d93-4fdb-97cc-2611fabac28d




After:

https://github.com/user-attachments/assets/3632d71b-93ff-4e6b-8f5c-9ca153ad2c16

