### PR TITLE
mmapgenerator - correct walkable radius

### DIFF
--- a/contrib/mmap/config.json
+++ b/contrib/mmap/config.json
@@ -6,11 +6,11 @@
 	{
 		"walkableSlopeAngle":      75.0,
 		"walkableSlopeAngleVMaps": 61.0,
-		"walkableRadius":          2,
+		"walkableRadius":          1,
 		"walkableClimb":           0,
 		"walkableClimbModelTransition": 0,
 		"walkableHeight":          0,
-		"borderSize":              5,
+		"borderSize":              4,
 		"maxEdgeLen":              45,
 		"maxSimplificationError":  1.8,
 		"mergeRegionArea":         10,

--- a/contrib/mmap/config.json
+++ b/contrib/mmap/config.json
@@ -6,11 +6,11 @@
 	{
 		"walkableSlopeAngle":      75.0,
 		"walkableSlopeAngleVMaps": 61.0,
-		"walkableRadius":          1,
+		"walkableRadius":          0,
 		"walkableClimb":           0,
 		"walkableClimbModelTransition": 0,
 		"walkableHeight":          0,
-		"borderSize":              4,
+		"borderSize":              0,
 		"maxEdgeLen":              45,
 		"maxSimplificationError":  1.8,
 		"mergeRegionArea":         10,

--- a/contrib/mmap/src/TileWorker.cpp
+++ b/contrib/mmap/src/TileWorker.cpp
@@ -485,6 +485,10 @@ namespace MMAP
         uint32 walkableClimbModelTransition = config.walkableClimb; // follows walkableClimb unless overridden below
         if (int const climbOverride = jsonTileConfig["walkableClimbModelTransition"].get<int>())
             walkableClimbModelTransition = climbOverride;
+        if (config.walkableRadius == 0)
+            config.walkableRadius = (int)ceilf(agentRadius / config.cs);
+        if (config.borderSize == 0)
+            config.borderSize = config.walkableRadius + 3;
 
         config.width = config.tileSize + config.borderSize * 2;
         config.height = config.tileSize + config.borderSize * 2;
@@ -989,7 +993,7 @@ namespace MMAP
     {
         return
         {
-            { "borderSize",                   4     }, // Non-navigable border around heightfield (voxels) - if overriding walkableRadius per tile, also override this (= walkableRadius + 3)
+            { "borderSize",                   0     }, // Non-navigable border around heightfield (voxels) - if overriding walkableRadius per tile, also override this (= walkableRadius + 3)
             { "detailSampleDist",             2.0f  }, // Sampling distance for detail mesh height data (world units)
             { "detailSampleMaxError",         0.5f  }, // Max deviation of detail mesh from heightfield data (world units)
             { "maxEdgeLen",                   45    }, // Max length for contour edges along mesh border (voxels - 12 world units / BASE_UNIT_DIM)
@@ -999,7 +1003,7 @@ namespace MMAP
             { "walkableClimb",                0     }, // Max ledge height that is traversable (voxels) - calculated at runtime
             { "walkableClimbModelTransition", 0     }, // Max ledge height at terrain<->model transitions (voxels) - 0 = same as walkableClimb
             { "walkableHeight",               0     }, // Min floor to ceiling height for walkable area (voxels) - calculated at runtime
-            { "walkableRadius",               1     }, // Distance to erode walkable area away from obstructions (voxels, ~0.27yd)
+            { "walkableRadius",               0     }, // Distance to erode walkable area away from obstructions(voxels) - 0 = ceil(agentRadius / cell size)
             { "walkableSlopeAngle",           75.0f }, // Max slope angle for terrain that is considered walkable (degrees)
             { "walkableSlopeAngleVMaps",      61.0f }, // Max slope angle for WMO/M2 models that is considered walkable (degrees)
             { "quick",                        -1    }, // -1=use global, 0=thorough build, 1=skip undermesh removal for faster build

--- a/contrib/mmap/src/TileWorker.cpp
+++ b/contrib/mmap/src/TileWorker.cpp
@@ -989,7 +989,7 @@ namespace MMAP
     {
         return
         {
-            { "borderSize",                   5     }, // Non-navigable border around heightfield (voxels) - if overriding walkableRadius per tile, also override this (= walkableRadius + 3)
+            { "borderSize",                   4     }, // Non-navigable border around heightfield (voxels) - if overriding walkableRadius per tile, also override this (= walkableRadius + 3)
             { "detailSampleDist",             2.0f  }, // Sampling distance for detail mesh height data (world units)
             { "detailSampleMaxError",         0.5f  }, // Max deviation of detail mesh from heightfield data (world units)
             { "maxEdgeLen",                   45    }, // Max length for contour edges along mesh border (voxels - 12 world units / BASE_UNIT_DIM)
@@ -999,7 +999,7 @@ namespace MMAP
             { "walkableClimb",                0     }, // Max ledge height that is traversable (voxels) - calculated at runtime
             { "walkableClimbModelTransition", 0     }, // Max ledge height at terrain<->model transitions (voxels) - 0 = same as walkableClimb
             { "walkableHeight",               0     }, // Min floor to ceiling height for walkable area (voxels) - calculated at runtime
-            { "walkableRadius",               2     }, // Distance to erode walkable area away from obstructions (voxels, ~0.53yd)
+            { "walkableRadius",               1     }, // Distance to erode walkable area away from obstructions (voxels, ~0.27yd)
             { "walkableSlopeAngle",           75.0f }, // Max slope angle for terrain that is considered walkable (degrees)
             { "walkableSlopeAngleVMaps",      61.0f }, // Max slope angle for WMO/M2 models that is considered walkable (degrees)
             { "quick",                        -1    }, // -1=use global, 0=thorough build, 1=skip undermesh removal for faster build


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
https://github.com/vmangos/core/pull/3473
changed walkable radius for continents from ceil(0.2 / 0.2666666)==1 to 2. Instances kept the walkable radius at 2.

This pr reverts the walkableradius from a default 2 - to a calculated 1 for continents and 2 for instances. And still allows the values to be overriden by the config.

Borderradius was also increased by 1. Also lowered this to radius+3 to match [Recasts example](https://github.com/recastnavigation/recastnavigation/blob/main/RecastDemo/Source/Sample_TileMesh.cpp#L845) and the old vmangos default.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/vmangos/core/issues/3552

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
