### PR TITLE
Remove offline players from BG queue

### DIFF
--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -668,7 +668,10 @@ void BattleGroundQueue::RemoveOfflinePlayer()
 
         if (remove)
         {
-            itr = m_queuedPlayers.erase(itr);
+            ObjectGuid playerGuid = itr->first;
+            ++itr; 
+
+            RemovePlayer(playerGuid, true); 
         }
         else
         {


### PR DESCRIPTION
This commit addresses an issue with group queueing where if a player group queues for a BG while in a raid with offline members, the offline members will get queued into the BG queue slot indefinitely, preventing others from joining.