### PR TITLE
Prevent visual bug on older clients where mobs appear to teleport to player

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -7425,6 +7425,14 @@ void Unit::SetRooted(bool apply)
     {
         SetRootedReal(apply);
         MovementPacketSender::SendMovementFlagChangeToAll(this, MOVEFLAG_ROOT, apply);
+
+        // Hackfix: Old clients teleport unit to last point if new spline begins right after unroot.
+        // In 1.8 sniffs it appears that the creature only begins chasing on the next world update,
+        // but motion is updated right away in our core, so send a sacrificial STOP spline after unroot.
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_6_1
+        if (!apply)
+            StopMoving(true);
+#endif
     }
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
If a mob breaks out of root or stun, and the player has moved away, the mobs will appear to teleport beside the player (presumably to the end location of their existing movement spline?) on clients 1.6.1 and older.

Now I really have no idea if this fix is proper or not... Honestly, I've had sporadic attempts fixing this problem for years now without any luck, but I was getting annoyed at how irritating it was to AoE farm mobs with this bug present so I sat down for a few hours tonight trying random shit until surprisingly this worked. Maybe it'll get the ball rolling on a real fix, or maybe the conditional `StopMoving` is good enough of an improvement for the older clients.

Feel free to just close this if there's a better solution.

### Proof
Before (stun):
https://github.com/user-attachments/assets/5f22ad07-1b46-42a2-b2d2-f281bd1b6801

Before (root):
https://github.com/user-attachments/assets/8d2e6b26-e687-4f2a-90b5-d07c22782a0b

After (stun):
https://github.com/user-attachments/assets/a1f8b9c6-9ee4-46d5-91b4-479150e4266d

After (root):
https://github.com/user-attachments/assets/6b56f68d-6240-4f82-a001-1ab0d00494bc

### Issues
<!-- Which Issues does this fix, which are related?-->
- I believe this fixes https://github.com/vmangos/core/issues/1262

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Use an older client (I've seen this happen on 1.6.1 and 1.5.1) 
- Stun or root a mob
- Move away from the mob while it is stunned/rooted
- Most of the time (not always) it will appear to teleport beside you when the stun/root breaks