### PR TITLE
Preserve the Forgiveness impact visual before Mograine's delayed death

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1293,16 +1293,16 @@ void Spell::EffectDummy(SpellEffectIndex effIdx)
                 {
                     if (unitTarget && m_casterUnit)
                     {
-                        ObjectGuid const targetGuid = unitTarget->GetObjectGuid();
+                        // kill is delayed so that spell visual can display properly
                         m_casterUnit->m_Events.AddLambdaEventAtOffset(
-                            [caster = m_casterUnit, targetGuid]
+                            [caster = m_casterUnit, targetGuid = unitTarget->GetObjectGuid()]
                             {
                                 if (!caster->IsInWorld())
                                     return;
                                 if (Unit* target = caster->GetMap()->GetUnit(targetGuid))
                                     if (target->IsAlive())
                                         caster->Kill(target, nullptr);
-                            }, 500);
+                            }, BATCHING_INTERVAL);
                     }
                     return;
                 }

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1293,7 +1293,16 @@ void Spell::EffectDummy(SpellEffectIndex effIdx)
                 {
                     if (unitTarget && m_casterUnit)
                     {
-                        m_casterUnit->Kill(unitTarget, nullptr);
+                        ObjectGuid const targetGuid = unitTarget->GetObjectGuid();
+                        m_casterUnit->m_Events.AddLambdaEventAtOffset(
+                            [caster = m_casterUnit, targetGuid]
+                            {
+                                if (!caster->IsInWorld())
+                                    return;
+                                if (Unit* target = caster->GetMap()->GetUnit(targetGuid))
+                                    if (target->IsAlive())
+                                        caster->Kill(target, nullptr);
+                            }, 500);
                     }
                     return;
                 }


### PR DESCRIPTION
## 🍰 Pullrequest

In the Scarlet Monastery Ashbringer event, the Forgiveness (28697) dummy effect kills Commander Mograine synchronously. `SMSG_SPELL_GO` has already been sent and the 1.12 DBC chain (28697 → visual 7615 → chest impact kit 317) attaches the impact to the target — but death state arrives in the same update, so the client cancels it and Mograine drops with no visible Forgiveness hit.

Fix: keep the stock spell packet as the sole visual producer and delay only the kill by a short scripted event, resolving Mograine by GUID at execution time so the deferred event can never hold a dangling `Unit*` (despawn/evade between cast and kill is a clean no-op).

### Proof
DBC chain from 1.12 client data: 28697 → SpellVisual 7615 → impact kit 317. Tested with a stock 1.12.1.5875 client: the impact renders on Mograine before he dies and the Ashbringer event completes normally end-to-end.

### Issues
- None found for this.