### PR TITLE
Fix memory leak in ReadableBuffer assignment operators

### DIFF
--- a/src/shared/IO/ReadableBuffer.h
+++ b/src/shared/IO/ReadableBuffer.h
@@ -94,6 +94,7 @@ namespace IO
         // nullptr stuff
         ReadableBuffer(std::nullptr_t) : m_ptr(nullptr), m_size(0), m_type(BufferType::Unset) {}
         ReadableBuffer& operator=(std::nullptr_t) {
+            Destruct();
             m_ptr = nullptr;
             m_size = 0;
             m_type = BufferType::Unset;
@@ -164,6 +165,7 @@ namespace IO
             if (this == &other)
                 return *this; // Self-assignment check
 
+            Destruct();
             m_ptr = other.m_ptr;
             m_size = other.m_size;
             m_type = other.m_type;
@@ -220,6 +222,10 @@ namespace IO
 
         ReadableBuffer& operator=(ReadableBuffer&& other) noexcept
         {
+            if (this == &other)
+                return *this; // Self-assignment check
+
+            Destruct();
             m_ptr = other.m_ptr;
             m_size = other.m_size;
             m_type = other.m_type;


### PR DESCRIPTION
## 🍰 Pullrequest

`IO::ReadableBuffer` stores its payload in a union of `shared_ptr`s with manual
lifetime management. The destructor correctly calls `Destruct()`, but none of
the three assignment operators release the pointer they are already holding
before overwriting the union:

- `operator=(std::nullptr_t)` only sets `m_type = Unset`, abandoning the held
  `shared_ptr` without running its destructor, so its refcount never drops.
- The copy and move assignment operators placement-new a new `shared_ptr`
  directly over the live one.

`AsyncSocket` assigns `m_writeSrc = nullptr` when a write completes, so every
write that goes through `m_writeSrc` strands one `shared_ptr<ByteBuffer>`
holding that connection's send buffer (the per-send-loop
`std::make_shared<ByteBuffer>()` from `WorldSocket::SendPacket`, each with a
4 KB `DEFAULT_SIZE` reservation).

This PR calls `Destruct()` at the top of all three assignment operators, and
adds the missing self-assignment check to move assignment — harmless before,
but required once `Destruct()` runs there: a self-move would free the payload
and then placement-new from the freed object.

**Why Windows is hit much harder than Linux**: `AsyncSocket_posix::Write()`
tries an inline `::send()` first and returns early without ever touching
`m_writeSrc` when the kernel accepts the whole buffer — which on a healthy
connection is nearly always, so the buggy assignment rarely executes. The IOCP
implementation has no such fast path; every write stores into `m_writeSrc` and
therefore leaks on completion. Linux still leaks on writes that would block
(slow clients, saturated links). This matches the reports in #3491 all coming
from Windows servers.

The bug was introduced with the file in 28818aabd ("Replace ACE with native IO
implementation", #2740). The fix does not change packet content, ordering, or
timing — only when the send buffer's memory is released; the send loop holds
its own reference to any buffer still in flight.

### Proof

Measured with 50 headless clients (real sessions: SRP6 login, world auth,
movement and combat across 18 zones) against builds of `e65e48e3c`, identical
20-minute load on both platforms. `ByteBuffer` was instrumented with
per-call-site net-live counters (constructor return address, decrement in the
destructor):

Windows (MSVC 19.44), before the fix — RSS 269 MB → 2946 MB, linear
~95 MB/min, no levelling off:
