### PR TITLE
Send melee attack state before lethal damage

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2196,12 +2196,12 @@ void Unit::AttackerStateUpdate(Unit* pVictim, WeaponAttackType attType, bool ext
 
     ProcDamageAndSpell(ProcSystemArguments(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.totalDamage, damageInfo.totalDamage + damageInfo.totalAbsorb + damageInfo.totalResist, damageInfo.attackType));
 
-    // In sniffs SMSG_ATTACKERSTATEUPDATE follows chance-on-hit spell casts.
+    // In sniffs SMSG_ATTACKERSTATEUPDATE is sent after chance on hit spell casts from CastItemCombatSpell. This fixes animation for Frostbrand Attack.
     // Send it before lethal damage so the client can still resolve the victim
     // for swing animation, combat feedback, and victim-anchored world text.
     SendAttackStateUpdate(&damageInfo);
 
-    // Damage remains after procs so victim auras can affect the caster on a killing blow.
+    // Damage is done after procs so it can trigger auras on the victim that affect the caster in case of killing blow.
     DealMeleeDamage(&damageInfo, true);
 
     if (IsPlayer())

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2196,11 +2196,13 @@ void Unit::AttackerStateUpdate(Unit* pVictim, WeaponAttackType attType, bool ext
 
     ProcDamageAndSpell(ProcSystemArguments(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.totalDamage, damageInfo.totalDamage + damageInfo.totalAbsorb + damageInfo.totalResist, damageInfo.attackType));
 
-    // Damage is done after procs so it can trigger auras on the victim that affect the caster in case of killing blow.
-    DealMeleeDamage(&damageInfo, true);
-
-    // In sniffs SMSG_ATTACKERSTATEUPDATE is sent after chance on hit spell casts from CastItemCombatSpell. This fixes animation for Frostbrand Attack.
+    // In sniffs SMSG_ATTACKERSTATEUPDATE follows chance-on-hit spell casts.
+    // Send it before lethal damage so the client can still resolve the victim
+    // for swing animation, combat feedback, and victim-anchored world text.
     SendAttackStateUpdate(&damageInfo);
+
+    // Damage remains after procs so victim auras can affect the caster on a killing blow.
+    DealMeleeDamage(&damageInfo, true);
 
     if (IsPlayer())
         DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (Player) %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",


### PR DESCRIPTION
## Pull request

Send `SMSG_ATTACKERSTATEUPDATE` after chance-on-hit procs but before applying melee damage. On a lethal white hit, applying damage first can advance the victim through its death lifecycle before the client receives the swing packet, leaving no victim object to anchor floating combat text.

The change preserves the sniff-backed ordering relative to chance-on-hit spell casts and keeps damage after procs, so victim auras can still affect the attacker on a killing blow.

### Proof

- The Vanilla footage and reproduction are documented in #3326.
- The nonlethal packet contents and combat-log behavior are unchanged; only dispatch relative to the server-side death transition moves.

### Issues

- Fixes #3326

### How2Test

1. Create a character and attack a low-level creature using only white auto attacks.
2. Let an auto attack deliver the killing blow.
3. Confirm the killing-blow damage appears as floating combat text as well as in the combat log.
4. Repeat with a chance-on-hit weapon effect and confirm its spell animation still precedes the melee swing feedback.

### Todo / Checklist

- [x] Keep chance-on-hit proc ordering unchanged.
- [x] Keep melee damage after proc processing.
- [x] Limit the change to `Unit::AttackerStateUpdate`.