### PR TITLE
Add missing include

### DIFF
--- a/src/game/Server/Packets/Combat.h
+++ b/src/game/Server/Packets/Combat.h
@@ -4,6 +4,7 @@
 #include "Packet.h"
 #include "ObjectGuid.h"
 #include "DamageStructs.h"
+#include "nonstd/optional.hpp"
 
 namespace WorldPackets { namespace Combat
 {


### PR DESCRIPTION
## 🍰 Pullrequest
Add a missing include, otherwise the build with `USE_PCH=OFF` throws errors.

### Proof
<!-- Link resources as proof -->
Error message:
```
/home/u1/vmangos/core/src/game/Server/Packets/Combat.h:165:9: error: ‘nonstd’ does not name a type; did you mean ‘const’?
  165 |         nonstd::optional<DebugMeleeAttackingStateInfo> debugInfo;
      |         ^~~~~~
      |         const
```

### How2Test
Use `USE_PCH=OFF` to build the core.
