### PR TITLE
Drop unused tables with no code references.

### DIFF
--- a/sql/migrations/20260826140125_characters.sql
+++ b/sql/migrations/20260826140125_characters.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260826140125');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260826140125');
+-- Add your query below.
+
+
+DROP TABLE IF EXISTS worldstates;
+DROP TABLE IF EXISTS character_duplicate_account;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20260826140914_logs.sql
+++ b/sql/migrations/20260826140914_logs.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260826140914');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260826140914');
+-- Add your query below.
+
+
+DROP TABLE IF EXISTS logs_trashcharacters;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20260826140915_logon.sql
+++ b/sql/migrations/20260826140915_logon.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260826140915');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260826140915');
+-- Add your query below.
+
+
+DROP TABLE IF EXISTS ip2nation;
+DROP TABLE IF EXISTS ip2nationcountries;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Deletes several unused tables.

- worldstates table, no idea what this was supposed to be. Has no code connected to it.

- character_duplicate_account table, has no code connected to it. Probably related to some anti account duplicator script once upon a time

- logs_trashcharacters table. Has no code connected to it. Unknown purpose.

- ip2nation and ip2nationcountries tables appears to be leftovers from when the switch was made to geoip.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
