### PR TITLE
Fix mmap generator aborting with the default configuration.

### DIFF
--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -113,6 +113,11 @@ namespace MMAP
 
         for (json::const_iterator mapIt = m_config.begin(); mapIt != m_config.end(); ++mapIt)
         {
+            // keys starting with '_' are comments ("_Info") or inert templates
+            // ("_map_override_template") and are not active map configs
+            if (!mapIt.key().empty() && mapIt.key()[0] == '_')
+                continue;
+
             if (!mapIt.value().is_object())
             {
                 printf("%s: entry '%s' is not a map config object!\n", configInputPath, mapIt.key().c_str());


### PR DESCRIPTION
## 🍰 Pullrequest

The configuration validation added in #3473 rejects any top-level `config.json` key whose value is not an object and calls `exit(EXIT_FAILURE)` when it encounters the first instance of such a key. The updated default `contrib/mmap/config.json` from that same PR has top-level `_Info` comment keys (string values), so `MoveMapGenerator` now aborts before building a single tile with the default configuration.

This skips `_`-prefixed top-level keys, matching the comment handling the `checkParams` lambda and the tile override loop in `validateConfig()` already use. Skipping `_map_override_template` as well is fine because it is inert ([`getMapIdConfig()`](https://github.com/vmangos/core/blob/66b158405593852880469c69084e63b58616f51d/contrib/mmap/src/TileWorker.cpp#L1009) only matches numeric map IDs).

### Proof
- None

### Issues
- None

### How2Test
- Run `MoveMapGenerator` with the default `contrib/mmap/config.json`; before this fix it prints `config.json: entry '_Info' is not a map config object!` and exits immediately, after it builds tiles as normal.

### Todo / Checklist
- [X] None