### PR TITLE
Check for Hearthstone space before changing a player’s home

### DIFF
--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -499,6 +499,25 @@ void WorldSession::SendBindPoint(Creature* npc)
     if (GetPlayer()->GetMap()->Instanceable())
         return;
 
+    // Spell 3286 applies the bind before creating a Hearthstone. Its
+    // create-item effect is in slot 1, while CheckCast only protects
+    // a non-triggered create-item effect in slot 0.
+    // Preflight the authoritative operation so a missing Hearthstone
+    // and full inventory cannot still change the player's home.
+    static uint32 const HearthstoneItemId = 6948;
+    if (!GetPlayer()->HasItemCount(HearthstoneItemId, 1, true))
+    {
+        ItemPosCountVec destinations;
+        InventoryResult const result = GetPlayer()->CanStoreNewItem(
+            NULL_BAG, NULL_SLOT, destinations, HearthstoneItemId, 1);
+        if (result != EQUIP_ERR_OK)
+        {
+            GetPlayer()->SendEquipError(
+                result, nullptr, nullptr, 0, HearthstoneItemId);
+            return;
+        }
+    }
+
     // send spell for bind 3286 bind magic
     npc->CastSpell(_player, 3286, true);                    // Bind
 


### PR DESCRIPTION
## Summary

When a player needs a new Hearthstone, check for bag space before the innkeeper changes their home location. If their bags are full, show the inventory error and leave their home unchanged. Players who already own a Hearthstone can still rebind normally.

## Details

## 🍰 Pullrequest

`SendBindPoint` unconditionally casts spell 3286 on `CMSG_BINDER_ACTIVATE`. Effect 0 (bind) executes before effect 1 (create Hearthstone item 6948), so a player with full bags and no Hearthstone gets a committed home-bind change plus a failed item creation — and the bind can't be rolled back.

The 5875 client's `ConfirmBinder` intentionally sends the packet without any inventory preflight, so the server is the only place to check. This adds a capacity preflight before the cast: a free slot is required only when the character owns no Hearthstone at all (bags and bank checked — an existing stone means effect 1 creates nothing). On failure the player gets the ordinary `EQUIP_ERR_INVENTORY_FULL`, the gossip stays open, and home is unchanged.

### Proof
Spell.dbc 3286: effect 0 `SPELL_EFFECT_BIND` precedes effect 1 `SPELL_EFFECT_CREATE_ITEM` (6948). Tested with a stock 1.12.1.5875 client: full-bag/no-stone binding fails cleanly with home intact; normal binding and rebinding with an existing stone unchanged.

### Issues
- None found for this.

[Codex, acting on behalf of relh]
