### PR TITLE
Accept the stock 1,000,000 random roll upper bound

### DIFF
--- a/src/game/Handlers/GroupHandler.cpp
+++ b/src/game/Handlers/GroupHandler.cpp
@@ -394,7 +394,7 @@ void WorldSession::HandleMinimapPingOpcode(WorldPackets::Group::MinimapPing cons
 void WorldSession::HandleRandomRollOpcode(WorldPackets::Group::RandomRoll const& packet)
 {
     /** error handling **/
-    if (packet.minimum > packet.maximum || packet.maximum > 10000) // < 32768 for urand call
+    if (packet.minimum > packet.maximum || packet.maximum > 1000000)
         return;
     /********************/
 


### PR DESCRIPTION
## 🍰 Pullrequest

`Script_RandomRoll` in client 1.12.1.5875 accepts `/roll` bounds up to and including 1,000,000 and sends both uint32 bounds in `MSG_RANDOM_ROLL`. The handler still enforces an older 10,000 ceiling and silently drops the request, so e.g. `/roll 999999` produces no result at all. `urand` handles the full range fine.

### Proof
Client gate from the 5875 binary: `Script_RandomRoll` rejects only bounds outside `[1, 1000000]` — anything it sends, a vanilla server answered. Tested with a stock 1.12.1.5875 client: `/roll 1000000` rolls; `/roll 1000001` is still rejected client-side.

### Issues
- None found for this.