### PR TITLE
clear emote state on enter combat

### DIFF
--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -3659,6 +3659,7 @@ void Creature::OnEnterCombat(Unit* pWho, bool notInCombat)
         ResetCombatTime();
         UpdateCombatState(true);
 
+        HandleEmoteState(0);
         SetStandState(UNIT_STAND_STATE_STAND);
         m_pacifiedTimer = 0;
 


### PR DESCRIPTION
Fixes creatures with EMOTE_STATE_SPELLPRECAST facing in combat.

Before:

https://github.com/user-attachments/assets/fe466789-4372-4522-908c-ba8b78590f28


After:

https://github.com/user-attachments/assets/8c15d887-0db9-4cc0-ab29-fc97ac9ce44b

