### PR TITLE
Fix Scholomance Occultist HP not carrying over on Dark Shade transform.

### DIFF
--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -1787,7 +1787,7 @@ void Creature::SelectLevel(float percentHealth, float percentMana)
     uint32 const level = minLevel == maxLevel ? minLevel : urand(minLevel, maxLevel);
 
     SetLevel(level);
-    InitStatsForLevel();
+    InitStatsForLevel(percentHealth, percentMana);
 }
 
 void Creature::InitStatsForLevel(float percentHealth, float percentMana)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
SelectLevel() takes in HP% and mana% as arguments, but then just ignores them and calls InitStatsForLevel() with nothing. Since that function defaults to 100% when no args are given, the creature always ends up at full HP.

So when UpdateEntry correctly passes the Scholomance Occultists current HP% into SelectLevel, it’s discarded and the Dark Shade always spawns at full HP.

1. The EventAI script for the Occultist→Dark Shade transform triggers `SCRIPT_COMMAND_UPDATE_ENTRY`, handled by `Map::ScriptCommand_UpdateEntry`, which calls `pSource->UpdateEntry(script.updateEntry.creatureEntry)`.
2. `Creature::UpdateEntry` computes the current HP%/mana% (since `preserveHPAndPower` defaults to `true`) and passes it into `SelectLevel(...)`.
3. `SelectLevel` receives the correct ~30% but drops it, calling `InitStatsForLevel()` bare.
4. `InitStatsForLevel` then defaults `percentHealth`/`percentMana` to `100.0f`, so it calls `SetHealth(health)`/`SetPower(POWER_MANA, mana)` (full) instead of `SetHealthPercent`/`SetPowerPercent`.

Because SelectLevel wasn’t passing HP percentages properly, any creature with less than 100% HP in the creature table was also broken on respawn. So if an Alliance player killed a priest quest NPC like Deathguard Kel which spawns at 60%, it would respawn at full health.

Example below of that happening without PR applied:
<img width="2559" height="1440" alt="Screenshot_20260817_050119" src="https://github.com/user-attachments/assets/8c756b95-6a03-4eaf-9dbb-6b75227122de" />
Respawning:
<img width="2559" height="1440" alt="Screenshot_20260817_050204" src="https://github.com/user-attachments/assets/f35dc25e-fa10-4277-b2cf-9b9f667b1bd3" />

With PR applied:
<img width="2559" height="1440" alt="Screenshot_20260817_050323" src="https://github.com/user-attachments/assets/89b18c14-4f73-4d88-afc7-64ecee01bc4b" />
Respawning:
<img width="2559" height="1440" alt="Screenshot_20260817_050338" src="https://github.com/user-attachments/assets/4586f65c-302b-42e9-b819-1eaa1e36098a" />

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2462
- fixes  #2269

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .go creature 48868
- Target a few of them and do .damage 5000 until one of them turn into Shade.
- Dark Shade should now no longer appear at 100%.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
