### PR TITLE
corrections to IsVendorItemValid

### DIFF
--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -11283,7 +11283,7 @@ bool ObjectMgr::IsVendorItemValid(bool isTemplate, char const* tableName, uint32
     }
 
     VendorItemData const* vItems = isTemplate ? GetNpcVendorTemplateItemList(vendor_entry) : GetNpcVendorItemList(vendor_entry);
-    VendorItemData const* tItems = isTemplate ? nullptr : GetNpcVendorTemplateItemList(vendor_entry);
+    VendorItemData const* tItems = (!isTemplate && cInfo->vendor_id) ? GetNpcVendorTemplateItemList(cInfo->vendor_id) : nullptr;
 
     if (!vItems && !tItems)
         return true;                                        // later checks for non-empty lists
@@ -11302,7 +11302,7 @@ bool ObjectMgr::IsVendorItemValid(bool isTemplate, char const* tableName, uint32
 
     if (!isTemplate)
     {
-        if (tItems && tItems->GetItem(item_id))
+        if (tItems && tItems->FindItem(item_id))
         {
             if (pl)
                 pl->PSendSysMessage(LANG_ITEM_ALREADY_IN_LIST, item_id);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
when isTemplate is false vendor_entry is creature_template.entry - and GetNpcVendorTemplateItemList needs a vendor id, so now we send a vendor id instead

Fixed a bug where item/slot id was mixed up
GetItem() is used to lookup a slot id
FindItem() is used to lookup an item id

this pr changes absolutely nothing... the endresult is the same dataset
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
