### PR TITLE
fix trainer type for trainers that only have recipes

### DIFF
--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -10602,7 +10602,7 @@ void ObjectMgr::LoadTrainers(char const* tableName, bool isTemplates)
         else
             trainerSpell.reqLevel = spellinfo->spellLevel;
 
-        if (SpellMgr::IsProfessionSpell(spellinfo->EffectTriggerSpell[0]))
+        if (SpellMgr::IsProfessionSpell(spellinfo->EffectTriggerSpell[0]) || SpellMgr::IsTradeskillSpell(spellinfo->EffectTriggerSpell[0]))
             data.trainerType = 2;
 
         ++count;

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -1344,6 +1344,15 @@ bool SpellMgr::IsProfessionSpell(uint32 spellId)
     return IsProfessionSkill(skill);
 }
 
+bool SpellMgr::IsTradeskillSpell(uint32 spellId)
+{
+    SpellEntry const* spellInfo = sSpellMgr.GetSpellEntry(spellId);
+    if (!spellInfo)
+        return false;
+
+    return spellInfo->Attributes & SPELL_ATTR_IS_TRADESKILL;
+}
+
 bool SpellMgr::IsPrimaryProfessionSpell(uint32 spellId)
 {
     SpellEntry const* spellInfo = sSpellMgr.GetSpellEntry(spellId);

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -607,6 +607,7 @@ class SpellMgr
 
         static bool IsProfessionOrRidingSpell(uint32 spellId);
         static bool IsProfessionSpell(uint32 spellId);
+        static bool IsTradeskillSpell(uint32 spellId);
         static bool IsPrimaryProfessionSpell(uint32 spellId);
         bool IsPrimaryProfessionFirstRankSpell(uint32 spellId) const;
 


### PR DESCRIPTION
This fixes an issue with some trainers having incorrect trainer type which causes their ui to display wrong icons and categories.
`.gm on`
`.go c "Nixx Sprocketspring"`
Before:
<img width="1920" height="1080" alt="WoWScrnShot_071026_114829_002" src="https://github.com/user-attachments/assets/66e9b952-8c8c-4fb9-9389-6b47e4fd53d8" />

After:
<img width="1920" height="1080" alt="WoWScrnShot_071026_114152_001" src="https://github.com/user-attachments/assets/941ee2cc-b434-4152-99c1-b7db343ec37a" />
