### PR TITLE
Correction for Cleansed Night Dragon option_text and improvement on related option text entries

### DIFF
--- a/sql/migrations/20260904111141_world.sql
+++ b/sql/migrations/20260904111141_world.sql
@@ -1,0 +1,27 @@
+DROP PROCEDURE IF EXISTS add_migration;
+DELIMITER ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20260904111141');
+IF v = 0 THEN
+INSERT INTO `migrations` VALUES ('20260904111141');
+-- Add your query below.
+
+-- Update to option text from screenshot
+UPDATE `gossip_menu_option` SET `option_text` = 'Pick the fruit from the night dragon.' WHERE `action_script_id` = 15344;
+
+-- Inferred text (educated guess)
+UPDATE `gossip_menu_option` SET `option_text` = 'Deeply inhale the fragrance from the songflower.' WHERE `action_script_id` = 15366;
+
+-- Less substantiated guesses
+UPDATE `gossip_menu_option` SET `option_text` = 'Collect the tubers from the whipper root.' WHERE `action_script_id` = 15343;
+UPDATE `gossip_menu_option` SET `option_text` = 'Pick the berries from the windblossom.' WHERE `action_script_id` = 15342;
+
+
+-- End of migration.
+END IF;
+END??
+DELIMITER ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

- Corrects `option_text` for Cleansed Night Dragon based on 1.8 screenshot

- Improves guesses for other entries based on forum posts

### Proof
<!-- Link resources as proof -->
- **Cleansed Night Dragon:**
<img width="1172" height="908" alt="image" src="https://github.com/user-attachments/assets/f129e833-51fb-4836-937e-bda6f6f0b9cc" />

Screenshot from patch 1.8 
Source: https://vanilla-archive.thealphaproject.eu/?folders=Felwood&img=689970.jpg

- **Cleansed Songflower:**

>By Cocoh [on 2005/08/01](https://www.wowhead.com/classic/quest=2523/corrupted-songflower#comments:id=2954883) (Patch 1.6.0)	
>
>Subject: "Quest broken"
>This quest is broken for now. If you <mark>inhale the songflower</mark> you will not get the stat buff and the crit increase. You will get a message that "the songflower was resisted".
>A GM told me that it is broken and they are looking into it. Hopefully next patch will fix that.

>[Cleansing songflower](https://web.archive.org/web/20060614093534/http://www.thottbot.com/?n=22437)
>by Townshi9, 1.4 years ago
>When you cleanse a songflower with cenarion plant salve x2, you <mark>deeply inhale the fragrance</mark> and it grants you +5% chance to critical with a hit and +15 to all attributes for 60 minutes

The Cleansed Night Dragon entry suggests that `option_text` would mention the name of the plant in the other cases as well.

Guessed entry: "Deeply inhale the fragrance from the songflower."

- **Cleansed Whipper Root:**

>[Multiple people can loot.](https://web.archive.org/web/20060428002855/http://www.thottbot.com/index.cgi?i=6414)
>by soandso1, 5.0 months ago
>I did it with a friend.  You both open the dialogue box, then click the <mark>"collect tuber yadda yadda"</mark> speach bubble at the bottom.  It worked for us twice.
>Make sure both of you have the dialogue box open before you collect.

Suggest this entry uses the verb "collect", and "yadda yadda" implying a continuation (an inclusion of the plant name most likely).

Guessed entry: "Collect the tubers from the whipper root."

- **Cleansed Windblossom:**

Couldn't find any data. My guess is solely based on the logic of comparing the "known" `option_text` entries to the gossip menu they are a part of:

>This vibrant night dragon plant stands in stark contrast to the demonic taint that sunders Felwood. Rare and luscious <mark>fruit,</mark> known as Night Dragon's Breath, hang heavily from the plant.

>Pick the <mark>fruit</mark> from the night dragon.

>This songflower plant stands out as a rock in the sea of corruption that is Felwood. Its petals have a powerful <mark>fragrance</mark> that bolsters your spirits and strengthens your resolve.

>Deeply inhale the <mark>fragrance</mark> from the songflower.

>This healthy whipper root plant stands as a polar opposite to the sickly taint of corruption that dominates Felwood. Tender and healthy roots yield delicious <mark>tubers</mark> that lay on the ground next to the plant.

>Collect the <mark>tubers</mark> from the whipper root.

In all cases the noun appearing in `option_text` is found in the latter half of the gossip menu.

>This windblossom plant stands out as a beacon of light in the darkness that is Felwood. Plump and juicy <mark>berries</mark> hang from the plant, ripe for the picking.

In the gossip menu Cleansed Windblossom the word berries is found in this spot, so I believe it's the most likely candidate (even though a noun such as "fruit" could also fit here). The verb is highly likely to be "pick", as it appears in the gossip menu and is the verb most commonly associated with harvesting berries.

Guessed entry: "Pick the berries from the windblossom."


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
