### PR TITLE
Fix quest log corruption in SendQuestUpdateAddItem

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -14551,7 +14551,10 @@ void Player::SendQuestUpdateAddItem(Quest const* pQuest, uint32 item_idx, uint32
         // Update player field and fire UNIT_QUEST_LOG_CHANGED for self for the current batch
         uint16 slot = FindQuestSlot(pQuest->GetQuestId());
         if (slot < MAX_QUEST_LOG_SIZE) {
-            SetQuestSlotCounter(slot + pQuest->GetReqCreatureOrGOcount(), uint8(item_idx), uint8(current + batchCount));
+            // item counters are stored after the creature or GO counters within the same quest slot
+            uint8 counterIdx = uint8(item_idx + pQuest->GetReqCreatureOrGOcount());
+            if (counterIdx < QUEST_OBJECTIVES_COUNT)
+                SetQuestSlotCounter(slot, counterIdx, uint8(current + batchCount));
         }
 
         count -= batchCount;


### PR DESCRIPTION
## 🍰 Pullrequest

`Player::SendQuestUpdateAddItem` applies the creature-objective count offset to the wrong argument of `SetQuestSlotCounter`:

```cpp
SetQuestSlotCounter(slot + pQuest->GetReqCreatureOrGOcount(), uint8(item_idx), uint8(current + batchCount));
```

Item counters pack after the creature counters *within the same quest slot*, so the offset belongs on the counter index, not the log slot. As written, looting a quest item writes the running item count into the quest sitting N rows below the collecting quest in the log, where N is the collecting quest's creature objective count, landing on that quest's objective `item_idx` - usually its first. Quests with no creature objectives are unaffected, since N is 0 there and the two forms are equivalent.

Two consequences:

- Normally it is a display corruption of the victim quest. The real counters and `character_queststatus` are untouched and a relog clears it, but until then that quest can show an impossible count, including a false "(Complete)".
- If the collecting quest sits near the end of the log, `slot + N` leaves the quest log block entirely: slots are 0..19 and the counter field is `PLAYER_QUEST_LOG_1_1 + slot * 3 + 1`, so slot 19 with one creature objective resolves to `UNIT_END + 0x49`, inside `PLAYER_VISIBLE_ITEM_1_0`. The `slot < MAX_QUEST_LOG_SIZE` guard tests the unoffset slot and the index stays inside the value array, so nothing catches it.

This moves the offset onto the counter index, keeping the write inside the already guarded slot, and bounds the index so a quest with 4 combined objectives cannot shift the 6-bit counter into the state byte. Introduced in 4f067300b (#2459).

### Proof

Observed live: three players showed "Captain Vachon slain: 8/1 (Complete)" on quest 371 without ever fighting him. The 8 was their Embalming Ichor count from Graverobbers (358: 2 creature objectives + 8x item 2834), sitting two log slots above - exactly the offset its `GetReqCreatureOrGOcount()` produces. Verified fixed on the same server: the quest below is now untouched.

The collecting quest itself never looked wrong, because item objectives are drawn from the player's bags - `_LoadQuestStatus` only ever writes `m_creatureOrGOcount` into the quest log fields, never item counts.

### Issues

- fixes #3522

### How2Test
For my specific case:

Accept Graverobbers (358), accept any filler quest, then accept At War With The Scarlet Crusade (371).
Loot an Embalming Ichor (item 2834)
Before this fix that quest 358 shows the ichor count on objective "Captain Vachon slain" in quest 371 which would show "8/1 (Complete)"
After the fix, both quests should track properly.  This applies to other quest combinations.
