### PR TITLE
unit.cpp - refactors

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -59,7 +59,8 @@
 #include "MovementPacketSender.h"
 #include "Errors.h"
 #include "Utilities/Random.h"
-#include "ScriptMgr.h"
+
+#include <limits>
 
 //#define DEBUG_DEBUFF_LIMIT
 
@@ -481,11 +482,9 @@ bool Unit::HaveOffhandWeapon() const
 
     if (IsPlayer())
         return ((Player*)this)->GetWeaponForAttack(OFF_ATTACK, true, true);
-    else
-    {
-        uint8 itemClass = GetByteValue(UNIT_VIRTUAL_ITEM_INFO + (1 * 2) + 0, VIRTUAL_ITEM_INFO_0_OFFSET_CLASS);
-        return itemClass == ITEM_CLASS_WEAPON;
-    }
+
+    uint8 itemClass = GetByteValue(UNIT_VIRTUAL_ITEM_INFO + (1 * 2) + 0, VIRTUAL_ITEM_INFO_0_OFFSET_CLASS);
+    return itemClass == ITEM_CLASS_WEAPON;
 }
 
 void Unit::SendHeartBeat(bool includingSelf)
@@ -2404,28 +2403,24 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* pVictim, WeaponAttackT
         {
             return MELEE_HIT_CRUSHING;
         }
-        else
+        // mobs can score crushing blows if they're 3 or more levels above victim
+        // or when their weapon skill is 15 or more above victim's defense skill
+        tmp = victimDefenseSkill;
+        int32 tmpmax = victimMaxSkillValueForLevel;
+        // having defense above your maximum (from items, talents etc.) has no effect
+        tmp = tmp > tmpmax ? tmpmax : tmp;
+        // tmp = mob's level * 5 - player's current defense skill
+        tmp = attackerMaxSkillValueForLevel - tmp;
+        if (tmp >= 15)
         {
-            // mobs can score crushing blows if they're 3 or more levels above victim
-            // or when their weapon skill is 15 or more above victim's defense skill
-            tmp = victimDefenseSkill;
-            int32 tmpmax = victimMaxSkillValueForLevel;
-            // having defense above your maximum (from items, talents etc.) has no effect
-            tmp = tmp > tmpmax ? tmpmax : tmp;
-            // tmp = mob's level * 5 - player's current defense skill
-            tmp = attackerMaxSkillValueForLevel - tmp;
-            if (tmp >= 15)
+            // add 2% chance per lacking skill point, min. is 15%
+            tmp = tmp * 200 - 1500;
+            if (roll < (sum += tmp))
             {
-                // add 2% chance per lacking skill point, min. is 15%
-                tmp = tmp * 200 - 1500;
-                if (roll < (sum += tmp))
-                {
-                    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: CRUSHING <%d, %d)", sum - tmp, sum);
-                    return MELEE_HIT_CRUSHING;
-                }
+                DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: CRUSHING <%d, %d)", sum - tmp, sum);
+                return MELEE_HIT_CRUSHING;
             }
         }
-
     }
 
     DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: NORMAL");
@@ -2702,17 +2697,13 @@ float Unit::GetUnitDodgeChance() const
         return 0.0f;
     if (IsPlayer())
         return GetFloatValue(PLAYER_DODGE_PERCENTAGE);
-    else
-    {
-        if (((Creature const*)this)->IsTotem())
-            return 0.0f;
-        else
-        {
-            float dodge = 5.0f;
-            dodge += GetTotalAuraModifier(SPELL_AURA_MOD_DODGE_PERCENT);
-            return dodge > 0.0f ? dodge : 0.0f;
-        }
-    }
+
+    if (((Creature const*)this)->IsTotem())
+        return 0.0f;
+
+    float dodge = 5.0f;
+    dodge += GetTotalAuraModifier(SPELL_AURA_MOD_DODGE_PERCENT);
+    return dodge > 0.0f ? dodge : 0.0f;
 }
 
 float Unit::GetUnitParryChance() const
@@ -2769,17 +2760,13 @@ float Unit::GetUnitBlockChance() const
         // is player but has no block ability or no not broken shield equipped
         return 0.0f;
     }
-    else
-    {
-        if (((Creature const*)this)->IsTotem())
-            return 0.0f;
-        else
-        {
-            float block = 5.0f;
-            block += GetTotalAuraModifier(SPELL_AURA_MOD_BLOCK_PERCENT);
-            return block > 0.0f ? block : 0.0f;
-        }
-    }
+
+    if (((Creature const*)this)->IsTotem())
+        return 0.0f;
+
+    float block = 5.0f;
+    block += GetTotalAuraModifier(SPELL_AURA_MOD_BLOCK_PERCENT);
+    return block > 0.0f ? block : 0.0f;
 }
 
 float Unit::GetUnitCriticalChance(WeaponAttackType attackType, Unit const* pVictim) const
@@ -3068,8 +3055,8 @@ bool Unit::IsInAccessablePlaceFor(Creature const* c) const
 {
     if (IsInWater())
         return c->CanSwim();
-    else
-        return c->CanWalk() || c->CanFly();
+
+    return c->CanWalk() || c->CanFly();
 }
 
 bool Unit::CanSwimAtPosition(float x, float y, float z) const
@@ -5975,10 +5962,7 @@ void Unit::ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply)
                     return;
         }
 
-        SpellImmune Immune;
-        Immune.spellId = spellId;
-        Immune.type = type;
-        m_spellImmune[op].push_back(Immune);
+        m_spellImmune[op].push_back({spellId, type});
     }
     else
     {
@@ -8923,7 +8907,7 @@ void Unit::HandlePetCommand(CommandStates command, Unit* pTarget)
 
             ClearUnitState(UNIT_STATE_FOLLOW);
             // This is true if pet has no target or has target but targets differs.
-            if (GetVictim() != pTarget || (GetVictim() == pTarget && !GetCharmInfo()->IsCommandAttack()) || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_POSSESSED))
+            if (GetVictim() != pTarget || !GetCharmInfo()->IsCommandAttack() || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_POSSESSED))
             {
                 if (GetVictim())
                     AttackStop();
@@ -9702,7 +9686,11 @@ uint8 Unit::GetEnemyCountInRadiusAround(Unit const* pTarget, float radius) const
     MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(pTarget, this, radius);
     MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
     Cell::VisitAllObjects(pTarget, searcher, radius);
-    return targets.size();
+
+    if (targets.size() > std::numeric_limits<uint8>::max())
+        return std::numeric_limits<uint8>::max();
+
+    return static_cast<uint8>(targets.size());
 }
 
 void Unit::GetEnemyListInRadiusAround(Unit const* pTarget, float radius, std::list<Unit*>& targets) const
@@ -9731,11 +9719,7 @@ Unit* Unit::SelectRandomUnfriendlyTarget(Unit const* except /*= nullptr*/, float
            (inFront && !this->HasInArc(*tIter, M_PI_F / 2)) ||
            (isValidAttackTarget && !IsValidAttackTarget(*tIter)) ||
            (notPvpEnabling && !CanAttackWithoutEnablingPvP(*tIter)))
-        {
-            std::list<Unit*>::iterator tIter2 = tIter;
-            ++tIter;
-            targets.erase(tIter2);
-        }
+            tIter = targets.erase(tIter);
         else
             ++tIter;
     }
@@ -9744,13 +9728,7 @@ Unit* Unit::SelectRandomUnfriendlyTarget(Unit const* except /*= nullptr*/, float
     if (targets.empty())
         return nullptr;
 
-    // select random
-    uint32 rIdx = urand(0, targets.size() - 1);
-    std::list<Unit*>::const_iterator tcIter = targets.begin();
-    for (uint32 i = 0; i < rIdx; ++i)
-        ++tcIter;
-
-    return *tcIter;
+    return SelectRandomContainerElement(targets);
 }
 
 Unit* Unit::SelectRandomFriendlyTarget(Unit const* except /*= nullptr*/, float radius /*= ATTACK_DISTANCE*/, bool inCombat) const
@@ -9770,11 +9748,7 @@ Unit* Unit::SelectRandomFriendlyTarget(Unit const* except /*= nullptr*/, float r
     for (std::list<Unit*>::iterator tIter = targets.begin(); tIter != targets.end();)
     {
         if (!IsWithinLOSInMap(*tIter) || (inCombat && !(*tIter)->IsInCombat()) || (*tIter)->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE))
-        {
-            std::list<Unit*>::iterator tIter2 = tIter;
-            ++tIter;
-            targets.erase(tIter2);
-        }
+            tIter = targets.erase(tIter);
         else
             ++tIter;
     }
@@ -9783,13 +9757,7 @@ Unit* Unit::SelectRandomFriendlyTarget(Unit const* except /*= nullptr*/, float r
     if (targets.empty())
         return nullptr;
 
-    // select random
-    uint32 rIdx = urand(0, targets.size() - 1);
-    std::list<Unit*>::const_iterator tcIter = targets.begin();
-    for (uint32 i = 0; i < rIdx; ++i)
-        ++tcIter;
-
-    return *tcIter;
+    return SelectRandomContainerElement(targets);
 }
 
 // Returns friendly unit with the most amount of hp missing from max hp
@@ -10244,17 +10212,10 @@ void Unit::StopAttackFaction(uint32 factionId)
         }
     }
 
-    AttackerSet const& attackers = GetAttackers();
-    for (AttackerSet::const_iterator itr = attackers.begin(); itr != attackers.end();)
-    {
+    AttackerSet attackers = GetAttackers();
+    for (AttackerSet::const_iterator itr = attackers.begin(); itr != attackers.end(); ++itr)
         if ((*itr)->GetFactionId() == factionId)
-        {
             (*itr)->AttackStop();
-            itr = attackers.begin();
-        }
-        else
-            ++itr;
-    }
 
     GetHostileRefManager().deleteReferencesForFaction(factionId);
 
@@ -10497,14 +10458,14 @@ bool Unit::GetRandomAttackPoint(Unit const* attacker, float &x, float &y, float 
         sizeFactor = DEFAULT_WORLD_OBJECT_SIZE;
 
     bool const canOnlySwim = attacker->CanSwim() && !attacker->CanWalk() && !attacker->CanFly();
-    bool const reachableBySwiming = attacker->CanSwimAtPosition(GetPosition());
+    bool const reachableBySwimming = attacker->CanSwimAtPosition(GetPosition());
 
     uint32 attackerCount = GetAttackers().size();
     if (attackerCount > 0)
         --attackerCount;
 
     // Don't compute a random position for a moving player or when swimming to player near shore
-    if ((IsPlayer() && IsMoving()) || (canOnlySwim && !reachableBySwiming))
+    if ((IsPlayer() && IsMoving()) || (canOnlySwim && !reachableBySwimming))
         attackerCount = 0;
 
     angle += (attackerCount ? ((float(M_PI / 2) - float(M_PI) * rand_norm_f()) * attackerCount / sizeFactor) * 0.3f : 0);
@@ -10539,10 +10500,10 @@ bool Unit::GetRandomAttackPoint(Unit const* attacker, float &x, float &y, float 
     y = initialPos.y + dist * sin(angle) * normalizedVectXY;
     z = initialPos.z + dist * normalizedVectZ;
 
-    if (attacker->CanFly() || (attacker->CanSwim() && reachableBySwiming) || !HasMMapsForCurrentMap())
+    if (attacker->CanFly() || (attacker->CanSwim() && reachableBySwimming) || !HasMMapsForCurrentMap())
     {
         GetMap()->GetLosHitPosition(initialPos.x, initialPos.y, initialPos.z, x, y, z, -0.2f);
-        if (attacker->CanSwim() && reachableBySwiming)
+        if (attacker->CanSwim() && reachableBySwimming)
         {
             float ground = 0.0f;
             float waterSurface = GetTerrain()->GetWaterLevel(x, y, z, &ground);
@@ -10555,7 +10516,7 @@ bool Unit::GetRandomAttackPoint(Unit const* attacker, float &x, float &y, float 
         }
         return true;
     }
-    else if (canOnlySwim && !reachableBySwiming)
+    else if (canOnlySwim && !reachableBySwimming)
     {
         z = GetTerrain()->GetWaterLevel(attacker->GetPositionX(), attacker->GetPositionY(), attacker->GetPositionZ());
         if (z != VMAP_INVALID_HEIGHT_VALUE)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
A small collection of minor refactors

- removed duplicate import
- flattened code - remove unneeded indentation after return
- simplified a boolean expr
- deduplication - make use of SelectRandomContainerElement
- corrected spelling of swimming
- remove unneeded use of 2nd iterator in SelectRandomUnfriendlyTarget and SelectRandomfriendlyTarget
- changed attackers in StopAttackFaction from a ref to a copy - pros: we dont need to reset iterator - cons: we are creating a copy... arguments can definitely be made for not changing this, but this way it matches [Spell::DoAllEffectOnTarget](https://github.com/vmangos/core/blob/development/src/game/Spells/Spell.cpp#L1533)
- not strictly a refactor, but clamping size to uint8 in GetEnemyCountInRadiusAround

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
