### PR TITLE
GetHeightStatic - add a delta to Z before choosing vmap height over mapheight

### DIFF
--- a/src/game/Maps/GridMap.cpp
+++ b/src/game/Maps/GridMap.cpp
@@ -860,7 +860,7 @@ float TerrainInfo::GetHeightStatic(float x, float y, float z, bool useVmaps/*=tr
             // we have mapheight and vmapheight and must select more appropriate
 
             // we are already under the surface or vmap height above map heigt
-            if (z < mapHeight || vmapHeight > mapHeight)
+            if (z + 1.0f  < mapHeight || vmapHeight > mapHeight)
                 return vmapHeight;
             return mapHeight;                               // better use .map surface height
         }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Prevent switching to vmap height, when z is slightly below mapheight,

Issue from https://github.com/vmangos/core/issues/3485 explained:

Pet is moving from ground to water. Underneath the terrain we have the sunken temple.
<img width="436" height="347" alt="image" src="https://github.com/user-attachments/assets/6e0a9c71-f2c6-43e1-9820-6dbbe7e31c9c" />

issue was traced to:
UpdateAllowedPositionZ -> GetWaterOrGroundLevel -> getHeightStatic

returning Z based on vmap height instead of mapheight.

Notes: 

- Probably needs more thorough testing (does it cause issues elsewhere in the world)
- Maybe some tinkering needed to find the best delta value


### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/vmangos/core/issues/3485

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
