### PR TITLE
Prevent master respawn on slave aggro.

### DIFF
--- a/src/game/Group/CreatureLinkingMgr.cpp
+++ b/src/game/Group/CreatureLinkingMgr.cpp
@@ -469,6 +469,7 @@ void CreatureLinkingHolder::DoCreatureLinkingEvent(CreatureLinkingEvent eventTyp
                         if (pMaster->IsControlledByPlayer())
                             return;
                         pMaster->EnterCombatWithTarget(pEnemy);
+                        break;
                     case LINKING_EVENT_EVADE:
                         if (!pMaster->IsAlive())
                             pMaster->Respawn();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
DoCreatureLinkingEvent fell through from LINKING_EVENT_AGGRO into LINKING_EVENT_EVADE due to a missing break which caused dead masters  (e.g. General Angerforge) to respawn whenever a linked slave with (FLAG_TO_AGGRO_ON_AGGRO) entered combat.

This PR adds a break to LINKING_EVENT_AGGRO which prevents the respawning of master.
NPCs affected are General Angerforge, Maexxna (no longer instantly despawns if you somehow managed to kill her and leave some adds up), Hezrul Bloodmark (who could even be turned into walking corpse with this bug) and Ruuzel.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2217

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .go creature angerforge
- Target Angerforge and use .die
- Hit any of his adds.
- Angerforge should no longer respawn.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
