### PR TITLE
Add forgotten Call of Air NPCs in Thousand Needles.

### DIFF
--- a/sql/migrations/20260816021552_world.sql
+++ b/sql/migrations/20260816021552_world.sql
@@ -1,0 +1,41 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260816021552');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260816021552');
+-- Add your query below.
+
+
+-- Add Call of Air NPCs in Thousand Needles, which were forgotten and unintentionally left in when the quest was changed.
+INSERT INTO `creature` (`guid`, `id`, `id2`, `id3`, `id4`, `id5`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `patch_min`, `patch_max`) VALUES
+(2635, 5898, 0, 0, 0, 0, 1, -5473.201171875, -3152.729736328125, 99.33782958984375, 0.523598790168762207, 120, 120, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 10),
+(2636, 5898, 0, 0, 0, 0, 1, -5479.60302734375, -3142.520751953125, 98.58148193359375, 2.111848354339599609, 120, 120, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 10),
+(2637, 5898, 0, 0, 0, 0, 1, -5473.46484375, -3147.193115234375, 98.759552001953125, 4.939281940460205078, 120, 120, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 10),
+(2638, 5898, 0, 0, 0, 0, 1, -5467.62353515625, -3150.5498046875, 99.17620086669921875, 4.223696708679199218, 120, 120, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 10),
+(2639, 5898, 0, 0, 0, 0, 1, -5470.25927734375, -3142.655517578125, 98.3877716064453125, 0.907571196556091308, 120, 120, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 10),
+(2640, 5902, 0, 0, 0, 0, 1, -5461.4345703125, -3144.56201171875, 99.42690277099609375, 0.593411922454833984, 120, 120, 0.0, 100.0, 100.0, 0, 0, 0.0, 0, 10);
+
+-- Add Elemental Spirit Invisibility so they only are visible with Sapta
+INSERT INTO `creature_addon` (`guid`, `patch`, `display_id`, `mount_display_id`, `equipment_id`, `stand_state`, `sheath_state`, `emote_state`, `auras`) VALUES
+(2635, 0, 0, 0, -1, 0, 1, 0, '8203'), -- 5898
+(2636, 0, 0, 0, -1, 0, 1, 0, '8203'), -- 5898
+(2637, 0, 0, 0, -1, 0, 1, 0, '8203'), -- 5898
+(2638, 0, 0, 0, -1, 0, 1, 0, '8203'), -- 5898
+(2639, 0, 0, 0, -1, 0, 1, 0, '8203'), -- 5898
+(2640, 0, 0, 0, -1, 0, 1, 0, '8203'); -- 5902
+
+-- Air Spirit should not be targetable.
+UPDATE `creature_template` SET `static_flags1` = `static_flags1` | 512 /*Uninteractible*/ WHERE `entry`=5898;
+-- Set correct level to Minor Manifestation of Air, previous was incorrectly level 1
+UPDATE `creature_template` SET `level_min` = 33, `level_max` = 33 WHERE `entry` = 5902;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Add Call of Air NPCs in Thousand Needles, which were forgotten and unintentionally left in when the quest was changed.

With PR applied but no sapta buff applied:
<img width="2559" height="1439" alt="Screenshot_20260816_040802" src="https://github.com/user-attachments/assets/2f73261b-8628-4ab6-995b-ae375ba1cb9a" />
With PR applied but with sapta buff applied:
<img width="2559" height="1439" alt="Screenshot_20260816_040751" src="https://github.com/user-attachments/assets/f9633e6a-d0e0-4bcd-97c2-1e962f5565d3" />

### Proof
<!-- Link resources as proof -->
- Video from 2009, around the time when people first discovered the NPCs:
https://www.youtube.com/watch?v=ONHA2Sr3SBs

- Image from classic TBC PTR that I took while sniffing:
<img width="1574" height="814" alt="Screenshot_20260816_042204" src="https://github.com/user-attachments/assets/2e50b74e-e762-4f72-8570-bf46e0b90e5e" />

- Sniffed on classic TBC PTR: hidden_shaman_npcs_2.5.5.64796_2025-12-10_02-09-24

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .go creature 2635
- .add 6637
- Walk up to stone column and drink it
- NPC should now appear

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
