### PR TITLE
Fix Obsidian Destroyer's Drain Mana.

### DIFF
--- a/sql/migrations/20260801035152_world.sql
+++ b/sql/migrations/20260801035152_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260801035152');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260801035152');
+-- Add your query below.
+
+
+-- Fix Obsidian Destroyer's Drain Mana targeting.
+DELETE FROM `spell_effect_mod` WHERE `Id`=25755 AND `EffectIndex` IN (0, 1);
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Spell 25755 (Drain Mana) had two rows in the spell_effect_mod table that forced EffectImplicitTargetA = 15 on both effects, overriding the correct DBC value of 6. This appears to have been an attempt to turn the spell into multi-target, but it completely broke targeting and prevented 25755 from hitting anything. The actual multi-targeting for 25755 has been handled by spell 25754 (Drain Mana) since before this PR.

The intended behavior (and how it works after this PR):
1. The NPC casts 25754 every 7 seconds.
2. 25754 runs AQ20DrainManaScript, which selects up to 6 players who have mana.
3. 25754 then casts 25755 on each of those targets.
4. 25755 drains mana and plays the visual.

Thanks to [GoonBoiBarry](https://github.com/GoonBoiBarry) for providing the fix in #2042

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #2042

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
-->
1. .gm on
2. .go creature 301189
3. .gm off
4. Profit

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
