### PR TITLE
Validate the master looter GUID in CMSG_LOOT_METHOD

### DIFF
--- a/src/game/Handlers/GroupHandler.cpp
+++ b/src/game/Handlers/GroupHandler.cpp
@@ -351,9 +351,16 @@ void WorldSession::HandleLootMethodOpcode(WorldPackets::Group::LootMethod const&
         return;
     /********************/
 
+    if (packet.lootMethod == MASTER_LOOT && !group->IsMember(packet.lootMaster))
+        return;
+
+    ObjectGuid const lootMaster = packet.lootMethod == MASTER_LOOT
+        ? packet.lootMaster
+        : ObjectGuid();
+
     // everything is fine, do it
     group->SetLootMethod((LootMethod)packet.lootMethod);
-    group->SetLooterGuid(packet.lootMaster);
+    group->SetLooterGuid(lootMaster);
     group->SetLootThreshold((ItemQualities)packet.lootThreshold);
     group->SendUpdate();
 }

--- a/src/game/Handlers/GroupHandler.cpp
+++ b/src/game/Handlers/GroupHandler.cpp
@@ -346,21 +346,23 @@ void WorldSession::HandleLootMethodOpcode(WorldPackets::Group::LootMethod const&
     if (!group)
         return;
 
-    /** error handling **/
     if (!group->IsLeader(GetPlayer()->GetObjectGuid()))
         return;
-    /********************/
 
-    if (packet.lootMethod == MASTER_LOOT && !group->IsMember(packet.lootMaster))
-        return;
-
-    ObjectGuid const lootMaster = packet.lootMethod == MASTER_LOOT
-        ? packet.lootMaster
-        : ObjectGuid();
-
+    if (packet.lootMethod == MASTER_LOOT)
+    {
+        if (!group->IsMember(packet.lootMaster))
+            return;
+    }
+    else
+    {
+        // cannot have loot master in other loot methods
+        const_cast<ObjectGuid&>(packet.lootMaster).Clear();
+    }
+    
     // everything is fine, do it
     group->SetLootMethod((LootMethod)packet.lootMethod);
-    group->SetLooterGuid(lootMaster);
+    group->SetLooterGuid(packet.lootMaster);
     group->SetLootThreshold((ItemQualities)packet.lootThreshold);
     group->SendUpdate();
 }


### PR DESCRIPTION
## 🍰 Pullrequest

`HandleLootMethodOpcode` checks only that the sender is the leader and then stores `packet.lootMaster` unconditionally. Two gaps versus the stock producer:

- A modified client can set an arbitrary GUID (non-member, offline player, creature) as durable master-looter state.
- For non-master methods the stock client always sends a zero master GUID; storing whatever arrived leaves stale looter GUIDs on non-master methods.

This requires that master loot names a current roster member (leader included) and canonicalizes the stored looter GUID to zero for every other method.

### Proof
Producer contract from the 5875 binary: `Script_SetLootMethod` resolves the master against the active player, party, or raid roster before `CMSG_LOOT_METHOD` is sent — a compliant client can never produce the GUIDs this rejects. Tested with a stock 1.12.1.5875 client; master-loot assignment and method switching behave identically.

### Issues
- None found for this (loot-distribution reports #1130/#1871 concern a different path).