### PR TITLE
Remove stalked-target auras from the target when the caster dies

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -4209,6 +4209,27 @@ void Unit::RemoveAuraTypeOnDeath(AuraType auraType)
 
 void Unit::RemoveAllAurasOnDeath()
 {
+    // Auras that track their target for the caster (SPELL_AURA_MOD_STALKED,
+    // i.e. Hunter's Mark) end when the tracking caster dies. Other
+    // caster-owned single-target auras retain their existing death behavior.
+    SingleCastSpellTargetMap& singleTargets = GetSingleCastSpellTargets();
+    for (SingleCastSpellTargetMap::iterator itr = singleTargets.begin(); itr != singleTargets.end();)
+    {
+        SpellEntry const* spellInfo = itr->first;
+        if (!spellInfo->HasAura(SPELL_AURA_MOD_STALKED))
+        {
+            ++itr;
+            continue;
+        }
+
+        ObjectGuid const targetGuid = itr->second;
+        singleTargets.erase(itr);
+        if (IsInWorld())
+            if (Unit* target = GetMap()->GetUnit(targetGuid))
+                target->RemoveAurasByCasterSpell(spellInfo->Id, GetObjectGuid(), AURA_REMOVE_BY_DEATH);
+        itr = singleTargets.begin();
+    }
+
     // used just after dieing to remove all visible auras
     // and disable the mods for the passive ones
     for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)


### PR DESCRIPTION
## 🍰 Pullrequest

When a hunter dies, Hunter's Mark currently stays on the target for its full duration. In vanilla the mark drops when its caster dies.

Per review feedback this now keys on `SPELL_AURA_MOD_STALKED` instead of checking for Hunter's Mark specifically: on death, the dying unit's single-cast-target registry is walked and stalked-target auras are removed from their targets, before local death-aura cleanup runs.

In the 1.12 DBC the only single-target spells carrying the stalked aura are the four Hunter's Mark ranks, Mind Vision (a channel that already ends on caster death), and the internal Syndicate Tracker (MURP) DND spell, so the generic check stays tightly scoped in practice.

### Proof
Vanilla footage of the mark dropping on hunter death (see the videos in #1615). Tested with a stock 1.12.1.5875 client: the mark drops from the target frame on caster death; other single-target auras are unaffected.

### Issues
- fixes #1615