### PR TITLE
Clamp auction time left to the client's signed 32-bit millisecond range

### DIFF
--- a/src/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -835,7 +835,9 @@ bool AuctionEntry::BuildAuctionInfo(WorldPacket& data) const
     data << uint32(startbid);                               // Auction->startbid (not sure if useful)
     data << uint32(bid ? GetAuctionOutBid() : 0);           // minimal outbid
     data << uint32(buyout);                                 // auction->buyout
-    data << uint32((expireTime - time(nullptr))*IN_MILLISECONDS); // time left
+    int64 const timeLeftMs = std::max<int64>(
+        0, int64(expireTime - time(nullptr)) * IN_MILLISECONDS);
+    data << uint32(std::min<int64>(timeLeftMs, INT32_MAX)); // time left
     data << ObjectGuid(HIGHGUID_PLAYER, bidder);            // auction->bidder current
     data << uint32(bid);                                    // current bid
     return true;

--- a/src/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -835,9 +835,8 @@ bool AuctionEntry::BuildAuctionInfo(WorldPacket& data) const
     data << uint32(startbid);                               // Auction->startbid (not sure if useful)
     data << uint32(bid ? GetAuctionOutBid() : 0);           // minimal outbid
     data << uint32(buyout);                                 // auction->buyout
-    int64 const timeLeftMs = std::max<int64>(
-        0, int64(expireTime - time(nullptr)) * IN_MILLISECONDS);
-    data << uint32(std::min<int64>(timeLeftMs, INT32_MAX)); // time left
+    int64 const timeLeftMs = std::min<int64>(std::max<int64>(0, int64(expireTime - time(nullptr)) * IN_MILLISECONDS), INT32_MAX);
+    data << uint32(timeLeftMs);                             // time left
     data << ObjectGuid(HIGHGUID_PLAYER, bidder);            // auction->bidder current
     data << uint32(bid);                                    // current bid
     return true;


### PR DESCRIPTION
## 🍰 Pullrequest

The auction list packets write `uint32((expireTime - time(nullptr)) * IN_MILLISECONDS)` for the time-left field. The 1.12.1.5875 client adds this dword to its current 32-bit tick and `Script_GetAuctionItemTimeLeft` later subtracts the tick back out with signed 32-bit arithmetic, so any interval past the signed half-range (~24.8 days, reachable with raised auction-duration rates) wraps into the client's expired path. This clamps the written interval to `[0, INT32_MAX]` ms; the zero floor also covers the race where an auction expires while its list packet is being built.

### Proof
Client behavior from the 5875 binary: the auction-list handlers retain `recv_tick + time_left` per row and `Script_GetAuctionItemTimeLeft` computes the difference as a signed int. Tested with a stock 1.12.1.5875 client.

### Issues
- None found for this.