### PR TITLE
Allow multiple Nefarius's Corruption accepters per scepter run

### DIFF
--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_vaelastrasz.cpp
@@ -477,15 +477,19 @@ bool QuestAccept_vaelastrasz(Player* pPlayer, Creature* pCreature, Quest const* 
 
     if (pQuest->GetQuestId() == QUEST_NEFARIUS_CORRUPTION)
     {
-        // Only one may accept
-        if (m_pInstance->GetData(TYPE_SCEPTER_RUN) != NOT_STARTED)
+        uint32 const scepterRunState = m_pInstance->GetData(TYPE_SCEPTER_RUN);
+        if (scepterRunState == NOT_STARTED)
+        {
+            // The first accepter starts the timed run and owns its one
+            // conditioned shard; later accepters must not replace it.
+            m_pInstance->SetData(TYPE_SCEPTER_RUN, SPECIAL);
+            m_pInstance->SetData(DATA_SCEPTER_CHAMPION, pPlayer->GetObjectGuid());
+        }
+        else if (scepterRunState != SPECIAL)
         {
             pPlayer->FailQuest(QUEST_NEFARIUS_CORRUPTION);
             return false;
         }
-
-        m_pInstance->SetData(TYPE_SCEPTER_RUN, SPECIAL);
-        m_pInstance->SetData(DATA_SCEPTER_CHAMPION, pPlayer->GetObjectGuid());
 
         // Permanently bind player to instance
         pCreature->GetMap()->BindToInstanceOrRaid(pPlayer, pCreature->GetRespawnTimeEx(), true);


### PR DESCRIPTION
## 🍰 Pullrequest

`boss_vaelastrasz` hard-fails Nefarius's Corruption for anyone who accepts after the first accepter (`// Only one may accept` → immediate `FailQuest`). In vanilla, multiple raiders could hold the quest during the same timed run — the exclusivity was on the reward, not the acceptance: Nefarian drops exactly one Red Scepter Shard, conditioned on the run's champion.

The instance script already records the first accepter as the Scepter Champion and conditions the single shard on that GUID. This keeps that loot owner stable and stops insta-failing later accepters while Vaelastrasz is still offering the quest in the pre-start SPECIAL state. Timer, champion designation, and the one-shard guarantee are unchanged.

### Proof
Vanilla-era attunement records describe several scepter-run participants holding the quest concurrently with a single shard recipient per run. Tested: multiple accepters can hold the quest, exactly one shard drops for the champion, expiry semantics unchanged.

### Issues
- relates #2998 (timer-expiry side of the same quest; this PR does not change timer behavior)