### PR TITLE
Fix stabling for dismissed & dead pets.

### DIFF
--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -625,16 +625,59 @@ void WorldSession::HandleStablePet(WorldPackets::Npc::StablePet const& packet)
 
     Pet* pet = _player->GetPet();
 
-    // can't place in stable dead pet
-    if (!pet || !pet->IsAlive() || pet->GetPetType() != HUNTER_PET)
+    // Dismissed pet (exists in DB but not summoned)
+    if (!pet)
+    {
+        CharacterPetCache const* currentPetData = sCharacterDatabaseCache.GetCharacterPetByOwner(_player->GetGUIDLow());
+        if (!currentPetData || (currentPetData->slot != PET_SAVE_AS_CURRENT && currentPetData->slot != PET_SAVE_NOT_IN_SLOT))
+        {
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        CreatureInfo const* currentCreatureInfo = sObjectMgr.GetCreatureTemplate(currentPetData->entry);
+        if (!currentCreatureInfo || !currentCreatureInfo->IsTameable())
+        {
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        uint32 free_slot = PET_SAVE_FIRST_STABLE_SLOT;
+        bool usedSlots[PET_SAVE_LAST_STABLE_SLOT - PET_SAVE_FIRST_STABLE_SLOT + 1] = {false};
+        CharPetMap const& pets = sCharacterDatabaseCache.GetCharPetsMap();
+        CharPetMap::const_iterator myPets = pets.find(GetPlayer()->GetGUIDLow());
+        if (myPets != pets.end())
+            for (const auto it : myPets->second)
+                if (it->slot >= PET_SAVE_FIRST_STABLE_SLOT && it->slot <= PET_SAVE_LAST_STABLE_SLOT)
+                    usedSlots[it->slot - PET_SAVE_FIRST_STABLE_SLOT] = true;
+
+        for (free_slot = PET_SAVE_FIRST_STABLE_SLOT; free_slot <= PET_SAVE_LAST_STABLE_SLOT && usedSlots[free_slot - PET_SAVE_FIRST_STABLE_SLOT]; ++free_slot);
+
+        if (free_slot <= GetPlayer()->m_stableSlots)
+        {
+            CharacterDatabase.BeginTransaction();
+            static SqlStatementID updPet;
+            SqlStatement stmt = CharacterDatabase.CreateStatement(updPet, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+            stmt.PExecute(uint32(free_slot), _player->GetGUIDLow(), currentPetData->id);
+            CharacterDatabase.CommitTransaction();
+
+            const_cast<CharacterPetCache*>(currentPetData)->slot = free_slot;
+            SendStableResult(STABLE_SUCCESS_STABLE);
+        }
+        else
+            SendStableResult(STABLE_ERR_STABLE);
+
+        return;
+    }
+
+    // Summoned pet (alive or dead)
+    if (pet->GetPetType() != HUNTER_PET)
     {
         SendStableResult(STABLE_ERR_STABLE);
         return;
     }
 
     uint32 free_slot = PET_SAVE_FIRST_STABLE_SLOT;
-
-    // Find free slot for pet
     bool usedSlots[PET_SAVE_LAST_STABLE_SLOT - PET_SAVE_FIRST_STABLE_SLOT + 1] = {false};
     CharPetMap const& pets = sCharacterDatabaseCache.GetCharPetsMap();
     CharPetMap::const_iterator myPets = pets.find(GetPlayer()->GetGUIDLow());
@@ -665,8 +708,16 @@ void WorldSession::HandleUnstablePet(WorldPackets::Npc::UnstablePet const& packe
     GetPlayer()->InterruptSpellsWithChannelFlags(AURA_INTERRUPT_INTERACTING_CANCELS);
     GetPlayer()->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_INTERACTING_CANCELS);
 
-    CharacterPetCache const* petData = sCharacterDatabaseCache.GetCharacterPetCacheByOwnerAndId(_player->GetGUIDLow(), packet.petNumber);
+    // Only block if a pet is actually summoned in world
+    Pet* pet = _player->GetPet();
+    if (pet)
+    {
+        SendStableResult(STABLE_ERR_STABLE);
+        return;
+    }
 
+    // Look up the pet being unstabled
+    CharacterPetCache const* petData = sCharacterDatabaseCache.GetCharacterPetCacheByOwnerAndId(_player->GetGUIDLow(), packet.petNumber);
     if (!petData || petData->slot < PET_SAVE_FIRST_STABLE_SLOT || petData->slot > PET_SAVE_LAST_STABLE_SLOT)
     {
         SendStableResult(STABLE_ERR_STABLE);
@@ -681,11 +732,68 @@ void WorldSession::HandleUnstablePet(WorldPackets::Npc::UnstablePet const& packe
         return;
     }
 
-    // Player may have a pet, but unsummoned currently (too far away from owner ...). Do not erase this pet!
-    Pet* pet = _player->GetPet();
-    if (pet || sCharacterDatabaseCache.GetCharacterPetByOwner(_player->GetGUIDLow()))
+    // The current pet is dismissed. Treat this as a swap: move the dismissed pet
+    // into the vacated stable slot before unstabling the new one.
+    CharacterPetCache const* currentPetData = sCharacterDatabaseCache.GetCharacterPetByOwner(_player->GetGUIDLow());
+    if (currentPetData && (currentPetData->slot == PET_SAVE_AS_CURRENT || currentPetData->slot == PET_SAVE_NOT_IN_SLOT))
     {
-        SendStableResult(STABLE_ERR_STABLE);
+        uint32 slot = petData->slot;
+
+        // If the pet being unstabled is dead, swap slots and leave it NOT_IN_SLOT
+        if (petData->currentHealth == 0)
+        {
+            CharacterDatabase.BeginTransaction();
+            static SqlStatementID updPet1;
+            SqlStatement stmt = CharacterDatabase.CreateStatement(updPet1, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+            stmt.PExecute(uint32(slot), _player->GetGUIDLow(), currentPetData->id);
+            static SqlStatementID updPet2;
+            stmt = CharacterDatabase.CreateStatement(updPet2, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+            stmt.PExecute(uint32(PET_SAVE_NOT_IN_SLOT), _player->GetGUIDLow(), petData->id);
+            CharacterDatabase.CommitTransaction();
+
+            const_cast<CharacterPetCache*>(currentPetData)->slot = slot;
+            const_cast<CharacterPetCache*>(petData)->slot = PET_SAVE_NOT_IN_SLOT;
+            SendStableResult(STABLE_SUCCESS_UNSTABLE);
+            return;
+        }
+
+        // Swap slots and summon the new pet
+        CharacterDatabase.BeginTransaction();
+        static SqlStatementID updPet1;
+        SqlStatement stmt = CharacterDatabase.CreateStatement(updPet1, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+        stmt.PExecute(uint32(slot), _player->GetGUIDLow(), currentPetData->id);
+        static SqlStatementID updPet2;
+        stmt = CharacterDatabase.CreateStatement(updPet2, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+        stmt.PExecute(uint32(PET_SAVE_AS_CURRENT), _player->GetGUIDLow(), petData->id);
+        CharacterDatabase.CommitTransaction();
+
+        const_cast<CharacterPetCache*>(currentPetData)->slot = slot;
+        const_cast<CharacterPetCache*>(petData)->slot = PET_SAVE_AS_CURRENT;
+
+        Pet* newpet = new Pet(HUNTER_PET);
+        if (!newpet->LoadPetFromDB(_player, creatureId, packet.petNumber))
+        {
+            delete newpet;
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        SendPetNameQuery(newpet->GetObjectGuid(), newpet->GetCharmInfo()->GetPetNumber());
+        SendStableResult(STABLE_SUCCESS_UNSTABLE);
+        return;
+    }
+
+    // No current pet - simple unstable
+    if (petData->currentHealth == 0)
+    {
+        CharacterDatabase.BeginTransaction();
+        static SqlStatementID updPet;
+        SqlStatement stmt = CharacterDatabase.CreateStatement(updPet, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+        stmt.PExecute(uint32(PET_SAVE_NOT_IN_SLOT), _player->GetGUIDLow(), petData->id);
+        CharacterDatabase.CommitTransaction();
+
+        const_cast<CharacterPetCache*>(petData)->slot = PET_SAVE_NOT_IN_SLOT;
+        SendStableResult(STABLE_SUCCESS_UNSTABLE);
         return;
     }
 
@@ -698,6 +806,7 @@ void WorldSession::HandleUnstablePet(WorldPackets::Npc::UnstablePet const& packe
         return;
     }
 
+    SendPetNameQuery(newpet->GetObjectGuid(), newpet->GetCharmInfo()->GetPetNumber());
     SendStableResult(STABLE_SUCCESS_UNSTABLE);
 }
 
@@ -745,13 +854,99 @@ void WorldSession::HandleStableSwapPet(WorldPackets::Npc::StableSwapPet const& p
 
     Pet* pet = _player->GetPet();
 
-    if (!pet || !pet->IsAlive() || pet->GetPetType() != HUNTER_PET)
+    // Dismissed pet (exists in DB but not summoned)
+    if (!pet)
+    {
+        CharacterPetCache const* currentPetData = sCharacterDatabaseCache.GetCharacterPetByOwner(_player->GetGUIDLow());
+        if (!currentPetData || (currentPetData->slot != PET_SAVE_AS_CURRENT && currentPetData->slot != PET_SAVE_NOT_IN_SLOT))
+        {
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        CreatureInfo const* currentCreatureInfo = sObjectMgr.GetCreatureTemplate(currentPetData->entry);
+        if (!currentCreatureInfo || !currentCreatureInfo->IsTameable())
+        {
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        CharacterPetCache const* swappedPet = sCharacterDatabaseCache.GetCharacterPetCacheByOwnerAndId(_player->GetGUIDLow(), packet.petNumber);
+        if (!swappedPet)
+        {
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        uint32 slot = swappedPet->slot;
+        uint32 creature_id = swappedPet->entry;
+        if (!creature_id)
+        {
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        CreatureInfo const* creatureInfo = sObjectMgr.GetCreatureTemplate(creature_id);
+        if (!creatureInfo || !creatureInfo->IsTameable())
+        {
+            SendStableResult(STABLE_ERR_STABLE);
+            return;
+        }
+
+        // If swapped pet is dead, move to PET_SAVE_NOT_IN_SLOT instead of spawning
+        if (swappedPet->currentHealth == 0)
+        {
+            CharacterDatabase.BeginTransaction();
+            static SqlStatementID updPet1;
+            SqlStatement stmt = CharacterDatabase.CreateStatement(updPet1, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+            stmt.PExecute(uint32(slot), _player->GetGUIDLow(), currentPetData->id);
+            static SqlStatementID updPet2;
+            stmt = CharacterDatabase.CreateStatement(updPet2, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+            stmt.PExecute(uint32(PET_SAVE_NOT_IN_SLOT), _player->GetGUIDLow(), swappedPet->id);
+            CharacterDatabase.CommitTransaction();
+
+            const_cast<CharacterPetCache*>(currentPetData)->slot = slot;
+            const_cast<CharacterPetCache*>(swappedPet)->slot = PET_SAVE_NOT_IN_SLOT;
+            SendStableResult(STABLE_SUCCESS_UNSTABLE);
+            return;
+        }
+
+        // Move current pet to stable slot, swapped pet to current
+        CharacterDatabase.BeginTransaction();
+        static SqlStatementID updPet1;
+        SqlStatement stmt = CharacterDatabase.CreateStatement(updPet1, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+        stmt.PExecute(uint32(slot), _player->GetGUIDLow(), currentPetData->id);
+        static SqlStatementID updPet2;
+        stmt = CharacterDatabase.CreateStatement(updPet2, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+        stmt.PExecute(uint32(PET_SAVE_AS_CURRENT), _player->GetGUIDLow(), swappedPet->id);
+        CharacterDatabase.CommitTransaction();
+
+        const_cast<CharacterPetCache*>(currentPetData)->slot = slot;
+        const_cast<CharacterPetCache*>(swappedPet)->slot = PET_SAVE_AS_CURRENT;
+
+        // Summon the unstabled pet
+        Pet* newpet = new Pet(HUNTER_PET);
+        if (!newpet->LoadPetFromDB(_player, creature_id, packet.petNumber))
+        {
+            delete newpet;
+            SendStableResult(STABLE_ERR_STABLE);
+        }
+        else
+        {
+            SendPetNameQuery(newpet->GetObjectGuid(), newpet->GetCharmInfo()->GetPetNumber());
+            SendStableResult(STABLE_SUCCESS_UNSTABLE);
+        }
+
+        return;
+    }
+
+    // Summoned pet (alive or dead)
+    if (pet->GetPetType() != HUNTER_PET)
     {
         SendStableResult(STABLE_ERR_STABLE);
         return;
     }
 
-    // find swapped pet slot in stable
     CharacterPetCache const* swappedPet = sCharacterDatabaseCache.GetCharacterPetCacheByOwnerAndId(_player->GetGUIDLow(), packet.petNumber);
     if (!swappedPet)
     {
@@ -759,9 +954,8 @@ void WorldSession::HandleStableSwapPet(WorldPackets::Npc::StableSwapPet const& p
         return;
     }
 
-    uint32 slot        = swappedPet->slot;
+    uint32 slot = swappedPet->slot;
     uint32 creature_id = swappedPet->entry;
-
     if (!creature_id)
     {
         SendStableResult(STABLE_ERR_STABLE);
@@ -775,17 +969,35 @@ void WorldSession::HandleStableSwapPet(WorldPackets::Npc::StableSwapPet const& p
         return;
     }
 
+    // If swapped pet is dead, move to PET_SAVE_NOT_IN_SLOT instead of spawning
+    if (swappedPet->currentHealth == 0)
+    {
+        pet->Unsummon(PetSaveMode(slot), _player);
+        CharacterDatabase.BeginTransaction();
+        static SqlStatementID updPet;
+        SqlStatement stmt = CharacterDatabase.CreateStatement(updPet, "UPDATE `character_pet` SET `slot` = ? WHERE `owner_guid` = ? AND `id` = ?");
+        stmt.PExecute(uint32(PET_SAVE_NOT_IN_SLOT), _player->GetGUIDLow(), swappedPet->id);
+        CharacterDatabase.CommitTransaction();
+
+        const_cast<CharacterPetCache*>(swappedPet)->slot = PET_SAVE_NOT_IN_SLOT;
+        SendStableResult(STABLE_SUCCESS_UNSTABLE);
+        return;
+    }
+
     pet->Unsummon(PetSaveMode(slot), _player);
 
-    // summon unstabled pet
-    Pet* newpet = new Pet;
+    // Summon the unstabled pet
+    Pet* newpet = new Pet(HUNTER_PET);
     if (!newpet->LoadPetFromDB(_player, creature_id, packet.petNumber))
     {
         delete newpet;
         SendStableResult(STABLE_ERR_STABLE);
     }
     else
+    {
+        SendPetNameQuery(newpet->GetObjectGuid(), newpet->GetCharmInfo()->GetPetNumber());
         SendStableResult(STABLE_SUCCESS_UNSTABLE);
+    }
 }
 
 void WorldSession::HandleRepairItemOpcode(WorldPackets::Npc::RepairItem const& packet)

--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -783,7 +783,7 @@ void WorldSession::HandleUnstablePet(WorldPackets::Npc::UnstablePet const& packe
         return;
     }
 
-    // No current pet - simple unstable
+    // No current pet and the pet being unstabled is dead — move to NOT_IN_SLOT
     if (petData->currentHealth == 0)
     {
         CharacterDatabase.BeginTransaction();

--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -783,7 +783,7 @@ void WorldSession::HandleUnstablePet(WorldPackets::Npc::UnstablePet const& packe
         return;
     }
 
-    // No current pet and the pet being unstabled is dead — move to NOT_IN_SLOT
+    // Empty current slot and the pet being unstabled is dead, move to NOT_IN_SLOT
     if (petData->currentHealth == 0)
     {
         CharacterDatabase.BeginTransaction();

--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -533,7 +533,7 @@ void WorldSession::SendStablePet(ObjectGuid guid)
 
     uint8 num = 0;                                          // counter for place holder
 
-    // not let move dead pet in slot
+    // Send current summoned pet if alive
     if (pet && pet->IsAlive() && pet->GetPetType() == HUNTER_PET)
     {
         data << uint32(pet->GetCharmInfo()->GetPetNumber());
@@ -544,7 +544,7 @@ void WorldSession::SendStablePet(ObjectGuid guid)
         data << uint8(0x01);                                // client slot 1 == current pet (0)
         ++num;
     }
-    // Pet may be despawned if owner went far away from pet for example.
+    // Send current pet from DB if dismissed or dead
     else if (CharacterPetCache const* currentPetData = sCharacterDatabaseCache.GetCharacterPetByOwner(_player->GetGUIDLow()))
     {
         data << uint32(currentPetData->id);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR makes it possible for hunters to stable dismissed and dead pets (including dismissed dead pet). Before you couldn't stable dismissed pets or dead pets.

Also fixes the name of pets when unstabling, before it would always show up as unknown unless you click the pet unstabled pet in the current pet slot.

Written with a bunch of help from AI, but all works as expected in game. There may be some possible improvements that could be done to the code, especially to reduce the code duplication.

### Proof
<!-- Link resources as proof -->
Proof covers everything except stabling a dead pet still in the world, but proof shows you can stable a dead dismissed pet, so logically you should also be able to stable a dead in world pet.

Note: Classic TBC PTR can’t be used to test this because it seems its stable master behaves like retail, dismissing all pets on unstabling.

- Joana stables pet in first slot
https://youtu.be/cboL6vEDetw?si=KAvGXeMmWECHKDYY&t=227
Afterwards he unstables it, which causes it be summoned:
https://www.youtube.com/watch?v=jX9wGm27CSc&t=200s

- Switched unstabled pet with stabled pet:
https://youtu.be/VBlnzRNTatI?si=-HiqJeW6jjaleA0Z&t=37

- Dropping off dismissed pet at stable master
https://youtu.be/rFcE2P8E44c?si=14qex3kssUfrP42G&t=5034
becomes spawned upon collecting it with stable master
https://youtu.be/rFcE2P8E44c?si=QBt_rZJaJnNwQQC-&t=5571

- Joana stables the dead dismissed pet in vanilla patch 1.9.2:
https://youtu.be/Ehxo0J_87iI?t=17
Joana takes the dead pet out from stable, tries to use Call Pet only to get message "Your pet is dead":
https://youtu.be/Ehxo0J_87iI?t=622
He then use revive pet and it summons the pet.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Tame pet
- Target pet and do .die
- Go to stable master and stable it
- Unstable pet
- Revive it
- Dismiss it
- Stable it
- Tame another pet
- Go to stable master
- Swap the pets, either by dragging current to pet slot 1 or by dragging pet slot 1 into current
- Try swapping with dead pet as well

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
