### PR TITLE
Fix Moam mana at spawn.

### DIFF
--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_moam.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_moam.cpp
@@ -67,6 +67,7 @@ struct boss_moamAI : public ScriptedAI
 
         m_bIsInCombat = false;
         m_uiArmorValue = m_creature->GetDefaultArmor();
+        m_creature->SetPower(POWER_MANA, 0);
 
         m_OGvictim.Clear();
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR makes Moams mana be at 0 at spawn which matches both vanilla and classic.
Prior to this PR, the mana was only set to 0 on combat.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #2043

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1. .gm on
2. .go creature 90909
3. .gm off
4. Profit

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
